### PR TITLE
Add trim and ID3 options for conversion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM node:20-slim
 
 # Install ffmpeg, Python, yt-dlp, and PyTube
 RUN apt-get update \
-  && apt-get install -y ffmpeg curl ca-certificates python3 python3-pip \
-  && pip3 install --no-cache-dir yt-dlp pytube \
+  && apt-get install -y --no-install-recommends ffmpeg curl ca-certificates python3 python3-pip \
+  && python3 -m pip install --no-cache-dir --break-system-packages yt-dlp pytube \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 FROM node:20-slim
 
-# Install ffmpeg
-RUN apt-get update && apt-get install -y ffmpeg curl ca-certificates && rm -rf /var/lib/apt/lists/*
+# Install ffmpeg, Python, yt-dlp, and PyTube
+RUN apt-get update \
+  && apt-get install -y ffmpeg curl ca-certificates python3 python3-pip \
+  && pip3 install --no-cache-dir yt-dlp pytube \
+  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 COPY package*.json ./

--- a/index.js
+++ b/index.js
@@ -65,6 +65,7 @@ const ffmpegToMp3 = (input, output, opts = {}) => {
     let logs = "";
     ff.stdout.on("data", (d) => (logs += d.toString()));
     ff.stderr.on("data", (d) => (logs += d.toString()));
+    ff.on("error", (err) => reject(err));
     ff.on("close", (code) => {
       if (code === 0) resolve(logs);
       else reject(new Error(logs));
@@ -137,6 +138,12 @@ app.post("/api/convert", async (req, res) => {
     let logs = "";
     proc.stdout.on("data", (d) => (logs += d.toString()));
     proc.stderr.on("data", (d) => (logs += d.toString()));
+
+    proc.on("error", (e) => {
+      if (!res.headersSent) {
+        res.status(500).json({ error: "yt-dlp tidak bisa dijalankan", detail: e.message });
+      }
+    });
 
     proc.on("close", async (code) => {
       if (code !== 0) {

--- a/index.js
+++ b/index.js
@@ -88,12 +88,18 @@ app.post("/api/convert", async (req, res) => {
 
     let trimOpt = null;
     if (trim && (trim.start !== undefined || trim.end !== undefined)) {
-      const start = Number(trim.start) || 0;
-      const end = Number(trim.end);
-      if (Number.isNaN(end) || end < start) {
+      const hasStart = trim.start !== undefined;
+      const hasEnd = trim.end !== undefined;
+      const start = hasStart ? Number(trim.start) : 0;
+      const end = hasEnd ? Number(trim.end) : undefined;
+      if ((hasStart && Number.isNaN(start)) ||
+          (hasEnd && Number.isNaN(end)) ||
+          (hasStart && hasEnd && end < start)) {
         return res.status(400).json({ error: "trim tidak valid" });
       }
-      trimOpt = { start, end };
+      trimOpt = {};
+      if (hasStart) trimOpt.start = start;
+      if (hasEnd) trimOpt.end = end;
     }
 
     const id = nanoid(10);

--- a/index.js
+++ b/index.js
@@ -6,8 +6,13 @@ import { promises as fsp } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { nanoid } from "nanoid";
-// Tambahan untuk ffmpeg portable:
-import ffmpegPath from "ffmpeg-static";
+// Tambahan untuk ffmpeg portable (opsional)
+let ffmpegPath = null;
+try {
+  ffmpegPath = (await import("ffmpeg-static")).default;
+} catch {
+  ffmpegPath = null;
+}
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = dirname(__filename);


### PR DESCRIPTION
## Summary
- allow `/api/convert` to read `id3`, `trim`, and `normalize` parameters
- add `ffmpegToMp3` helper with optional trimming, ID3 metadata, and loudness normalization
- validate trim ranges before running ffmpeg and apply processing when requested

## Testing
- `npm test` *(fails: Missing script "test")*
- `node index.js` *(fails: Cannot find package 'ffmpeg-static')*
- `npm install ffmpeg-static` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b574d246b08331a328643742a375e9