### PR TITLE
Add trim, ID3, filename, sample rate, and playlist queue options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 FROM node:20-slim
 
-# Install ffmpeg
-RUN apt-get update && apt-get install -y ffmpeg curl ca-certificates && rm -rf /var/lib/apt/lists/*
+# Install ffmpeg, Python, yt-dlp, and PyTube
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ffmpeg curl ca-certificates python3 python3-pip \
+  && python3 -m pip install --no-cache-dir --break-system-packages yt-dlp pytube \
+  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 COPY package*.json ./

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Aplikasi web sederhana untuk mengunduh audio dari video YouTube dan mengonversin
 
 ## Fitur Utama
 - Unduh audio dari tautan YouTube secara langsung.
-- Tentukan nama berkas output dan laju sampel (44.1 kHz atau 48 kHz).
+- Tentukan nama berkas output dan laju sampel (44.1 kHz, 48 kHz, atau 96 kHz).
+- Opsi FLAC lossless (Hi-Res) untuk kualitas maksimal.
 - Pemangkasan awal/akhir audio serta penyematan metadata ID3 (judul, artis, album).
 - Normalisasi loudness opsional untuk hasil audio yang konsisten.
 - Riwayat unduhan dengan tombol salin, unduh ulang, dan hapus setiap entri.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# YouTube to MP3 Converter
+
+Aplikasi web sederhana untuk mengunduh audio dari video YouTube dan mengonversinya menjadi MP3. Layanan ini berjalan di [`mis-ytmp3-backend.onrender.com`](https://mis-ytmp3-backend.onrender.com).
+
+## Fitur Utama
+- Unduh audio dari tautan YouTube secara langsung.
+- Tentukan nama berkas output dan laju sampel (44.1 kHz atau 48 kHz).
+- Pemangkasan awal/akhir audio serta penyematan metadata ID3 (judul, artis, album).
+- Normalisasi loudness opsional untuk hasil audio yang konsisten.
+- Riwayat unduhan dengan tombol salin, unduh ulang, dan hapus setiap entri.
+- Tutorial singkat otomatis saat pertama kali membuka aplikasi.
+- Antrian playlist: masukkan banyak URL dan konversi satu per satu.
+
+## Cara Menggunakan
+1. Buka halaman [converter](https://mis-ytmp3-backend.onrender.com).
+2. Masukkan URL video YouTube pada kolom yang tersedia.
+3. Pilih kualitas, atur nama file, dan lengkapi metadata jika diperlukan.
+4. Klik **Convert** dan tunggu hingga proses selesai, lalu unduh MP3 hasil konversi.
+5. Untuk banyak video, tempelkan beberapa URL di kolom *Playlist* dan gunakan **Convert Antrian**.
+
+## Lisensi
+Proyek ini dirilis di bawah lisensi MIT.

--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ Aplikasi web sederhana untuk mengunduh audio dari video YouTube dan mengonversin
 - Tentukan nama berkas output dan laju sampel (44.1 kHz, 48 kHz, atau 96 kHz).
 - Opsi FLAC lossless (Hi-Res) untuk kualitas maksimal.
 - Pemangkasan awal/akhir audio serta penyematan metadata ID3 (judul, artis, album).
+- Thumbnail video otomatis dijadikan gambar album; artis diisi dari nama channel, album mengikuti judul video.
 - Normalisasi loudness opsional untuk hasil audio yang konsisten.
 - Riwayat unduhan dengan tombol salin, unduh ulang, dan hapus setiap entri.
 - Tutorial singkat otomatis saat pertama kali membuka aplikasi.
 - Antrian playlist: masukkan banyak URL dan konversi satu per satu.
+- Tombol **Dolby Atmos** untuk mencoba mengambil audio multi-channel bila tersedia.
 
 ## Cara Menggunakan
 1. Buka halaman [converter](https://mis-ytmp3-backend.onrender.com).

--- a/download_audio.py
+++ b/download_audio.py
@@ -1,6 +1,18 @@
 # download_audio.py — helper for PyTube audio download
-import sys, os
-from pytube import YouTube
+import sys, os, subprocess
+
+# Ensure PyTube is available even if not pre-installed
+try:
+    from pytube import YouTube
+except ModuleNotFoundError:
+    try:
+        subprocess.check_call(
+            [sys.executable, "-m", "pip", "install", "--quiet", "pytube"]
+        )
+        from pytube import YouTube
+    except Exception as e:
+        print(f"failed to install pytube: {e}", file=sys.stderr)
+        sys.exit(1)
 
 def main():
     if len(sys.argv) < 4:

--- a/index.html
+++ b/index.html
@@ -5,12 +5,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>YouTube → MP3/M4A | Converter UI</title>
   <meta name="description" content="Konversi video YouTube ke MP3/M4A dengan UI cantik berbasis Bootstrap 5, dukung dark-mode, riwayat, dan log proses." />
+  <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+  <meta name="theme-color" content="#0d1117" media="(prefers-color-scheme: dark)" />
   <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet" />
   <style>
     :root { --radius: 1.2rem; }
-    body { min-height: 100dvh; background-image: radial-gradient(60rem 40rem at 120% -10%, rgba(99,102,241,.15), transparent), radial-gradient(40rem 30rem at -10% 120%, rgba(16,185,129,.12), transparent); }
+    body { min-height: 100dvh; background-color: var(--bs-body-bg); background-image: radial-gradient(50rem 40rem at 100% 0%, rgba(99,102,241,.25), transparent), radial-gradient(50rem 40rem at 0% 100%, rgba(16,185,129,.2), transparent); }
+    html[data-bs-theme='dark'] body { background-image: radial-gradient(50rem 40rem at 100% 0%, rgba(99,102,241,.35), transparent), radial-gradient(50rem 40rem at 0% 100%, rgba(16,185,129,.25), transparent); }
     .card { border-radius: var(--radius); }
     .form-control, .form-select, .btn { border-radius: .9rem; }
     .brand-badge { letter-spacing:.08em; }
@@ -55,7 +58,7 @@
 
             <div class="mb-3" id="previewWrap" hidden>
               <div class="ratio ratio-16x9 mb-2">
-                <img id="thumb" class="rounded object-fit-cover" alt="Thumbnail" />
+                <img id="thumb" class="rounded object-fit-cover" alt="Thumbnail" loading="lazy" />
               </div>
               <div id="videoTitle" class="fw-semibold"></div>
             </div>
@@ -68,6 +71,7 @@
               <div class="input-group mt-2">
                 <input id="queueUrl" type="url" class="form-control" placeholder="Tambahkan URL ke antrian" />
                 <button class="btn btn-outline-secondary" id="addQueueBtn" type="button"><i class="bi bi-plus-lg"></i> Tambah</button>
+                <button class="btn btn-outline-danger" id="clearQueueBtn" type="button" aria-label="Hapus antrian"><i class="bi bi-trash"></i></button>
               </div>
               <ul class="list-group mt-2" id="queueList"></ul>
             </div>
@@ -348,9 +352,11 @@
     });
     const textarea = $('#playlist');
     if(textarea) textarea.value = queue.join('\n');
+    const clearBtn = $('#clearQueueBtn');
+    if(clearBtn) clearBtn.disabled = queue.length === 0;
   }
 
-  $('#queueList')?.addEventListener('click', (e) => {
+$('#queueList')?.addEventListener('click', (e) => {
     const btn = e.target.closest('button[data-idx]');
     if(!btn) return;
     queue.splice(Number(btn.getAttribute('data-idx')),1);
@@ -365,13 +371,17 @@
     renderQueue();
   });
 
+  $('#clearQueueBtn')?.addEventListener('click', () => { queue.length = 0; renderQueue(); });
+
   // ===== Theme Toggle =====
   const themeToggle = $('#themeToggle');
   const applyTheme = (t) => document.documentElement.setAttribute('data-bs-theme', t);
   const themeKey = 'ytmp3.theme';
   const tutorialKey = 'ytmp3.tutorial.v1';
   const initTheme = () => {
-    const t = localStorage.getItem(themeKey) || 'light';
+    const stored = localStorage.getItem(themeKey);
+    const prefers = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const t = stored || prefers;
     applyTheme(t);
     themeToggle.innerHTML = t === 'light' ? '<i class="bi bi-moon-stars"></i>' : '<i class="bi bi-sun"></i>';
   };

--- a/index.html
+++ b/index.html
@@ -63,6 +63,12 @@
               <label for="playlist" class="form-label">Playlist / Antrian</label>
               <textarea id="playlist" class="form-control" rows="3" placeholder="Satu URL YouTube per baris"></textarea>
               <div class="form-text">Setiap URL akan diproses bergiliran.</div>
+
+              <div class="input-group mt-2">
+                <input id="queueUrl" type="url" class="form-control" placeholder="Tambahkan URL ke antrian" />
+                <button class="btn btn-outline-secondary" id="addQueueBtn" type="button"><i class="bi bi-plus-lg"></i> Tambah</button>
+              </div>
+              <ul class="list-group mt-2" id="queueList"></ul>
             </div>
 
             <div class="row g-3 mb-3">
@@ -144,7 +150,7 @@
 
             <div class="d-grid d-sm-flex gap-2 align-items-center">
               <button id="convertBtn" class="btn btn-primary btn-lg"><i class="bi bi-magic"></i> Convert</button>
-              <button id="convertQueueBtn" class="btn btn-outline-primary"><i class="bi bi-list"></i> Convert Antrian</button>
+              <button id="downloadAllBtn" class="btn btn-outline-primary"><i class="bi bi-download"></i> Download Semua</button>
               <button id="clearBtn" class="btn btn-outline-secondary"><i class="bi bi-x-circle"></i> Bersihkan</button>
             </div>
 
@@ -306,6 +312,37 @@
     const b = getBackend();
     badge.textContent = b ? new URL(b).host : location.host;
   };
+
+  // ===== Queue =====
+  const queue = [];
+  function renderQueue(){
+    const ul = $('#queueList');
+    if(!ul) return;
+    ul.innerHTML = '';
+    queue.forEach((url, idx) => {
+      const li = document.createElement('li');
+      li.className = 'list-group-item d-flex justify-content-between align-items-center';
+      li.innerHTML = `<span class="small text-break me-2 flex-grow-1">${url}</span><button class="btn btn-sm btn-outline-danger" data-idx="${idx}"><i class="bi bi-x"></i></button>`;
+      ul.appendChild(li);
+    });
+    const textarea = $('#playlist');
+    if(textarea) textarea.value = queue.join('\n');
+  }
+
+  $('#queueList')?.addEventListener('click', (e) => {
+    const btn = e.target.closest('button[data-idx]');
+    if(!btn) return;
+    queue.splice(Number(btn.getAttribute('data-idx')),1);
+    renderQueue();
+  });
+
+  $('#addQueueBtn')?.addEventListener('click', () => {
+    const url = $('#queueUrl').value.trim();
+    if(!/^https?:\/\//i.test(url)){ setToast('URL tidak valid'); return; }
+    queue.push(url);
+    $('#queueUrl').value = '';
+    renderQueue();
+  });
 
   // ===== Theme Toggle =====
   const themeToggle = $('#themeToggle');
@@ -475,10 +512,11 @@
 
   // ===== Convert handler =====
   $('#convertBtn').addEventListener('click', doConvert);
-  $('#convertQueueBtn').addEventListener('click', doConvertQueue);
+  $('#downloadAllBtn').addEventListener('click', doConvertQueue);
   $('#clearBtn').addEventListener('click', () => {
     $('#url').value='';
     $('#playlist').value='';
+    queue.length = 0; renderQueue();
     $('#trimStart').value='';
     $('#trimEnd').value='';
     $('#fileName').value='';
@@ -491,7 +529,7 @@
   });
   $('#url').addEventListener('keydown', (e)=>{ if(e.key==='Enter') doConvert(); });
 
-  async function doConvert(urlOverride){
+  async function doConvert(urlOverride, autoDownload = false){
     const url = (urlOverride || $('#url').value).trim();
     if(!/^https?:\/\//i.test(url)){ setToast('Masukkan URL YouTube yang valid'); $('#url').focus(); return; }
     const body = {
@@ -534,6 +572,7 @@
       $('#status').textContent = 'Selesai';
       $('#loadingSpinner').style.display = 'none';
       if(data.logs && $('#showLog').checked){ $('#logs').textContent = data.logs; }
+      if(autoDownload) $('#downloadLink').click();
       pushHistory({ downloadUrl: data.downloadUrl, format: data.format, abr: body.abr, fileName: data.fileName });
       setToast('Berhasil diproses');
     }catch(err){
@@ -547,13 +586,14 @@
   }
 
   async function doConvertQueue(){
-    const urls = $('#playlist').value.split(/\n+/).map(s=>s.trim()).filter(u=>/^https?:\/\//i.test(u));
-    if(!urls.length){ setToast('Isi playlist dengan URL valid'); return; }
+    const urls = queue.length ? [...queue] : $('#playlist').value.split(/\n+/).map(s=>s.trim()).filter(u=>/^https?:\/\//i.test(u));
+    if(!urls.length){ setToast('Antrian kosong'); return; }
     for(let i=0;i<urls.length;i++){
       $('#url').value = urls[i];
       await updatePreview();
       setToast(`Memproses ${i+1}/${urls.length}`);
-      await doConvert(urls[i]);
+      await doConvert(urls[i], true);
+      if(queue.length){ queue.shift(); renderQueue(); }
     }
     setToast('Semua antrian selesai');
   }
@@ -568,6 +608,7 @@
     initTheme();
     loadSettings();
     renderHistory();
+    renderQueue();
     updateBackendBadge();
     updatePreview();
     if(!localStorage.getItem(tutorialKey)){

--- a/index.html
+++ b/index.html
@@ -102,6 +102,7 @@
                 <select id="format" class="form-select">
                   <option value="mp3">MP3 (re-encode, fleksibel)</option>
                   <option value="m4a" selected>M4A (super cepat)</option>
+                  <option value="flac">FLAC (Hi-Res lossless)</option>
                 </select>
               </div>
               <div class="col-md-4">
@@ -119,6 +120,7 @@
                 <select id="sampleRate" class="form-select">
                   <option value="44100" selected>44.1 kHz</option>
                   <option value="48000">48 kHz</option>
+                  <option value="96000">96 kHz (Hi-Res)</option>
                 </select>
               </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -183,6 +183,11 @@
               <label class="form-check-label" for="normalize">Normalisasi audio</label>
             </div>
 
+            <div class="form-check form-switch mb-3">
+              <input class="form-check-input" type="checkbox" id="atmos" />
+              <label class="form-check-label" for="atmos">Dolby Atmos (multi-channel)</label>
+            </div>
+
             <div class="dropzone mb-3" id="dropzone">
               <i class="bi bi-cloud-arrow-up fs-4 d-block mb-1"></i>
               <div class="small text-secondary">Seret & lepas file <code>cookies.txt</code> ke sini (opsional) untuk bypass age‑gate</div>
@@ -202,6 +207,10 @@
                 <div id="status" class="fw-medium">Memproses…</div>
                 <span class="badge text-bg-secondary" id="backendBadge" title="Target backend"></span>
               </div>
+            </div>
+
+            <div class="progress w-100 mt-2" id="convertProgWrap" hidden>
+              <div class="progress-bar" id="convertProgress" role="progressbar" style="width:0%">0%</div>
             </div>
 
             <progress id="queueProgress" class="w-100 mt-2" value="0" max="100" hidden aria-label="Progress antrian"></progress>
@@ -566,6 +575,8 @@ $('#queueList')?.addEventListener('click', (e) => {
       $('#thumb').src = data.thumbnail_url; $('#videoTitle').textContent = data.title;
       $('#previewWrap').hidden = false;
       $('#id3Title').value = data.title;
+      $('#id3Artist').value = data.author_name || '';
+      $('#id3Album').value = data.title;
       $('#fileName').value = sanitizeFileName(data.title);
     }catch{ $('#previewWrap').hidden = true; }
   }
@@ -639,8 +650,10 @@ $('#queueList')?.addEventListener('click', (e) => {
     $('#id3Artist').value='';
     $('#id3Album').value='';
     $('#normalize').checked=false;
+    $('#atmos').checked=false;
     $('#previewWrap').hidden=true; $('#thumb').src=''; $('#videoTitle').textContent='';
     $('#resultWrap').hidden=true; $('#statusWrap').hidden=true; $('#logWrap').hidden=true; $('#logs').textContent='';
+    $('#convertProgWrap').hidden=true;
   });
   $('#url').addEventListener('keydown', (e)=>{ if(e.key==='Enter') doConvert(null, $('#autoDownload').checked); });
 
@@ -653,7 +666,8 @@ $('#queueList')?.addEventListener('click', (e) => {
       abr: Number($('#abr').value),
       sampleRate: Number($('#sampleRate').value),
       fileName: sanitizeFileName($('#fileName').value.trim()),
-      noPlaylist: $('#noPlaylist').checked
+      noPlaylist: $('#noPlaylist').checked,
+      atmos: $('#atmos').checked
     };
 
     const id3 = {
@@ -672,10 +686,18 @@ $('#queueList')?.addEventListener('click', (e) => {
     if(Object.keys(trim).length) body.trim = trim;
 
     body.normalize = $('#normalize').checked;
+    if($('#thumb').src) body.coverUrl = $('#thumb').src;
 
     $('#statusWrap').hidden = false; $('#resultWrap').hidden = true; $('#logWrap').hidden = !$('#showLog').checked; $('#logs').textContent = '';
     $('#loadingSpinner').style.display = '';
     $('#status').textContent = 'Memproses…';
+    const progWrap = $('#convertProgWrap');
+    const progBar = $('#convertProgress');
+    progWrap.hidden = false; progBar.style.width='0%'; progBar.textContent='0%';
+    let fake = 0;
+    const timer = setInterval(()=>{
+      if(fake < 90){ fake = Math.min(90, fake + Math.random()*10); progBar.style.width = fake+'%'; progBar.textContent = Math.round(fake)+'%'; }
+    },500);
 
     try{
       const resp = await fetch(api('/api/convert'), { method:'POST', headers:{ 'Content-Type':'application/json' }, body: JSON.stringify(body) });
@@ -686,6 +708,7 @@ $('#queueList')?.addEventListener('click', (e) => {
       $('#resultWrap').hidden = false;
       $('#status').textContent = 'Selesai';
       $('#loadingSpinner').style.display = 'none';
+      fake = 100; progBar.style.width='100%'; progBar.textContent='100%';
       if(data.logs && $('#showLog').checked){ $('#logs').textContent = data.logs; }
       if(autoDownload) $('#downloadLink').click();
       pushHistory({ downloadUrl: data.downloadUrl, format: data.format, abr: body.abr, fileName: data.fileName });
@@ -698,6 +721,9 @@ $('#queueList')?.addEventListener('click', (e) => {
       $('#logWrap').hidden = false;
       $('#logs').textContent = (err && err.stack) ? err.stack : String(err);
       setToast('Terjadi error: '+err.message);
+    } finally {
+      clearInterval(timer);
+      setTimeout(()=>{ progWrap.hidden = true; }, 500);
     }
   }
 

--- a/index.html
+++ b/index.html
@@ -52,15 +52,28 @@
               <div id="urlHelp" class="form-text">Dukung single video. Centang "Abaikan playlist" untuk mempercepat.</div>
             </div>
 
+            <div class="mb-3" id="previewWrap" hidden>
+              <div class="ratio ratio-16x9 mb-2">
+                <img id="thumb" class="rounded object-fit-cover" alt="Thumbnail" />
+              </div>
+              <div id="videoTitle" class="fw-semibold"></div>
+            </div>
+
+            <div class="mb-3">
+              <label for="playlist" class="form-label">Playlist / Antrian</label>
+              <textarea id="playlist" class="form-control" rows="3" placeholder="Satu URL YouTube per baris"></textarea>
+              <div class="form-text">Setiap URL akan diproses bergiliran.</div>
+            </div>
+
             <div class="row g-3 mb-3">
-              <div class="col-sm-6">
+              <div class="col-md-4">
                 <label class="form-label">Format</label>
                 <select id="format" class="form-select">
                   <option value="mp3">MP3 (re-encode, fleksibel)</option>
                   <option value="m4a" selected>M4A (super cepat)</option>
                 </select>
               </div>
-              <div class="col-sm-6">
+              <div class="col-md-4">
                 <label class="form-label">Kualitas (MP3)</label>
                 <select id="abr" class="form-select">
                   <option value="320">320 kbps</option>
@@ -68,6 +81,13 @@
                   <option value="192" selected>192 kbps</option>
                   <option value="128">128 kbps</option>
                   <option value="64">64 kbps</option>
+                </select>
+              </div>
+              <div class="col-md-4">
+                <label class="form-label">Sample Rate</label>
+                <select id="sampleRate" class="form-select">
+                  <option value="44100" selected>44.1 kHz</option>
+                  <option value="48000">48 kHz</option>
                 </select>
               </div>
             </div>
@@ -87,6 +107,34 @@
               </div>
             </div>
 
+            <div class="row g-3 mb-3">
+              <div class="col-sm-6">
+                <label class="form-label">Trim Mulai</label>
+                <input id="trimStart" type="text" class="form-control" placeholder="detik atau hh:mm:ss" />
+              </div>
+              <div class="col-sm-6">
+                <label class="form-label">Trim Selesai</label>
+                <input id="trimEnd" type="text" class="form-control" placeholder="detik atau hh:mm:ss" />
+              </div>
+            </div>
+
+            <div class="mb-3">
+              <label class="form-label">Nama file</label>
+              <input id="fileName" type="text" class="form-control" placeholder="Nama file output" />
+            </div>
+
+            <div class="mb-3">
+              <label class="form-label">Metadata ID3</label>
+              <input id="id3Title" type="text" class="form-control mb-2" placeholder="Judul" />
+              <input id="id3Artist" type="text" class="form-control mb-2" placeholder="Artis" />
+              <input id="id3Album" type="text" class="form-control" placeholder="Album" />
+            </div>
+
+            <div class="form-check form-switch mb-3">
+              <input class="form-check-input" type="checkbox" id="normalize" />
+              <label class="form-check-label" for="normalize">Normalisasi audio</label>
+            </div>
+
             <div class="dropzone mb-3" id="dropzone">
               <i class="bi bi-cloud-arrow-up fs-4 d-block mb-1"></i>
               <div class="small text-secondary">Seret & lepas file <code>cookies.txt</code> ke sini (opsional) untuk bypass age‑gate</div>
@@ -96,6 +144,7 @@
 
             <div class="d-grid d-sm-flex gap-2 align-items-center">
               <button id="convertBtn" class="btn btn-primary btn-lg"><i class="bi bi-magic"></i> Convert</button>
+              <button id="convertQueueBtn" class="btn btn-outline-primary"><i class="bi bi-list"></i> Convert Antrian</button>
               <button id="clearBtn" class="btn btn-outline-secondary"><i class="bi bi-x-circle"></i> Bersihkan</button>
             </div>
 
@@ -189,7 +238,30 @@
       <div class="d-grid gap-2">
         <button class="btn btn-outline-primary" id="adminUpload"><i class="bi bi-cloud-upload"></i> Upload sekarang</button>
         <button class="btn btn-outline-secondary" id="checkCookie"><i class="bi bi-shield-check"></i> Cek status cookies</button>
-        <div id="cookieStatus" class="small text-secondary"></div>
+    <div id="cookieStatus" class="small text-secondary"></div>
+  </div>
+  </div>
+  </div>
+
+  <!-- Tutorial Modal -->
+  <div class="modal fade" id="tutorialModal" tabindex="-1">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Tutorial Singkat</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <ol class="mb-0">
+            <li>Tempel URL YouTube.</li>
+            <li>Pilih format, kualitas, dan opsi lain.</li>
+            <li>Klik <strong>Convert</strong> atau <strong>Convert Antrian</strong>.</li>
+            <li>Unduh hasilnya.</li>
+          </ol>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-primary" data-bs-dismiss="modal">Mengerti</button>
+        </div>
       </div>
     </div>
   </div>
@@ -239,6 +311,7 @@
   const themeToggle = $('#themeToggle');
   const applyTheme = (t) => document.documentElement.setAttribute('data-bs-theme', t);
   const themeKey = 'ytmp3.theme';
+  const tutorialKey = 'ytmp3.tutorial.v1';
   const initTheme = () => {
     const t = localStorage.getItem(themeKey) || 'light';
     applyTheme(t);
@@ -259,22 +332,41 @@
     localStorage.setItem(historyKey, JSON.stringify(list.slice(0, 10)));
     renderHistory();
   };
+  const removeHistory = (idx) => {
+    const list = JSON.parse(localStorage.getItem(historyKey) || '[]');
+    list.splice(idx, 1);
+    localStorage.setItem(historyKey, JSON.stringify(list));
+    renderHistory();
+  };
   const renderHistory = () => {
     const list = JSON.parse(localStorage.getItem(historyKey) || '[]');
     const ul = $('#historyList'); ul.innerHTML = '';
     $('#historyEmpty').style.display = list.length ? 'none' : '';
-    list.forEach((it) => {
+    list.forEach((it, idx) => {
       const li = document.createElement('li');
       li.className = 'list-group-item d-flex align-items-start gap-2';
       li.innerHTML = `
         <i class="bi bi-file-music mt-1"></i>
         <div class="flex-grow-1">
           <div class="small">${new Date(it.at).toLocaleString()}</div>
-          <a class="history-link" href="${it.downloadUrl}" target="_blank">${it.downloadUrl}</a>
+          <a class="history-link" href="${it.downloadUrl}" download="${it.fileName || ''}" target="_blank">${it.fileName || it.downloadUrl}</a>
           <div class="small text-secondary">${it.format?.toUpperCase()}${it.abr?(' · '+it.abr+'kbps'):''}</div>
         </div>
-        <a class="btn btn-sm btn-outline-primary" href="${it.downloadUrl}" download><i class="bi bi-download"></i></a>`;
+        <div class="btn-group btn-group-sm">
+          <a class="btn btn-outline-primary" href="${it.downloadUrl}" download="${it.fileName || ''}" title="Download"><i class="bi bi-download"></i></a>
+          <button class="btn btn-outline-secondary copy-btn" data-url="${it.downloadUrl}" title="Salin link"><i class="bi bi-clipboard"></i></button>
+          <button class="btn btn-outline-danger delete-btn" data-idx="${idx}" title="Hapus"><i class="bi bi-trash"></i></button>
+        </div>`;
       ul.appendChild(li);
+    });
+    ul.querySelectorAll('.copy-btn').forEach(btn => {
+      btn.addEventListener('click', async () => {
+        try { await navigator.clipboard.writeText(btn.dataset.url); setToast('Link disalin'); }
+        catch { setToast('Tidak bisa menyalin'); }
+      });
+    });
+    ul.querySelectorAll('.delete-btn').forEach(btn => {
+      btn.addEventListener('click', () => removeHistory(Number(btn.dataset.idx)));
     });
   };
 
@@ -300,13 +392,41 @@
   });
 
   // ===== URL helpers =====
+  function parseTime(str){
+    if(!str) return null;
+    if(/^\d+(?::\d+)*$/.test(str)){
+      return str.split(':').reduce((acc,v)=>acc*60+Number(v),0);
+    }
+    const n = Number(str);
+    return Number.isNaN(n) ? null : n;
+  }
+
+  function sanitizeFileName(str){
+    return str.replace(/[\\/:*?"<>|\r\n]+/g,'').replace(/\s+/g,' ').trim();
+  }
+
+  async function updatePreview(){
+    const url = $('#url').value.trim();
+    if(!/^https?:\/\//i.test(url)){ $('#previewWrap').hidden = true; return; }
+    try{
+      const resp = await fetch(`https://www.youtube.com/oembed?url=${encodeURIComponent(url)}&format=json`);
+      const data = await resp.json();
+      $('#thumb').src = data.thumbnail_url; $('#videoTitle').textContent = data.title;
+      $('#previewWrap').hidden = false;
+      if(!$('#id3Title').value) $('#id3Title').value = data.title;
+      if(!$('#fileName').value) $('#fileName').value = sanitizeFileName(data.title);
+    }catch{ $('#previewWrap').hidden = true; }
+  }
   $('#pasteBtn').addEventListener('click', async () => {
     try { $('#url').value = (await navigator.clipboard.readText() || '').trim(); } catch {}
     $('#url').focus();
+    updatePreview();
   });
   $('#sampleBtn').addEventListener('click', () => {
     $('#url').value = 'https://www.youtube.com/watch?v=7UecFm_bSTU';
+    updatePreview();
   });
+  $('#url').addEventListener('change', updatePreview);
 
   // ===== Drag & drop cookies.txt =====
   const dz = $('#dropzone');
@@ -355,18 +475,50 @@
 
   // ===== Convert handler =====
   $('#convertBtn').addEventListener('click', doConvert);
-  $('#clearBtn').addEventListener('click', () => { $('#url').value=''; $('#resultWrap').hidden=true; $('#statusWrap').hidden=true; $('#logWrap').hidden=true; $('#logs').textContent=''; });
+  $('#convertQueueBtn').addEventListener('click', doConvertQueue);
+  $('#clearBtn').addEventListener('click', () => {
+    $('#url').value='';
+    $('#playlist').value='';
+    $('#trimStart').value='';
+    $('#trimEnd').value='';
+    $('#fileName').value='';
+    $('#id3Title').value='';
+    $('#id3Artist').value='';
+    $('#id3Album').value='';
+    $('#normalize').checked=false;
+    $('#previewWrap').hidden=true; $('#thumb').src=''; $('#videoTitle').textContent='';
+    $('#resultWrap').hidden=true; $('#statusWrap').hidden=true; $('#logWrap').hidden=true; $('#logs').textContent='';
+  });
   $('#url').addEventListener('keydown', (e)=>{ if(e.key==='Enter') doConvert(); });
 
-  async function doConvert(){
-    const url = $('#url').value.trim();
+  async function doConvert(urlOverride){
+    const url = (urlOverride || $('#url').value).trim();
     if(!/^https?:\/\//i.test(url)){ setToast('Masukkan URL YouTube yang valid'); $('#url').focus(); return; }
     const body = {
       url,
       format: $('#format').value,
       abr: Number($('#abr').value),
+      sampleRate: Number($('#sampleRate').value),
+      fileName: sanitizeFileName($('#fileName').value.trim()),
       noPlaylist: $('#noPlaylist').checked
     };
+
+    const id3 = {
+      title: $('#id3Title').value.trim(),
+      artist: $('#id3Artist').value.trim(),
+      album: $('#id3Album').value.trim()
+    };
+    Object.keys(id3).forEach(k => { if(!id3[k]) delete id3[k]; });
+    if(Object.keys(id3).length) body.id3 = id3;
+
+    const trim = {};
+    const s = parseTime($('#trimStart').value.trim());
+    const e = parseTime($('#trimEnd').value.trim());
+    if(s !== null) trim.start = s;
+    if(e !== null) trim.end = e;
+    if(Object.keys(trim).length) body.trim = trim;
+
+    body.normalize = $('#normalize').checked;
 
     $('#statusWrap').hidden = false; $('#resultWrap').hidden = true; $('#logWrap').hidden = !$('#showLog').checked; $('#logs').textContent = '';
     $('#loadingSpinner').style.display = '';
@@ -377,12 +529,12 @@
       const data = await resp.json();
       if(!resp.ok) throw new Error(data.error || 'Gagal memproses');
 
-      $('#downloadLink').href = data.downloadUrl; $('#downloadLink').setAttribute('download','');
+      $('#downloadLink').href = data.downloadUrl; $('#downloadLink').setAttribute('download', data.fileName || 'audio');
       $('#resultWrap').hidden = false;
       $('#status').textContent = 'Selesai';
       $('#loadingSpinner').style.display = 'none';
       if(data.logs && $('#showLog').checked){ $('#logs').textContent = data.logs; }
-      pushHistory({ downloadUrl: data.downloadUrl, format: data.format, abr: body.abr });
+      pushHistory({ downloadUrl: data.downloadUrl, format: data.format, abr: body.abr, fileName: data.fileName });
       setToast('Berhasil diproses');
     }catch(err){
       $('#status').textContent = 'Error: ' + err.message;
@@ -392,6 +544,18 @@
       $('#logs').textContent = (err && err.stack) ? err.stack : String(err);
       setToast('Terjadi error: '+err.message);
     }
+  }
+
+  async function doConvertQueue(){
+    const urls = $('#playlist').value.split(/\n+/).map(s=>s.trim()).filter(u=>/^https?:\/\//i.test(u));
+    if(!urls.length){ setToast('Isi playlist dengan URL valid'); return; }
+    for(let i=0;i<urls.length;i++){
+      $('#url').value = urls[i];
+      await updatePreview();
+      setToast(`Memproses ${i+1}/${urls.length}`);
+      await doConvert(urls[i]);
+    }
+    setToast('Semua antrian selesai');
   }
 
   // ===== Copy log =====
@@ -405,6 +569,12 @@
     loadSettings();
     renderHistory();
     updateBackendBadge();
+    updatePreview();
+    if(!localStorage.getItem(tutorialKey)){
+      const m = new bootstrap.Modal($('#tutorialModal'));
+      m.show();
+      $('#tutorialModal').addEventListener('hidden.bs.modal', ()=>localStorage.setItem(tutorialKey,'1'), { once:true });
+    }
   })();
   </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -8,8 +8,19 @@
   <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
   <meta name="theme-color" content="#0d1117" media="(prefers-color-scheme: dark)" />
   <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet" />
+  <link rel="preload" as="style" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" onload="this.onload=null;this.rel='stylesheet'">
+  <link rel="preload" as="style" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" onload="this.onload=null;this.rel='stylesheet'">
+  <noscript>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
+  </noscript>
+  <style>
+    @font-face {
+      font-family: "bootstrap-icons";
+      src: url("https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/fonts/bootstrap-icons.woff2") format("woff2");
+      font-display: swap;
+    }
+  </style>
   <style>
     :root { --radius: 1.2rem; }
     body { min-height: 100dvh; background-color: var(--bs-body-bg); background-image: radial-gradient(50rem 40rem at 100% 0%, rgba(99,102,241,.25), transparent), radial-gradient(50rem 40rem at 0% 100%, rgba(16,185,129,.2), transparent); }
@@ -30,7 +41,7 @@
       <a class="navbar-brand fw-semibold" href="#"><i class="bi bi-music-note-beamed me-2"></i>YT → MP3/M4A</a>
       <div class="d-flex gap-2 ms-auto">
         <button class="btn btn-outline-secondary" id="themeToggle" type="button" aria-label="Toggle theme"><i class="bi bi-moon-stars"></i></button>
-        <button class="btn btn-primary" data-bs-toggle="offcanvas" data-bs-target="#offcanvasSettings"><i class="bi bi-gear"></i> <span class="d-none d-sm-inline">Pengaturan</span></button>
+        <button class="btn btn-primary" data-bs-toggle="offcanvas" data-bs-target="#offcanvasSettings" aria-label="Buka pengaturan"><i class="bi bi-gear"></i> <span class="d-none d-sm-inline">Pengaturan</span></button>
       </div>
     </div>
   </nav>
@@ -59,7 +70,7 @@
               <div class="input-group">
                 <span class="input-group-text"><i class="bi bi-link-45deg"></i></span>
                 <input id="url" type="url" class="form-control" placeholder="Tempel URL YouTube (https://...)" autocomplete="off" required>
-                <button class="btn btn-outline-secondary" id="pasteBtn" type="button"><i class="bi bi-clipboard2"></i></button>
+                <button class="btn btn-outline-secondary" id="pasteBtn" type="button" aria-label="Tempel dari clipboard"><i class="bi bi-clipboard2"></i></button>
                 <button class="btn btn-outline-secondary" id="sampleBtn" type="button">Contoh</button>
               </div>
               <div id="urlHelp" class="form-text">Dukung single video. Centang "Abaikan playlist" untuk mempercepat.</div>
@@ -87,14 +98,14 @@
 
             <div class="row g-3 mb-3">
               <div class="col-md-4">
-                <label class="form-label">Format</label>
+                <label for="format" class="form-label">Format</label>
                 <select id="format" class="form-select">
                   <option value="mp3">MP3 (re-encode, fleksibel)</option>
                   <option value="m4a" selected>M4A (super cepat)</option>
                 </select>
               </div>
               <div class="col-md-4">
-                <label class="form-label">Kualitas (MP3)</label>
+                <label for="abr" class="form-label">Kualitas (MP3)</label>
                 <select id="abr" class="form-select">
                   <option value="320">320 kbps</option>
                   <option value="256">256 kbps</option>
@@ -104,7 +115,7 @@
                 </select>
               </div>
               <div class="col-md-4">
-                <label class="form-label">Sample Rate</label>
+                <label for="sampleRate" class="form-label">Sample Rate</label>
                 <select id="sampleRate" class="form-select">
                   <option value="44100" selected>44.1 kHz</option>
                   <option value="48000">48 kHz</option>
@@ -284,11 +295,11 @@
   </div>
 
   <!-- Tutorial Modal -->
-  <div class="modal fade" id="tutorialModal" tabindex="-1">
+  <div class="modal fade" id="tutorialModal" tabindex="-1" aria-labelledby="tutorialModalLabel">
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">
-          <h5 class="modal-title">Tutorial Singkat</h5>
+          <h5 class="modal-title" id="tutorialModalLabel">Tutorial Singkat</h5>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">
@@ -325,7 +336,7 @@
     </div>
   </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" defer></script>
   <script>
   // ===== Utilities =====
   const $ = (sel) => document.querySelector(sel);

--- a/index.html
+++ b/index.html
@@ -563,8 +563,8 @@ $('#queueList')?.addEventListener('click', (e) => {
       const data = await resp.json();
       $('#thumb').src = data.thumbnail_url; $('#videoTitle').textContent = data.title;
       $('#previewWrap').hidden = false;
-      if(!$('#id3Title').value) $('#id3Title').value = data.title;
-      if(!$('#fileName').value) $('#fileName').value = sanitizeFileName(data.title);
+      $('#id3Title').value = data.title;
+      $('#fileName').value = sanitizeFileName(data.title);
     }catch{ $('#previewWrap').hidden = true; }
   }
   $('#pasteBtn').addEventListener('click', async () => {

--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
   </style>
 </head>
 <body>
+  <a href="#mainContent" class="visually-hidden-focusable">Lewati ke konten utama</a>
   <nav class="navbar navbar-expand-lg sticky-top bg-body-tertiary shadow-sm">
     <div class="container">
       <a class="navbar-brand fw-semibold" href="#"><i class="bi bi-music-note-beamed me-2"></i>YT → MP3/M4A</a>
@@ -31,7 +32,7 @@
     </div>
   </nav>
 
-  <main class="container py-4 py-md-5">
+  <main id="mainContent" class="container py-4 py-md-5">
     <div class="row g-4">
       <div class="col-lg-7">
         <div class="card shadow-sm">
@@ -115,6 +116,21 @@
 
             <div class="row g-3 mb-3">
               <div class="col-sm-6">
+                <div class="form-check form-switch">
+                  <input class="form-check-input" type="checkbox" id="autoDownload" checked>
+                  <label class="form-check-label" for="autoDownload">Auto-download</label>
+                </div>
+              </div>
+              <div class="col-sm-6">
+                <div class="form-check form-switch">
+                  <input class="form-check-input" type="checkbox" id="autoClear">
+                  <label class="form-check-label" for="autoClear">Auto-bersihkan</label>
+                </div>
+              </div>
+            </div>
+
+            <div class="row g-3 mb-3">
+              <div class="col-sm-6">
                 <label class="form-label">Trim Mulai</label>
                 <input id="trimStart" type="text" class="form-control" placeholder="detik atau hh:mm:ss" />
               </div>
@@ -162,6 +178,8 @@
               </div>
             </div>
 
+            <progress id="queueProgress" class="w-100 mt-2" value="0" max="100" hidden aria-label="Progress antrian"></progress>
+
             <div class="mt-3" id="resultWrap" hidden>
               <div class="alert alert-success d-flex align-items-center" role="alert">
                 <i class="bi bi-check-circle me-2"></i>
@@ -196,6 +214,9 @@
             </div>
             <div id="historyEmpty" class="text-secondary small">Belum ada riwayat. Selesai convert, link akan tersimpan di sini.</div>
             <ul class="list-group list-group-flush" id="historyList"></ul>
+            <div class="d-grid mt-3">
+              <button class="btn btn-outline-danger btn-sm" id="clearHistory"><i class="bi bi-trash3"></i> Bersihkan Riwayat</button>
+            </div>
           </div>
         </div>
 
@@ -322,7 +343,7 @@
     queue.forEach((url, idx) => {
       const li = document.createElement('li');
       li.className = 'list-group-item d-flex justify-content-between align-items-center';
-      li.innerHTML = `<span class="small text-break me-2 flex-grow-1">${url}</span><button class="btn btn-sm btn-outline-danger" data-idx="${idx}"><i class="bi bi-x"></i></button>`;
+      li.innerHTML = `<span class="small text-break me-2 flex-grow-1">${url}</span><button class="btn btn-sm btn-outline-danger" data-idx="${idx}" aria-label="Hapus dari antrian"><i class="bi bi-x"></i></button>`;
       ul.appendChild(li);
     });
     const textarea = $('#playlist');
@@ -406,6 +427,12 @@
       btn.addEventListener('click', () => removeHistory(Number(btn.dataset.idx)));
     });
   };
+
+  $('#clearHistory')?.addEventListener('click', () => {
+    localStorage.removeItem(historyKey);
+    renderHistory();
+    setToast('Riwayat dibersihkan');
+  });
 
   // ===== Settings (offcanvas) =====
   const loadSettings = () => {
@@ -511,7 +538,7 @@
   });
 
   // ===== Convert handler =====
-  $('#convertBtn').addEventListener('click', doConvert);
+  $('#convertBtn').addEventListener('click', () => doConvert(null, $('#autoDownload').checked));
   $('#downloadAllBtn').addEventListener('click', doConvertQueue);
   $('#clearBtn').addEventListener('click', () => {
     $('#url').value='';
@@ -527,7 +554,7 @@
     $('#previewWrap').hidden=true; $('#thumb').src=''; $('#videoTitle').textContent='';
     $('#resultWrap').hidden=true; $('#statusWrap').hidden=true; $('#logWrap').hidden=true; $('#logs').textContent='';
   });
-  $('#url').addEventListener('keydown', (e)=>{ if(e.key==='Enter') doConvert(); });
+  $('#url').addEventListener('keydown', (e)=>{ if(e.key==='Enter') doConvert(null, $('#autoDownload').checked); });
 
   async function doConvert(urlOverride, autoDownload = false){
     const url = (urlOverride || $('#url').value).trim();
@@ -575,6 +602,7 @@
       if(autoDownload) $('#downloadLink').click();
       pushHistory({ downloadUrl: data.downloadUrl, format: data.format, abr: body.abr, fileName: data.fileName });
       setToast('Berhasil diproses');
+      if($('#autoClear').checked && !urlOverride){ $('#clearBtn').click(); }
     }catch(err){
       $('#status').textContent = 'Error: ' + err.message;
       $('#loadingSpinner').style.display = 'none';
@@ -588,13 +616,17 @@
   async function doConvertQueue(){
     const urls = queue.length ? [...queue] : $('#playlist').value.split(/\n+/).map(s=>s.trim()).filter(u=>/^https?:\/\//i.test(u));
     if(!urls.length){ setToast('Antrian kosong'); return; }
+    const progress = $('#queueProgress');
+    progress.hidden = false; progress.max = urls.length; progress.value = 0;
     for(let i=0;i<urls.length;i++){
       $('#url').value = urls[i];
       await updatePreview();
       setToast(`Memproses ${i+1}/${urls.length}`);
       await doConvert(urls[i], true);
+       progress.value = i+1;
       if(queue.length){ queue.shift(); renderQueue(); }
     }
+    progress.hidden = true;
     setToast('Semua antrian selesai');
   }
 

--- a/index.html
+++ b/index.html
@@ -36,6 +36,15 @@
   </nav>
 
   <main id="mainContent" class="container py-4 py-md-5">
+    <div id="welcomeCard" class="card shadow-sm mb-4" hidden>
+      <div class="card-body d-flex justify-content-between align-items-start">
+        <div>
+          <h5 class="mb-1">Selamat datang!</h5>
+          <p class="mb-0 small text-secondary">Gunakan form di bawah untuk mengonversi video YouTube menjadi audio dan jelajahi fitur seperti trim, metadata, serta antrian.</p>
+        </div>
+        <button type="button" class="btn-close ms-2" id="dismissWelcome" aria-label="Tutup"></button>
+      </div>
+    </div>
     <div class="row g-4">
       <div class="col-lg-7">
         <div class="card shadow-sm">
@@ -283,12 +292,21 @@
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">
-          <ol class="mb-0">
+          <p>Ikuti langkah berikut untuk memulai:</p>
+          <ol>
             <li>Tempel URL YouTube.</li>
-            <li>Pilih format, kualitas, dan opsi lain.</li>
-            <li>Klik <strong>Convert</strong> atau <strong>Convert Antrian</strong>.</li>
+            <li>Pilih format, kualitas, dan opsi lainnya.</li>
+            <li>Klik <strong>Convert</strong> atau <strong>Download Semua</strong>.</li>
             <li>Unduh hasilnya.</li>
           </ol>
+          <hr>
+          <p class="mb-0">Fitur utama:</p>
+          <ul class="mb-0">
+            <li><strong>Trim</strong> untuk memotong durasi.</li>
+            <li><strong>ID3</strong> menulis judul, artis, dan album.</li>
+            <li><strong>Normalisasi</strong> menyamakan volume.</li>
+            <li><strong>Antrian</strong> memproses banyak URL sekaligus.</li>
+          </ul>
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-primary" data-bs-dismiss="modal">Mengerti</button>
@@ -344,14 +362,19 @@
     const ul = $('#queueList');
     if(!ul) return;
     ul.innerHTML = '';
-    queue.forEach((url, idx) => {
+    queue.forEach((item, idx) => {
       const li = document.createElement('li');
       li.className = 'list-group-item d-flex justify-content-between align-items-center';
-      li.innerHTML = `<span class="small text-break me-2 flex-grow-1">${url}</span><button class="btn btn-sm btn-outline-danger" data-idx="${idx}" aria-label="Hapus dari antrian"><i class="bi bi-x"></i></button>`;
+      li.innerHTML = `
+        <div class="me-2 flex-grow-1 text-break">
+          <div class="small fw-semibold">${item.title || 'Memuat judul...'}</div>
+          <div class="small text-secondary">${item.url}</div>
+        </div>
+        <button class="btn btn-sm btn-outline-danger" data-idx="${idx}" aria-label="Hapus dari antrian"><i class="bi bi-x"></i></button>`;
       ul.appendChild(li);
     });
     const textarea = $('#playlist');
-    if(textarea) textarea.value = queue.join('\n');
+    if(textarea) textarea.value = queue.map(q=>q.url).join('\n');
     const clearBtn = $('#clearQueueBtn');
     if(clearBtn) clearBtn.disabled = queue.length === 0;
   }
@@ -363,12 +386,41 @@ $('#queueList')?.addEventListener('click', (e) => {
     renderQueue();
   });
 
-  $('#addQueueBtn')?.addEventListener('click', () => {
+  $('#addQueueBtn')?.addEventListener('click', async () => {
     const url = $('#queueUrl').value.trim();
     if(!/^https?:\/\//i.test(url)){ setToast('URL tidak valid'); return; }
-    queue.push(url);
+    const item = { url, title: '' };
+    queue.push(item);
     $('#queueUrl').value = '';
     renderQueue();
+    try{
+      const resp = await fetch(`https://www.youtube.com/oembed?url=${encodeURIComponent(url)}&format=json`);
+      const data = await resp.json();
+      item.title = data.title;
+      renderQueue();
+    }catch{
+      item.title = url;
+      renderQueue();
+    }
+  });
+
+  $('#playlist')?.addEventListener('change', async () => {
+    queue.length = 0;
+    const lines = $('#playlist').value.split(/\n+/).map(s=>s.trim()).filter(u=>/^https?:\/\//i.test(u));
+    for(const url of lines){
+      const item = { url, title: '' };
+      queue.push(item);
+      renderQueue();
+      try{
+        const resp = await fetch(`https://www.youtube.com/oembed?url=${encodeURIComponent(url)}&format=json`);
+        const data = await resp.json();
+        item.title = data.title;
+        renderQueue();
+      }catch{
+        item.title = url;
+        renderQueue();
+      }
+    }
   });
 
   $('#clearQueueBtn')?.addEventListener('click', () => { queue.length = 0; renderQueue(); });
@@ -378,6 +430,7 @@ $('#queueList')?.addEventListener('click', (e) => {
   const applyTheme = (t) => document.documentElement.setAttribute('data-bs-theme', t);
   const themeKey = 'ytmp3.theme';
   const tutorialKey = 'ytmp3.tutorial.v1';
+  const welcomeKey = 'ytmp3.welcome.v1';
   const initTheme = () => {
     const stored = localStorage.getItem(themeKey);
     const prefers = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
@@ -391,6 +444,17 @@ $('#queueList')?.addEventListener('click', (e) => {
     applyTheme(nxt); localStorage.setItem(themeKey, nxt);
     themeToggle.innerHTML = nxt === 'light' ? '<i class="bi bi-moon-stars"></i>' : '<i class="bi bi-sun"></i>';
   });
+
+  function initWelcome(){
+    const card = $('#welcomeCard');
+    if(!card) return;
+    if(localStorage.getItem(welcomeKey)) { card.remove(); return; }
+    card.hidden = false;
+    $('#dismissWelcome')?.addEventListener('click', () => {
+      localStorage.setItem(welcomeKey,'1');
+      card.remove();
+    });
+  }
 
   // ===== History =====
   const historyKey = 'ytmp3.history.v1';
@@ -624,16 +688,20 @@ $('#queueList')?.addEventListener('click', (e) => {
   }
 
   async function doConvertQueue(){
-    const urls = queue.length ? [...queue] : $('#playlist').value.split(/\n+/).map(s=>s.trim()).filter(u=>/^https?:\/\//i.test(u));
+    const urls = queue.length ? queue.map(q=>q.url) : $('#playlist').value.split(/\n+/).map(s=>s.trim()).filter(u=>/^https?:\/\//i.test(u));
     if(!urls.length){ setToast('Antrian kosong'); return; }
     const progress = $('#queueProgress');
     progress.hidden = false; progress.max = urls.length; progress.value = 0;
     for(let i=0;i<urls.length;i++){
       $('#url').value = urls[i];
+      $('#id3Title').value='';
+      $('#id3Artist').value='';
+      $('#id3Album').value='';
+      $('#fileName').value='';
       await updatePreview();
       setToast(`Memproses ${i+1}/${urls.length}`);
       await doConvert(urls[i], true);
-       progress.value = i+1;
+      progress.value = i+1;
       if(queue.length){ queue.shift(); renderQueue(); }
     }
     progress.hidden = true;
@@ -648,6 +716,7 @@ $('#queueList')?.addEventListener('click', (e) => {
   // ===== Init =====
   (function init(){
     initTheme();
+    initWelcome();
     loadSettings();
     renderHistory();
     renderQueue();

--- a/index.html
+++ b/index.html
@@ -338,6 +338,7 @@
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" defer></script>
   <script>
+  document.addEventListener('DOMContentLoaded', () => {
   // ===== Utilities =====
   const $ = (sel) => document.querySelector(sel);
   const $$ = (sel) => document.querySelectorAll(sel);
@@ -739,6 +740,7 @@ $('#queueList')?.addEventListener('click', (e) => {
       $('#tutorialModal').addEventListener('hidden.bs.modal', ()=>localStorage.setItem(tutorialKey,'1'), { once:true });
     }
   })();
+  });
   </script>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -388,8 +388,10 @@ app.post("/api/convert", async (req, res) => {
       if (code !== 0) {
         return runPyTubeFallback("yt-dlp gagal", logs);
       }
-      // Cari file hasil (id.*)
-      const files = readdirSync(JOBS_DIR).filter(f => f.startsWith(id + "."));
+      // Cari file hasil (id.*) tapi abaikan file cover
+      const files = readdirSync(JOBS_DIR).filter(
+        f => f.startsWith(id + ".") && !f.endsWith(".cover.jpg")
+      );
       if (!files.length) return res.status(500).json({ error: "Output tidak ditemukan", logs });
 
       let filename   = files[0];

--- a/index.js
+++ b/index.js
@@ -367,7 +367,7 @@ app.post("/api/convert", async (req, res) => {
             if (coverPath) try { await fsp.unlink(coverPath); } catch {}
           } catch (err) {
             if (!res.headersSent) {
-              res.status(500).json({ error: "ffmpeg gagal", logs: baseLogs + pyLogs + err.message });
+              res.status(500).json({ error: err.message || "ffmpeg gagal", logs: baseLogs + pyLogs + err.message });
             }
           }
         });
@@ -424,7 +424,7 @@ app.post("/api/convert", async (req, res) => {
         }
       } catch (e) {
         if (coverPath) try { await fsp.unlink(coverPath); } catch {}
-        return res.status(500).json({ error: "ffmpeg gagal", logs: logs + e.message });
+        return res.status(500).json({ error: e.message || "ffmpeg gagal", logs: logs + e.message });
       }
 
       if (coverPath) try { await fsp.unlink(coverPath); } catch {}

--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -52,15 +52,22 @@
               <div id="urlHelp" class="form-text">Dukung single video. Centang "Abaikan playlist" untuk mempercepat.</div>
             </div>
 
+            <div class="mb-3" id="previewWrap" hidden>
+              <div class="ratio ratio-16x9 mb-2">
+                <img id="thumb" class="rounded object-fit-cover" alt="Thumbnail" />
+              </div>
+              <div id="videoTitle" class="fw-semibold"></div>
+            </div>
+
             <div class="row g-3 mb-3">
-              <div class="col-sm-6">
+              <div class="col-md-4">
                 <label class="form-label">Format</label>
                 <select id="format" class="form-select">
                   <option value="mp3">MP3 (re-encode, fleksibel)</option>
                   <option value="m4a" selected>M4A (super cepat)</option>
                 </select>
               </div>
-              <div class="col-sm-6">
+              <div class="col-md-4">
                 <label class="form-label">Kualitas (MP3)</label>
                 <select id="abr" class="form-select">
                   <option value="320">320 kbps</option>
@@ -68,6 +75,13 @@
                   <option value="192" selected>192 kbps</option>
                   <option value="128">128 kbps</option>
                   <option value="64">64 kbps</option>
+                </select>
+              </div>
+              <div class="col-md-4">
+                <label class="form-label">Sample Rate</label>
+                <select id="sampleRate" class="form-select">
+                  <option value="44100" selected>44.1 kHz</option>
+                  <option value="48000">48 kHz</option>
                 </select>
               </div>
             </div>
@@ -85,6 +99,34 @@
                   <label class="form-check-label" for="showLog">Tampilkan log proses</label>
                 </div>
               </div>
+            </div>
+
+            <div class="row g-3 mb-3">
+              <div class="col-sm-6">
+                <label class="form-label">Trim Mulai</label>
+                <input id="trimStart" type="text" class="form-control" placeholder="detik atau hh:mm:ss" />
+              </div>
+              <div class="col-sm-6">
+                <label class="form-label">Trim Selesai</label>
+                <input id="trimEnd" type="text" class="form-control" placeholder="detik atau hh:mm:ss" />
+              </div>
+            </div>
+
+            <div class="mb-3">
+              <label class="form-label">Nama file</label>
+              <input id="fileName" type="text" class="form-control" placeholder="Nama file output" />
+            </div>
+
+            <div class="mb-3">
+              <label class="form-label">Metadata ID3</label>
+              <input id="id3Title" type="text" class="form-control mb-2" placeholder="Judul" />
+              <input id="id3Artist" type="text" class="form-control mb-2" placeholder="Artis" />
+              <input id="id3Album" type="text" class="form-control" placeholder="Album" />
+            </div>
+
+            <div class="form-check form-switch mb-3">
+              <input class="form-check-input" type="checkbox" id="normalize" />
+              <label class="form-check-label" for="normalize">Normalisasi audio</label>
             </div>
 
             <div class="dropzone mb-3" id="dropzone">
@@ -259,22 +301,41 @@
     localStorage.setItem(historyKey, JSON.stringify(list.slice(0, 10)));
     renderHistory();
   };
+  const removeHistory = (idx) => {
+    const list = JSON.parse(localStorage.getItem(historyKey) || '[]');
+    list.splice(idx, 1);
+    localStorage.setItem(historyKey, JSON.stringify(list));
+    renderHistory();
+  };
   const renderHistory = () => {
     const list = JSON.parse(localStorage.getItem(historyKey) || '[]');
     const ul = $('#historyList'); ul.innerHTML = '';
     $('#historyEmpty').style.display = list.length ? 'none' : '';
-    list.forEach((it) => {
+    list.forEach((it, idx) => {
       const li = document.createElement('li');
       li.className = 'list-group-item d-flex align-items-start gap-2';
       li.innerHTML = `
         <i class="bi bi-file-music mt-1"></i>
         <div class="flex-grow-1">
           <div class="small">${new Date(it.at).toLocaleString()}</div>
-          <a class="history-link" href="${it.downloadUrl}" target="_blank">${it.downloadUrl}</a>
+          <a class="history-link" href="${it.downloadUrl}" download="${it.fileName || ''}" target="_blank">${it.fileName || it.downloadUrl}</a>
           <div class="small text-secondary">${it.format?.toUpperCase()}${it.abr?(' · '+it.abr+'kbps'):''}</div>
         </div>
-        <a class="btn btn-sm btn-outline-primary" href="${it.downloadUrl}" download><i class="bi bi-download"></i></a>`;
+        <div class="btn-group btn-group-sm">
+          <a class="btn btn-outline-primary" href="${it.downloadUrl}" download="${it.fileName || ''}" title="Download"><i class="bi bi-download"></i></a>
+          <button class="btn btn-outline-secondary copy-btn" data-url="${it.downloadUrl}" title="Salin link"><i class="bi bi-clipboard"></i></button>
+          <button class="btn btn-outline-danger delete-btn" data-idx="${idx}" title="Hapus"><i class="bi bi-trash"></i></button>
+        </div>`;
       ul.appendChild(li);
+    });
+    ul.querySelectorAll('.copy-btn').forEach(btn => {
+      btn.addEventListener('click', async () => {
+        try { await navigator.clipboard.writeText(btn.dataset.url); setToast('Link disalin'); }
+        catch { setToast('Tidak bisa menyalin'); }
+      });
+    });
+    ul.querySelectorAll('.delete-btn').forEach(btn => {
+      btn.addEventListener('click', () => removeHistory(Number(btn.dataset.idx)));
     });
   };
 
@@ -300,13 +361,41 @@
   });
 
   // ===== URL helpers =====
+  function parseTime(str){
+    if(!str) return null;
+    if(/^\d+(?::\d+)*$/.test(str)){
+      return str.split(':').reduce((acc,v)=>acc*60+Number(v),0);
+    }
+    const n = Number(str);
+    return Number.isNaN(n) ? null : n;
+  }
+
+  function sanitizeFileName(str){
+    return str.replace(/[\\/:*?"<>|\r\n]+/g,'').replace(/\s+/g,' ').trim();
+  }
+
+  async function updatePreview(){
+    const url = $('#url').value.trim();
+    if(!/^https?:\/\//i.test(url)){ $('#previewWrap').hidden = true; return; }
+    try{
+      const resp = await fetch(`https://www.youtube.com/oembed?url=${encodeURIComponent(url)}&format=json`);
+      const data = await resp.json();
+      $('#thumb').src = data.thumbnail_url; $('#videoTitle').textContent = data.title;
+      $('#previewWrap').hidden = false;
+      if(!$('#id3Title').value) $('#id3Title').value = data.title;
+      if(!$('#fileName').value) $('#fileName').value = sanitizeFileName(data.title);
+    }catch{ $('#previewWrap').hidden = true; }
+  }
   $('#pasteBtn').addEventListener('click', async () => {
     try { $('#url').value = (await navigator.clipboard.readText() || '').trim(); } catch {}
     $('#url').focus();
+    updatePreview();
   });
   $('#sampleBtn').addEventListener('click', () => {
     $('#url').value = 'https://www.youtube.com/watch?v=7UecFm_bSTU';
+    updatePreview();
   });
+  $('#url').addEventListener('change', updatePreview);
 
   // ===== Drag & drop cookies.txt =====
   const dz = $('#dropzone');
@@ -355,7 +444,18 @@
 
   // ===== Convert handler =====
   $('#convertBtn').addEventListener('click', doConvert);
-  $('#clearBtn').addEventListener('click', () => { $('#url').value=''; $('#resultWrap').hidden=true; $('#statusWrap').hidden=true; $('#logWrap').hidden=true; $('#logs').textContent=''; });
+  $('#clearBtn').addEventListener('click', () => {
+    $('#url').value='';
+    $('#trimStart').value='';
+    $('#trimEnd').value='';
+    $('#fileName').value='';
+    $('#id3Title').value='';
+    $('#id3Artist').value='';
+    $('#id3Album').value='';
+    $('#normalize').checked=false;
+    $('#previewWrap').hidden=true; $('#thumb').src=''; $('#videoTitle').textContent='';
+    $('#resultWrap').hidden=true; $('#statusWrap').hidden=true; $('#logWrap').hidden=true; $('#logs').textContent='';
+  });
   $('#url').addEventListener('keydown', (e)=>{ if(e.key==='Enter') doConvert(); });
 
   async function doConvert(){
@@ -365,8 +465,27 @@
       url,
       format: $('#format').value,
       abr: Number($('#abr').value),
+      sampleRate: Number($('#sampleRate').value),
+      fileName: sanitizeFileName($('#fileName').value.trim()),
       noPlaylist: $('#noPlaylist').checked
     };
+
+    const id3 = {
+      title: $('#id3Title').value.trim(),
+      artist: $('#id3Artist').value.trim(),
+      album: $('#id3Album').value.trim()
+    };
+    Object.keys(id3).forEach(k => { if(!id3[k]) delete id3[k]; });
+    if(Object.keys(id3).length) body.id3 = id3;
+
+    const trim = {};
+    const s = parseTime($('#trimStart').value.trim());
+    const e = parseTime($('#trimEnd').value.trim());
+    if(s !== null) trim.start = s;
+    if(e !== null) trim.end = e;
+    if(Object.keys(trim).length) body.trim = trim;
+
+    body.normalize = $('#normalize').checked;
 
     $('#statusWrap').hidden = false; $('#resultWrap').hidden = true; $('#logWrap').hidden = !$('#showLog').checked; $('#logs').textContent = '';
     $('#loadingSpinner').style.display = '';
@@ -377,12 +496,12 @@
       const data = await resp.json();
       if(!resp.ok) throw new Error(data.error || 'Gagal memproses');
 
-      $('#downloadLink').href = data.downloadUrl; $('#downloadLink').setAttribute('download','');
+      $('#downloadLink').href = data.downloadUrl; $('#downloadLink').setAttribute('download', data.fileName || 'audio');
       $('#resultWrap').hidden = false;
       $('#status').textContent = 'Selesai';
       $('#loadingSpinner').style.display = 'none';
       if(data.logs && $('#showLog').checked){ $('#logs').textContent = data.logs; }
-      pushHistory({ downloadUrl: data.downloadUrl, format: data.format, abr: body.abr });
+      pushHistory({ downloadUrl: data.downloadUrl, format: data.format, abr: body.abr, fileName: data.fileName });
       setToast('Berhasil diproses');
     }catch(err){
       $('#status').textContent = 'Error: ' + err.message;
@@ -405,6 +524,7 @@
     loadSettings();
     renderHistory();
     updateBackendBadge();
+    updatePreview();
   })();
   </script>
 </body>

--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -102,6 +102,7 @@
                 <select id="format" class="form-select">
                   <option value="mp3">MP3 (re-encode, fleksibel)</option>
                   <option value="m4a" selected>M4A (super cepat)</option>
+                  <option value="flac">FLAC (Hi-Res lossless)</option>
                 </select>
               </div>
               <div class="col-md-4">
@@ -119,6 +120,7 @@
                 <select id="sampleRate" class="form-select">
                   <option value="44100" selected>44.1 kHz</option>
                   <option value="48000">48 kHz</option>
+                  <option value="96000">96 kHz (Hi-Res)</option>
                 </select>
               </div>
             </div>

--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -183,6 +183,11 @@
               <label class="form-check-label" for="normalize">Normalisasi audio</label>
             </div>
 
+            <div class="form-check form-switch mb-3">
+              <input class="form-check-input" type="checkbox" id="atmos" />
+              <label class="form-check-label" for="atmos">Dolby Atmos (multi-channel)</label>
+            </div>
+
             <div class="dropzone mb-3" id="dropzone">
               <i class="bi bi-cloud-arrow-up fs-4 d-block mb-1"></i>
               <div class="small text-secondary">Seret & lepas file <code>cookies.txt</code> ke sini (opsional) untuk bypass age‑gate</div>
@@ -202,6 +207,10 @@
                 <div id="status" class="fw-medium">Memproses…</div>
                 <span class="badge text-bg-secondary" id="backendBadge" title="Target backend"></span>
               </div>
+            </div>
+
+            <div class="progress w-100 mt-2" id="convertProgWrap" hidden>
+              <div class="progress-bar" id="convertProgress" role="progressbar" style="width:0%">0%</div>
             </div>
 
             <progress id="queueProgress" class="w-100 mt-2" value="0" max="100" hidden aria-label="Progress antrian"></progress>
@@ -566,6 +575,8 @@ $('#queueList')?.addEventListener('click', (e) => {
       $('#thumb').src = data.thumbnail_url; $('#videoTitle').textContent = data.title;
       $('#previewWrap').hidden = false;
       $('#id3Title').value = data.title;
+      $('#id3Artist').value = data.author_name || '';
+      $('#id3Album').value = data.title;
       $('#fileName').value = sanitizeFileName(data.title);
     }catch{ $('#previewWrap').hidden = true; }
   }
@@ -639,8 +650,10 @@ $('#queueList')?.addEventListener('click', (e) => {
     $('#id3Artist').value='';
     $('#id3Album').value='';
     $('#normalize').checked=false;
+    $('#atmos').checked=false;
     $('#previewWrap').hidden=true; $('#thumb').src=''; $('#videoTitle').textContent='';
     $('#resultWrap').hidden=true; $('#statusWrap').hidden=true; $('#logWrap').hidden=true; $('#logs').textContent='';
+    $('#convertProgWrap').hidden=true;
   });
   $('#url').addEventListener('keydown', (e)=>{ if(e.key==='Enter') doConvert(null, $('#autoDownload').checked); });
 
@@ -653,7 +666,8 @@ $('#queueList')?.addEventListener('click', (e) => {
       abr: Number($('#abr').value),
       sampleRate: Number($('#sampleRate').value),
       fileName: sanitizeFileName($('#fileName').value.trim()),
-      noPlaylist: $('#noPlaylist').checked
+      noPlaylist: $('#noPlaylist').checked,
+      atmos: $('#atmos').checked
     };
 
     const id3 = {
@@ -672,10 +686,18 @@ $('#queueList')?.addEventListener('click', (e) => {
     if(Object.keys(trim).length) body.trim = trim;
 
     body.normalize = $('#normalize').checked;
+    if($('#thumb').src) body.coverUrl = $('#thumb').src;
 
     $('#statusWrap').hidden = false; $('#resultWrap').hidden = true; $('#logWrap').hidden = !$('#showLog').checked; $('#logs').textContent = '';
     $('#loadingSpinner').style.display = '';
     $('#status').textContent = 'Memproses…';
+    const progWrap = $('#convertProgWrap');
+    const progBar = $('#convertProgress');
+    progWrap.hidden = false; progBar.style.width='0%'; progBar.textContent='0%';
+    let fake = 0;
+    const timer = setInterval(()=>{
+      if(fake < 90){ fake = Math.min(90, fake + Math.random()*10); progBar.style.width = fake+'%'; progBar.textContent = Math.round(fake)+'%'; }
+    },500);
 
     try{
       const resp = await fetch(api('/api/convert'), { method:'POST', headers:{ 'Content-Type':'application/json' }, body: JSON.stringify(body) });
@@ -686,6 +708,7 @@ $('#queueList')?.addEventListener('click', (e) => {
       $('#resultWrap').hidden = false;
       $('#status').textContent = 'Selesai';
       $('#loadingSpinner').style.display = 'none';
+      fake = 100; progBar.style.width='100%'; progBar.textContent='100%';
       if(data.logs && $('#showLog').checked){ $('#logs').textContent = data.logs; }
       if(autoDownload) $('#downloadLink').click();
       pushHistory({ downloadUrl: data.downloadUrl, format: data.format, abr: body.abr, fileName: data.fileName });
@@ -698,6 +721,9 @@ $('#queueList')?.addEventListener('click', (e) => {
       $('#logWrap').hidden = false;
       $('#logs').textContent = (err && err.stack) ? err.stack : String(err);
       setToast('Terjadi error: '+err.message);
+    } finally {
+      clearInterval(timer);
+      setTimeout(()=>{ progWrap.hidden = true; }, 500);
     }
   }
 

--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -8,8 +8,19 @@
   <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
   <meta name="theme-color" content="#0d1117" media="(prefers-color-scheme: dark)" />
   <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet" />
+  <link rel="preload" as="style" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" onload="this.onload=null;this.rel='stylesheet'">
+  <link rel="preload" as="style" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" onload="this.onload=null;this.rel='stylesheet'">
+  <noscript>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
+  </noscript>
+  <style>
+    @font-face {
+      font-family: "bootstrap-icons";
+      src: url("https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/fonts/bootstrap-icons.woff2") format("woff2");
+      font-display: swap;
+    }
+  </style>
   <style>
     :root { --radius: 1.2rem; }
     body { min-height: 100dvh; background-color: var(--bs-body-bg); background-image: radial-gradient(50rem 40rem at 100% 0%, rgba(99,102,241,.25), transparent), radial-gradient(50rem 40rem at 0% 100%, rgba(16,185,129,.2), transparent); }
@@ -30,7 +41,7 @@
       <a class="navbar-brand fw-semibold" href="#"><i class="bi bi-music-note-beamed me-2"></i>YT → MP3/M4A</a>
       <div class="d-flex gap-2 ms-auto">
         <button class="btn btn-outline-secondary" id="themeToggle" type="button" aria-label="Toggle theme"><i class="bi bi-moon-stars"></i></button>
-        <button class="btn btn-primary" data-bs-toggle="offcanvas" data-bs-target="#offcanvasSettings"><i class="bi bi-gear"></i> <span class="d-none d-sm-inline">Pengaturan</span></button>
+        <button class="btn btn-primary" data-bs-toggle="offcanvas" data-bs-target="#offcanvasSettings" aria-label="Buka pengaturan"><i class="bi bi-gear"></i> <span class="d-none d-sm-inline">Pengaturan</span></button>
       </div>
     </div>
   </nav>
@@ -59,7 +70,7 @@
               <div class="input-group">
                 <span class="input-group-text"><i class="bi bi-link-45deg"></i></span>
                 <input id="url" type="url" class="form-control" placeholder="Tempel URL YouTube (https://...)" autocomplete="off" required>
-                <button class="btn btn-outline-secondary" id="pasteBtn" type="button"><i class="bi bi-clipboard2"></i></button>
+                <button class="btn btn-outline-secondary" id="pasteBtn" type="button" aria-label="Tempel dari clipboard"><i class="bi bi-clipboard2"></i></button>
                 <button class="btn btn-outline-secondary" id="sampleBtn" type="button">Contoh</button>
               </div>
               <div id="urlHelp" class="form-text">Dukung single video. Centang "Abaikan playlist" untuk mempercepat.</div>
@@ -87,14 +98,14 @@
 
             <div class="row g-3 mb-3">
               <div class="col-md-4">
-                <label class="form-label">Format</label>
+                <label for="format" class="form-label">Format</label>
                 <select id="format" class="form-select">
                   <option value="mp3">MP3 (re-encode, fleksibel)</option>
                   <option value="m4a" selected>M4A (super cepat)</option>
                 </select>
               </div>
               <div class="col-md-4">
-                <label class="form-label">Kualitas (MP3)</label>
+                <label for="abr" class="form-label">Kualitas (MP3)</label>
                 <select id="abr" class="form-select">
                   <option value="320">320 kbps</option>
                   <option value="256">256 kbps</option>
@@ -104,7 +115,7 @@
                 </select>
               </div>
               <div class="col-md-4">
-                <label class="form-label">Sample Rate</label>
+                <label for="sampleRate" class="form-label">Sample Rate</label>
                 <select id="sampleRate" class="form-select">
                   <option value="44100" selected>44.1 kHz</option>
                   <option value="48000">48 kHz</option>
@@ -284,11 +295,11 @@
   </div>
 
   <!-- Tutorial Modal -->
-  <div class="modal fade" id="tutorialModal" tabindex="-1">
+  <div class="modal fade" id="tutorialModal" tabindex="-1" aria-labelledby="tutorialModalLabel">
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">
-          <h5 class="modal-title">Tutorial Singkat</h5>
+          <h5 class="modal-title" id="tutorialModalLabel">Tutorial Singkat</h5>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">
@@ -325,7 +336,7 @@
     </div>
   </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" defer></script>
   <script>
   // ===== Utilities =====
   const $ = (sel) => document.querySelector(sel);

--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -563,8 +563,8 @@ $('#queueList')?.addEventListener('click', (e) => {
       const data = await resp.json();
       $('#thumb').src = data.thumbnail_url; $('#videoTitle').textContent = data.title;
       $('#previewWrap').hidden = false;
-      if(!$('#id3Title').value) $('#id3Title').value = data.title;
-      if(!$('#fileName').value) $('#fileName').value = sanitizeFileName(data.title);
+      $('#id3Title').value = data.title;
+      $('#fileName').value = sanitizeFileName(data.title);
     }catch{ $('#previewWrap').hidden = true; }
   }
   $('#pasteBtn').addEventListener('click', async () => {

--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -36,6 +36,15 @@
   </nav>
 
   <main id="mainContent" class="container py-4 py-md-5">
+    <div id="welcomeCard" class="card shadow-sm mb-4" hidden>
+      <div class="card-body d-flex justify-content-between align-items-start">
+        <div>
+          <h5 class="mb-1">Selamat datang!</h5>
+          <p class="mb-0 small text-secondary">Gunakan form di bawah untuk mengonversi video YouTube menjadi audio dan jelajahi fitur seperti trim, metadata, serta antrian.</p>
+        </div>
+        <button type="button" class="btn-close ms-2" id="dismissWelcome" aria-label="Tutup"></button>
+      </div>
+    </div>
     <div class="row g-4">
       <div class="col-lg-7">
         <div class="card shadow-sm">
@@ -283,12 +292,21 @@
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">
-          <ol class="mb-0">
+          <p>Ikuti langkah berikut untuk memulai:</p>
+          <ol>
             <li>Tempel URL YouTube.</li>
-            <li>Pilih format, kualitas, dan opsi lain.</li>
-            <li>Klik <strong>Convert</strong> atau <strong>Convert Antrian</strong>.</li>
+            <li>Pilih format, kualitas, dan opsi lainnya.</li>
+            <li>Klik <strong>Convert</strong> atau <strong>Download Semua</strong>.</li>
             <li>Unduh hasilnya.</li>
           </ol>
+          <hr>
+          <p class="mb-0">Fitur utama:</p>
+          <ul class="mb-0">
+            <li><strong>Trim</strong> untuk memotong durasi.</li>
+            <li><strong>ID3</strong> menulis judul, artis, dan album.</li>
+            <li><strong>Normalisasi</strong> menyamakan volume.</li>
+            <li><strong>Antrian</strong> memproses banyak URL sekaligus.</li>
+          </ul>
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-primary" data-bs-dismiss="modal">Mengerti</button>
@@ -344,14 +362,19 @@
     const ul = $('#queueList');
     if(!ul) return;
     ul.innerHTML = '';
-    queue.forEach((url, idx) => {
+    queue.forEach((item, idx) => {
       const li = document.createElement('li');
       li.className = 'list-group-item d-flex justify-content-between align-items-center';
-      li.innerHTML = `<span class="small text-break me-2 flex-grow-1">${url}</span><button class="btn btn-sm btn-outline-danger" data-idx="${idx}" aria-label="Hapus dari antrian"><i class="bi bi-x"></i></button>`;
+      li.innerHTML = `
+        <div class="me-2 flex-grow-1 text-break">
+          <div class="small fw-semibold">${item.title || 'Memuat judul...'}</div>
+          <div class="small text-secondary">${item.url}</div>
+        </div>
+        <button class="btn btn-sm btn-outline-danger" data-idx="${idx}" aria-label="Hapus dari antrian"><i class="bi bi-x"></i></button>`;
       ul.appendChild(li);
     });
     const textarea = $('#playlist');
-    if(textarea) textarea.value = queue.join('\n');
+    if(textarea) textarea.value = queue.map(q=>q.url).join('\n');
     const clearBtn = $('#clearQueueBtn');
     if(clearBtn) clearBtn.disabled = queue.length === 0;
   }
@@ -363,12 +386,41 @@ $('#queueList')?.addEventListener('click', (e) => {
     renderQueue();
   });
 
-  $('#addQueueBtn')?.addEventListener('click', () => {
+  $('#addQueueBtn')?.addEventListener('click', async () => {
     const url = $('#queueUrl').value.trim();
     if(!/^https?:\/\//i.test(url)){ setToast('URL tidak valid'); return; }
-    queue.push(url);
+    const item = { url, title: '' };
+    queue.push(item);
     $('#queueUrl').value = '';
     renderQueue();
+    try{
+      const resp = await fetch(`https://www.youtube.com/oembed?url=${encodeURIComponent(url)}&format=json`);
+      const data = await resp.json();
+      item.title = data.title;
+      renderQueue();
+    }catch{
+      item.title = url;
+      renderQueue();
+    }
+  });
+
+  $('#playlist')?.addEventListener('change', async () => {
+    queue.length = 0;
+    const lines = $('#playlist').value.split(/\n+/).map(s=>s.trim()).filter(u=>/^https?:\/\//i.test(u));
+    for(const url of lines){
+      const item = { url, title: '' };
+      queue.push(item);
+      renderQueue();
+      try{
+        const resp = await fetch(`https://www.youtube.com/oembed?url=${encodeURIComponent(url)}&format=json`);
+        const data = await resp.json();
+        item.title = data.title;
+        renderQueue();
+      }catch{
+        item.title = url;
+        renderQueue();
+      }
+    }
   });
 
   $('#clearQueueBtn')?.addEventListener('click', () => { queue.length = 0; renderQueue(); });
@@ -378,6 +430,7 @@ $('#queueList')?.addEventListener('click', (e) => {
   const applyTheme = (t) => document.documentElement.setAttribute('data-bs-theme', t);
   const themeKey = 'ytmp3.theme';
   const tutorialKey = 'ytmp3.tutorial.v1';
+  const welcomeKey = 'ytmp3.welcome.v1';
   const initTheme = () => {
     const stored = localStorage.getItem(themeKey);
     const prefers = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
@@ -391,6 +444,17 @@ $('#queueList')?.addEventListener('click', (e) => {
     applyTheme(nxt); localStorage.setItem(themeKey, nxt);
     themeToggle.innerHTML = nxt === 'light' ? '<i class="bi bi-moon-stars"></i>' : '<i class="bi bi-sun"></i>';
   });
+
+  function initWelcome(){
+    const card = $('#welcomeCard');
+    if(!card) return;
+    if(localStorage.getItem(welcomeKey)) { card.remove(); return; }
+    card.hidden = false;
+    $('#dismissWelcome')?.addEventListener('click', () => {
+      localStorage.setItem(welcomeKey,'1');
+      card.remove();
+    });
+  }
 
   // ===== History =====
   const historyKey = 'ytmp3.history.v1';
@@ -624,16 +688,20 @@ $('#queueList')?.addEventListener('click', (e) => {
   }
 
   async function doConvertQueue(){
-    const urls = queue.length ? [...queue] : $('#playlist').value.split(/\n+/).map(s=>s.trim()).filter(u=>/^https?:\/\//i.test(u));
+    const urls = queue.length ? queue.map(q=>q.url) : $('#playlist').value.split(/\n+/).map(s=>s.trim()).filter(u=>/^https?:\/\//i.test(u));
     if(!urls.length){ setToast('Antrian kosong'); return; }
     const progress = $('#queueProgress');
     progress.hidden = false; progress.max = urls.length; progress.value = 0;
     for(let i=0;i<urls.length;i++){
       $('#url').value = urls[i];
+      $('#id3Title').value='';
+      $('#id3Artist').value='';
+      $('#id3Album').value='';
+      $('#fileName').value='';
       await updatePreview();
       setToast(`Memproses ${i+1}/${urls.length}`);
       await doConvert(urls[i], true);
-       progress.value = i+1;
+      progress.value = i+1;
       if(queue.length){ queue.shift(); renderQueue(); }
     }
     progress.hidden = true;
@@ -648,6 +716,7 @@ $('#queueList')?.addEventListener('click', (e) => {
   // ===== Init =====
   (function init(){
     initTheme();
+    initWelcome();
     loadSettings();
     renderHistory();
     renderQueue();

--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -5,12 +5,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>YouTube → MP3/M4A | Converter UI</title>
   <meta name="description" content="Konversi video YouTube ke MP3/M4A dengan UI cantik berbasis Bootstrap 5, dukung dark-mode, riwayat, dan log proses." />
+  <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+  <meta name="theme-color" content="#0d1117" media="(prefers-color-scheme: dark)" />
   <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet" />
   <style>
     :root { --radius: 1.2rem; }
-    body { min-height: 100dvh; background-image: radial-gradient(60rem 40rem at 120% -10%, rgba(99,102,241,.15), transparent), radial-gradient(40rem 30rem at -10% 120%, rgba(16,185,129,.12), transparent); }
+    body { min-height: 100dvh; background-color: var(--bs-body-bg); background-image: radial-gradient(50rem 40rem at 100% 0%, rgba(99,102,241,.25), transparent), radial-gradient(50rem 40rem at 0% 100%, rgba(16,185,129,.2), transparent); }
+    html[data-bs-theme='dark'] body { background-image: radial-gradient(50rem 40rem at 100% 0%, rgba(99,102,241,.35), transparent), radial-gradient(50rem 40rem at 0% 100%, rgba(16,185,129,.25), transparent); }
     .card { border-radius: var(--radius); }
     .form-control, .form-select, .btn { border-radius: .9rem; }
     .brand-badge { letter-spacing:.08em; }
@@ -21,6 +24,7 @@
   </style>
 </head>
 <body>
+  <a href="#mainContent" class="visually-hidden-focusable">Lewati ke konten utama</a>
   <nav class="navbar navbar-expand-lg sticky-top bg-body-tertiary shadow-sm">
     <div class="container">
       <a class="navbar-brand fw-semibold" href="#"><i class="bi bi-music-note-beamed me-2"></i>YT → MP3/M4A</a>
@@ -31,7 +35,7 @@
     </div>
   </nav>
 
-  <main class="container py-4 py-md-5">
+  <main id="mainContent" class="container py-4 py-md-5">
     <div class="row g-4">
       <div class="col-lg-7">
         <div class="card shadow-sm">
@@ -54,9 +58,22 @@
 
             <div class="mb-3" id="previewWrap" hidden>
               <div class="ratio ratio-16x9 mb-2">
-                <img id="thumb" class="rounded object-fit-cover" alt="Thumbnail" />
+                <img id="thumb" class="rounded object-fit-cover" alt="Thumbnail" loading="lazy" />
               </div>
               <div id="videoTitle" class="fw-semibold"></div>
+            </div>
+
+            <div class="mb-3">
+              <label for="playlist" class="form-label">Playlist / Antrian</label>
+              <textarea id="playlist" class="form-control" rows="3" placeholder="Satu URL YouTube per baris"></textarea>
+              <div class="form-text">Setiap URL akan diproses bergiliran.</div>
+
+              <div class="input-group mt-2">
+                <input id="queueUrl" type="url" class="form-control" placeholder="Tambahkan URL ke antrian" />
+                <button class="btn btn-outline-secondary" id="addQueueBtn" type="button"><i class="bi bi-plus-lg"></i> Tambah</button>
+                <button class="btn btn-outline-danger" id="clearQueueBtn" type="button" aria-label="Hapus antrian"><i class="bi bi-trash"></i></button>
+              </div>
+              <ul class="list-group mt-2" id="queueList"></ul>
             </div>
 
             <div class="row g-3 mb-3">
@@ -103,6 +120,21 @@
 
             <div class="row g-3 mb-3">
               <div class="col-sm-6">
+                <div class="form-check form-switch">
+                  <input class="form-check-input" type="checkbox" id="autoDownload" checked>
+                  <label class="form-check-label" for="autoDownload">Auto-download</label>
+                </div>
+              </div>
+              <div class="col-sm-6">
+                <div class="form-check form-switch">
+                  <input class="form-check-input" type="checkbox" id="autoClear">
+                  <label class="form-check-label" for="autoClear">Auto-bersihkan</label>
+                </div>
+              </div>
+            </div>
+
+            <div class="row g-3 mb-3">
+              <div class="col-sm-6">
                 <label class="form-label">Trim Mulai</label>
                 <input id="trimStart" type="text" class="form-control" placeholder="detik atau hh:mm:ss" />
               </div>
@@ -138,6 +170,7 @@
 
             <div class="d-grid d-sm-flex gap-2 align-items-center">
               <button id="convertBtn" class="btn btn-primary btn-lg"><i class="bi bi-magic"></i> Convert</button>
+              <button id="downloadAllBtn" class="btn btn-outline-primary"><i class="bi bi-download"></i> Download Semua</button>
               <button id="clearBtn" class="btn btn-outline-secondary"><i class="bi bi-x-circle"></i> Bersihkan</button>
             </div>
 
@@ -148,6 +181,8 @@
                 <span class="badge text-bg-secondary" id="backendBadge" title="Target backend"></span>
               </div>
             </div>
+
+            <progress id="queueProgress" class="w-100 mt-2" value="0" max="100" hidden aria-label="Progress antrian"></progress>
 
             <div class="mt-3" id="resultWrap" hidden>
               <div class="alert alert-success d-flex align-items-center" role="alert">
@@ -183,6 +218,9 @@
             </div>
             <div id="historyEmpty" class="text-secondary small">Belum ada riwayat. Selesai convert, link akan tersimpan di sini.</div>
             <ul class="list-group list-group-flush" id="historyList"></ul>
+            <div class="d-grid mt-3">
+              <button class="btn btn-outline-danger btn-sm" id="clearHistory"><i class="bi bi-trash3"></i> Bersihkan Riwayat</button>
+            </div>
           </div>
         </div>
 
@@ -231,7 +269,30 @@
       <div class="d-grid gap-2">
         <button class="btn btn-outline-primary" id="adminUpload"><i class="bi bi-cloud-upload"></i> Upload sekarang</button>
         <button class="btn btn-outline-secondary" id="checkCookie"><i class="bi bi-shield-check"></i> Cek status cookies</button>
-        <div id="cookieStatus" class="small text-secondary"></div>
+    <div id="cookieStatus" class="small text-secondary"></div>
+  </div>
+  </div>
+  </div>
+
+  <!-- Tutorial Modal -->
+  <div class="modal fade" id="tutorialModal" tabindex="-1">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Tutorial Singkat</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <ol class="mb-0">
+            <li>Tempel URL YouTube.</li>
+            <li>Pilih format, kualitas, dan opsi lain.</li>
+            <li>Klik <strong>Convert</strong> atau <strong>Convert Antrian</strong>.</li>
+            <li>Unduh hasilnya.</li>
+          </ol>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-primary" data-bs-dismiss="modal">Mengerti</button>
+        </div>
       </div>
     </div>
   </div>
@@ -277,12 +338,50 @@
     badge.textContent = b ? new URL(b).host : location.host;
   };
 
+  // ===== Queue =====
+  const queue = [];
+  function renderQueue(){
+    const ul = $('#queueList');
+    if(!ul) return;
+    ul.innerHTML = '';
+    queue.forEach((url, idx) => {
+      const li = document.createElement('li');
+      li.className = 'list-group-item d-flex justify-content-between align-items-center';
+      li.innerHTML = `<span class="small text-break me-2 flex-grow-1">${url}</span><button class="btn btn-sm btn-outline-danger" data-idx="${idx}" aria-label="Hapus dari antrian"><i class="bi bi-x"></i></button>`;
+      ul.appendChild(li);
+    });
+    const textarea = $('#playlist');
+    if(textarea) textarea.value = queue.join('\n');
+    const clearBtn = $('#clearQueueBtn');
+    if(clearBtn) clearBtn.disabled = queue.length === 0;
+  }
+
+$('#queueList')?.addEventListener('click', (e) => {
+    const btn = e.target.closest('button[data-idx]');
+    if(!btn) return;
+    queue.splice(Number(btn.getAttribute('data-idx')),1);
+    renderQueue();
+  });
+
+  $('#addQueueBtn')?.addEventListener('click', () => {
+    const url = $('#queueUrl').value.trim();
+    if(!/^https?:\/\//i.test(url)){ setToast('URL tidak valid'); return; }
+    queue.push(url);
+    $('#queueUrl').value = '';
+    renderQueue();
+  });
+
+  $('#clearQueueBtn')?.addEventListener('click', () => { queue.length = 0; renderQueue(); });
+
   // ===== Theme Toggle =====
   const themeToggle = $('#themeToggle');
   const applyTheme = (t) => document.documentElement.setAttribute('data-bs-theme', t);
   const themeKey = 'ytmp3.theme';
+  const tutorialKey = 'ytmp3.tutorial.v1';
   const initTheme = () => {
-    const t = localStorage.getItem(themeKey) || 'light';
+    const stored = localStorage.getItem(themeKey);
+    const prefers = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const t = stored || prefers;
     applyTheme(t);
     themeToggle.innerHTML = t === 'light' ? '<i class="bi bi-moon-stars"></i>' : '<i class="bi bi-sun"></i>';
   };
@@ -338,6 +437,12 @@
       btn.addEventListener('click', () => removeHistory(Number(btn.dataset.idx)));
     });
   };
+
+  $('#clearHistory')?.addEventListener('click', () => {
+    localStorage.removeItem(historyKey);
+    renderHistory();
+    setToast('Riwayat dibersihkan');
+  });
 
   // ===== Settings (offcanvas) =====
   const loadSettings = () => {
@@ -443,9 +548,12 @@
   });
 
   // ===== Convert handler =====
-  $('#convertBtn').addEventListener('click', doConvert);
+  $('#convertBtn').addEventListener('click', () => doConvert(null, $('#autoDownload').checked));
+  $('#downloadAllBtn').addEventListener('click', doConvertQueue);
   $('#clearBtn').addEventListener('click', () => {
     $('#url').value='';
+    $('#playlist').value='';
+    queue.length = 0; renderQueue();
     $('#trimStart').value='';
     $('#trimEnd').value='';
     $('#fileName').value='';
@@ -456,10 +564,10 @@
     $('#previewWrap').hidden=true; $('#thumb').src=''; $('#videoTitle').textContent='';
     $('#resultWrap').hidden=true; $('#statusWrap').hidden=true; $('#logWrap').hidden=true; $('#logs').textContent='';
   });
-  $('#url').addEventListener('keydown', (e)=>{ if(e.key==='Enter') doConvert(); });
+  $('#url').addEventListener('keydown', (e)=>{ if(e.key==='Enter') doConvert(null, $('#autoDownload').checked); });
 
-  async function doConvert(){
-    const url = $('#url').value.trim();
+  async function doConvert(urlOverride, autoDownload = false){
+    const url = (urlOverride || $('#url').value).trim();
     if(!/^https?:\/\//i.test(url)){ setToast('Masukkan URL YouTube yang valid'); $('#url').focus(); return; }
     const body = {
       url,
@@ -501,8 +609,10 @@
       $('#status').textContent = 'Selesai';
       $('#loadingSpinner').style.display = 'none';
       if(data.logs && $('#showLog').checked){ $('#logs').textContent = data.logs; }
+      if(autoDownload) $('#downloadLink').click();
       pushHistory({ downloadUrl: data.downloadUrl, format: data.format, abr: body.abr, fileName: data.fileName });
       setToast('Berhasil diproses');
+      if($('#autoClear').checked && !urlOverride){ $('#clearBtn').click(); }
     }catch(err){
       $('#status').textContent = 'Error: ' + err.message;
       $('#loadingSpinner').style.display = 'none';
@@ -511,6 +621,23 @@
       $('#logs').textContent = (err && err.stack) ? err.stack : String(err);
       setToast('Terjadi error: '+err.message);
     }
+  }
+
+  async function doConvertQueue(){
+    const urls = queue.length ? [...queue] : $('#playlist').value.split(/\n+/).map(s=>s.trim()).filter(u=>/^https?:\/\//i.test(u));
+    if(!urls.length){ setToast('Antrian kosong'); return; }
+    const progress = $('#queueProgress');
+    progress.hidden = false; progress.max = urls.length; progress.value = 0;
+    for(let i=0;i<urls.length;i++){
+      $('#url').value = urls[i];
+      await updatePreview();
+      setToast(`Memproses ${i+1}/${urls.length}`);
+      await doConvert(urls[i], true);
+       progress.value = i+1;
+      if(queue.length){ queue.shift(); renderQueue(); }
+    }
+    progress.hidden = true;
+    setToast('Semua antrian selesai');
   }
 
   // ===== Copy log =====
@@ -523,8 +650,14 @@
     initTheme();
     loadSettings();
     renderHistory();
+    renderQueue();
     updateBackendBadge();
     updatePreview();
+    if(!localStorage.getItem(tutorialKey)){
+      const m = new bootstrap.Modal($('#tutorialModal'));
+      m.show();
+      $('#tutorialModal').addEventListener('hidden.bs.modal', ()=>localStorage.setItem(tutorialKey,'1'), { once:true });
+    }
   })();
   </script>
 </body>

--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -338,6 +338,7 @@
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" defer></script>
   <script>
+  document.addEventListener('DOMContentLoaded', () => {
   // ===== Utilities =====
   const $ = (sel) => document.querySelector(sel);
   const $$ = (sel) => document.querySelectorAll(sel);
@@ -739,6 +740,7 @@ $('#queueList')?.addEventListener('click', (e) => {
       $('#tutorialModal').addEventListener('hidden.bs.modal', ()=>localStorage.setItem(tutorialKey,'1'), { once:true });
     }
   })();
+  });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow `/api/convert` to read `id3`, `trim`, `normalize`, `fileName`, `sampleRate`, and `abr` parameters
- add `ffmpegToMp3` helper with optional sample rate, trimming, ID3 metadata, and loudness normalization
- sanitize custom file names and include them in API responses so downloads aren't random IDs
- extend web UI with sample rate selector and editable output file name field
- add copy and delete controls to history entries and clear resets file name and metadata
- document project features and usage in `README.md`
- add first-run tutorial modal and playlist queue for sequential downloads

## Testing
- `npm test` *(fails: Missing script "test")*
- `node index.js`

------
https://chatgpt.com/codex/tasks/task_e_68b574d246b08331a328643742a375e9