### PR TITLE
Expose download URL and filename in convert API response

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,6 +131,9 @@ app.post('/api/convert', async (req,res)=>{
       ok: true,
       downloadUrl: dlUrl,
       filename,
+      // backward compatibility
+      download_url: dlUrl,
+      absolute_url: dlUrl,
       job: { id: jobId, kbps, url, file: filename, size: st.size }
     });
   } catch(e) {

--- a/index.js
+++ b/index.js
@@ -126,7 +126,13 @@ app.post('/api/convert', async (req,res)=>{
 
     const dlUrl = `/jobs/${jobId}/${basename(outPath)}`;
     const st = await fsp.stat(outPath);
-    res.json({ ok:true, job:{ id:jobId, kbps, url, file:basename(outPath), size:st.size }, download_url: dlUrl, absolute_url: dlUrl });
+    const filename = basename(outPath);
+    res.json({
+      ok: true,
+      downloadUrl: dlUrl,
+      filename,
+      job: { id: jobId, kbps, url, file: filename, size: st.size }
+    });
   } catch(e) {
     res.status(500).json({ error: String(e.message||e), hint:'Unggah cookies YouTube di /admin/upload-cookies jika kena age/robot check.' });
   }


### PR DESCRIPTION
## Summary
- Return `downloadUrl` and `filename` at the top level from `/api/convert`
- Keep job details under `job`
- UI already expects these camelCase keys

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b569fa0f1c8331ad2673de3d3a4f4c