### PR TITLE
Add phase one enhancements

### DIFF
--- a/download_subtitle.py
+++ b/download_subtitle.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+import json
+import re
+import subprocess
+import sys
+from typing import List, Tuple
+
+YouTube = None
+Caption = None
+
+
+def ensure_pytube():
+    global YouTube, Caption
+    if YouTube is not None:
+        return
+    try:
+        from pytube import YouTube as _YouTube  # type: ignore
+        from pytube import Caption as _Caption  # type: ignore
+        YouTube = _YouTube
+        Caption = _Caption
+    except ModuleNotFoundError:
+        try:
+            subprocess.check_call(
+                [sys.executable, "-m", "pip", "install", "--quiet", "pytube"]
+            )
+            from pytube import YouTube as _YouTube  # type: ignore
+            from pytube import Caption as _Caption  # type: ignore
+            YouTube = _YouTube
+            Caption = _Caption
+        except Exception as exc:  # pragma: no cover - install best effort
+            print(f"failed to install pytube: {exc}", file=sys.stderr)
+            sys.exit(90)
+
+
+def parse_patterns(raw: str) -> List[str]:
+    parts = [part.strip() for part in (raw or "").split(",")]
+    return [p for p in parts if p]
+
+
+def wildcard_match(pattern: str, value: str) -> bool:
+    escaped = re.escape(pattern).replace(r"\*", ".*")
+    return re.match(rf"^{escaped}$", value or "", re.IGNORECASE) is not None
+
+
+def collect_captions(yt) -> List[Tuple[object, str, bool, str]]:
+    results = []
+    for caption in yt.captions:  # type: ignore[attr-defined]
+        code = (getattr(caption, "code", "") or "").strip()
+        name = (getattr(caption, "name", "") or "").strip()
+        is_auto = code.lower().startswith("a.")
+        lang = code[2:] if is_auto and len(code) > 2 else code
+        if not lang:
+            lang = "auto" if is_auto else "subtitle"
+        results.append((caption, lang, is_auto, name))
+    return results
+
+
+def pick_caption(candidates, patterns, prefer_auto):
+    autos = [item for item in candidates if item[2]]
+    manuals = [item for item in candidates if not item[2]]
+
+    def select(pool):
+        for pattern in patterns:
+            for item in pool:
+                code = getattr(item[0], "code", "") or ""
+                if wildcard_match(pattern, item[1]) or wildcard_match(pattern, code):
+                    return item
+        return None
+
+    if prefer_auto:
+        choice = select(autos) or select(manuals)
+    else:
+        choice = select(manuals) or select(autos)
+
+    if choice:
+        return choice
+
+    if prefer_auto and autos:
+        return autos[0]
+    if manuals:
+        return manuals[0]
+    if autos:
+        return autos[0]
+    return candidates[0] if candidates else None
+
+
+def caption_to_srt(caption_obj) -> str:
+    xml = getattr(caption_obj, "xml_captions", None)
+    if not xml:
+        return ""
+    converter = getattr(caption_obj, "xml_caption_to_srt", None)
+    if callable(converter):
+        return converter(xml)
+    module_converter = getattr(Caption, "xml_caption_to_srt", None)
+    if callable(module_converter):
+        return module_converter(xml)
+    return ""
+
+
+def main():
+    if len(sys.argv) < 4:
+        print(
+            "usage: python3 download_subtitle.py <url> <lang_pref> <prefer_auto>",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    url = sys.argv[1]
+    lang_pref = sys.argv[2]
+    prefer_auto = sys.argv[3] not in ("0", "false", "False")
+
+    ensure_pytube()
+    try:
+        yt = YouTube(url)
+    except Exception as exc:
+        print(f"failed to load video: {exc}", file=sys.stderr)
+        sys.exit(3)
+
+    captions = collect_captions(yt)
+    if not captions:
+        print("no subtitles available", file=sys.stderr)
+        sys.exit(4)
+
+    patterns = parse_patterns(lang_pref)
+    choice = pick_caption(captions, patterns, prefer_auto)
+    if not choice:
+        print("no matching subtitle track", file=sys.stderr)
+        sys.exit(5)
+
+    caption_obj, lang, is_auto, name = choice
+    try:
+        srt = caption_to_srt(caption_obj)
+    except Exception as exc:
+        print(f"failed to convert subtitle: {exc}", file=sys.stderr)
+        sys.exit(6)
+
+    if not srt.strip():
+        print("empty subtitle", file=sys.stderr)
+        sys.exit(7)
+
+    payload = {
+        "srt": srt,
+        "lang": lang,
+        "auto": bool(is_auto),
+        "title": getattr(yt, "title", ""),
+        "author": getattr(yt, "author", ""),
+        "track": name,
+    }
+    print(json.dumps(payload))
+
+
+if __name__ == "__main__":
+    main()

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ import cors from "cors";
 import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, readdirSync, statSync } from "node:fs";
 import { promises as fsp } from "node:fs";
-import { join, dirname, basename, resolve as pathResolve } from "node:path";
+import { join, dirname, resolve as pathResolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { nanoid } from "nanoid";
 // Tambahan untuk ffmpeg portable (opsional)
@@ -669,6 +669,396 @@ const vttToSrt = (input = "") => {
   return lines.join("\n").trim();
 };
 
+const decodeHtmlEntities = (input = "") =>
+  (input || "")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/&#x([0-9a-f]+);/gi, (_, hex) => {
+      const code = Number.parseInt(hex, 16);
+      return Number.isFinite(code) ? String.fromCodePoint(code) : _;
+    })
+    .replace(/&#(\d+);/g, (_, dec) => {
+      const code = Number.parseInt(dec, 10);
+      return Number.isFinite(code) ? String.fromCodePoint(code) : _;
+    });
+
+const stripHtml = (input = "") =>
+  decodeHtmlEntities((input || "").replace(/<br\s*\/?>(?=\s*\n?)/gi, "\n").replace(/<[^>]+>/g, "")).replace(/\s+$/gm, "");
+
+const msToSrtTime = (value) => {
+  const ms = Math.max(0, Math.round(Number(value) || 0));
+  const totalSeconds = Math.floor(ms / 1000);
+  const milli = ms % 1000;
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const pad = (num, len = 2) => String(num).padStart(len, "0");
+  return `${pad(hours)}:${pad(minutes)}:${pad(seconds)},${pad(milli, 3)}`;
+};
+
+const parseClockTime = (value) => {
+  if (!value) return null;
+  const trimmed = String(value).trim();
+  if (!trimmed) return null;
+  if (/^\d+(?:\.\d+)?ms$/i.test(trimmed)) return Number.parseFloat(trimmed) || 0;
+  if (/^\d+(?:\.\d+)?s$/i.test(trimmed)) return (Number.parseFloat(trimmed) || 0) * 1000;
+  if (/^\d+(?:\.\d+)?m$/i.test(trimmed)) return (Number.parseFloat(trimmed) || 0) * 60 * 1000;
+  if (/^\d+(?:\.\d+)?h$/i.test(trimmed)) return (Number.parseFloat(trimmed) || 0) * 3600 * 1000;
+  if (/^\d{1,2}:\d{2}:\d{2}(?:\.\d+)?$/.test(trimmed)) {
+    const [h, m, s] = trimmed.split(":");
+    const seconds = Number.parseFloat(s) || 0;
+    return ((Number(h) || 0) * 3600 + (Number(m) || 0) * 60 + seconds) * 1000;
+  }
+  return null;
+};
+
+const convertSrvXmlToSrt = (xml = "") => {
+  const entries = [];
+  const regex = /<p\b([^>]*)>([\s\S]*?)<\/p>/gi;
+  let match;
+  while ((match = regex.exec(xml))) {
+    const attrs = match[1] || "";
+    const text = stripHtml(match[2] || "").replace(/\s+/g, " ").trim();
+    if (!text) continue;
+    const startMatch = attrs.match(/\bt="([^"]+)"/i) || attrs.match(/\bbegin="([^"]+)"/i);
+    const durMatch = attrs.match(/\bd="([^"]+)"/i) || attrs.match(/\bdur="([^"]+)"/i);
+    const endMatch = attrs.match(/\bend="([^"]+)"/i);
+    const startRaw = startMatch ? Number.parseFloat(startMatch[1]) : null;
+    const durRaw = durMatch ? Number.parseFloat(durMatch[1]) : null;
+    const endRaw = endMatch ? Number.parseFloat(endMatch[1]) : null;
+    const start = Number.isFinite(startRaw) ? startRaw : parseClockTime(startMatch?.[1]) || 0;
+    let end = Number.isFinite(endRaw) ? endRaw : parseClockTime(endMatch?.[1]);
+    let dur = Number.isFinite(durRaw) ? durRaw : parseClockTime(durMatch?.[1]);
+    entries.push({
+      start,
+      dur,
+      end,
+      text,
+    });
+  }
+  entries.sort((a, b) => (a.start || 0) - (b.start || 0));
+  if (!entries.length) return "";
+  for (let i = 0; i < entries.length; i += 1) {
+    const item = entries[i];
+    if (!Number.isFinite(item.end)) {
+      if (Number.isFinite(item.dur)) item.end = (item.start || 0) + item.dur;
+      else if (entries[i + 1]) item.end = entries[i + 1].start;
+    }
+    if (!Number.isFinite(item.end)) item.end = (item.start || 0) + 2000;
+  }
+  const lines = [];
+  let idx = 1;
+  for (const item of entries) {
+    const start = msToSrtTime(item.start || 0);
+    const end = msToSrtTime(item.end || ((item.start || 0) + 2000));
+    lines.push(String(idx));
+    lines.push(`${start} --> ${end}`);
+    lines.push(...item.text.split(/\n+/).map((line) => line.trim()).filter(Boolean));
+    lines.push("");
+    idx += 1;
+  }
+  return lines.join("\n").trim();
+};
+
+const convertTtmlToSrt = (xml = "") => {
+  const entries = [];
+  const regex = /<p\b([^>]*)>([\s\S]*?)<\/p>/gi;
+  let match;
+  while ((match = regex.exec(xml))) {
+    const attrs = match[1] || "";
+    const text = stripHtml(match[2] || "").replace(/\s+/g, " ").trim();
+    if (!text) continue;
+    const beginMatch = attrs.match(/\bbegin="([^"]+)"/i);
+    const endMatch = attrs.match(/\bend="([^"]+)"/i);
+    const durMatch = attrs.match(/\bdur="([^"]+)"/i);
+    const start = parseClockTime(beginMatch?.[1]) || 0;
+    let end = parseClockTime(endMatch?.[1]);
+    const dur = parseClockTime(durMatch?.[1]);
+    entries.push({ start, end, dur, text });
+  }
+  entries.sort((a, b) => (a.start || 0) - (b.start || 0));
+  if (!entries.length) return "";
+  for (let i = 0; i < entries.length; i += 1) {
+    const item = entries[i];
+    if (!Number.isFinite(item.end)) {
+      if (Number.isFinite(item.dur)) item.end = (item.start || 0) + item.dur;
+      else if (entries[i + 1]) item.end = entries[i + 1].start;
+    }
+    if (!Number.isFinite(item.end)) item.end = (item.start || 0) + 2000;
+  }
+  const lines = [];
+  let idx = 1;
+  for (const item of entries) {
+    const start = msToSrtTime(item.start || 0);
+    const end = msToSrtTime(item.end || ((item.start || 0) + 2000));
+    lines.push(String(idx));
+    lines.push(`${start} --> ${end}`);
+    lines.push(...item.text.split(/\n+/).map((line) => line.trim()).filter(Boolean));
+    lines.push("");
+    idx += 1;
+  }
+  return lines.join("\n").trim();
+};
+
+const convertJson3ToSrt = (jsonText = "") => {
+  try {
+    const data = JSON.parse(jsonText || "{}");
+    const events = Array.isArray(data.events) ? data.events : [];
+    const entries = [];
+    for (const event of events) {
+      const start = Number(event.tStartMs || event.tstartMs || 0);
+      const dur = Number(event.dDurationMs || event.dur || 0);
+      let text = "";
+      if (Array.isArray(event.segs)) {
+        text = event.segs.map((seg) => (typeof seg?.utf8 === "string" ? seg.utf8 : "")).join("");
+      } else if (typeof event.utf8 === "string") {
+        text = event.utf8;
+      }
+      text = stripHtml(text).replace(/\s+/g, " ").trim();
+      if (!text) continue;
+      entries.push({ start, dur, text });
+    }
+    if (!entries.length) return "";
+    entries.sort((a, b) => (a.start || 0) - (b.start || 0));
+    for (let i = 0; i < entries.length; i += 1) {
+      const item = entries[i];
+      if (!item.dur && entries[i + 1]) item.dur = entries[i + 1].start - item.start;
+      if (!item.dur || item.dur <= 0) item.dur = 2000;
+    }
+    const lines = [];
+    let idx = 1;
+    for (const item of entries) {
+      lines.push(String(idx));
+      lines.push(`${msToSrtTime(item.start || 0)} --> ${msToSrtTime((item.start || 0) + item.dur)}`);
+      lines.push(...item.text.split(/\n+/).map((line) => line.trim()).filter(Boolean));
+      lines.push("");
+      idx += 1;
+    }
+    return lines.join("\n").trim();
+  } catch {
+    return "";
+  }
+};
+
+const normalizeSrt = (text = "") => {
+  const normalized = (text || "").replace(/\r/g, "").trim();
+  if (!normalized) return "";
+  return normalized.endsWith("\n") ? normalized : `${normalized}\n`;
+};
+
+const convertSubtitleToSrt = (content = "", ext = "") => {
+  const lower = String(ext || "").toLowerCase();
+  if (lower === "srt") return normalizeSrt(content);
+  if (lower === "vtt" || lower === "webvtt") return normalizeSrt(vttToSrt(content));
+  if (lower === "ttml" || lower === "dfxp" || lower === "xml") return normalizeSrt(convertTtmlToSrt(content));
+  if (lower === "srv3" || lower === "srv2" || lower === "srv1") return normalizeSrt(convertSrvXmlToSrt(content));
+  if (lower === "json3") return normalizeSrt(convertJson3ToSrt(content));
+  const converted = vttToSrt(content);
+  if (converted) return normalizeSrt(converted);
+  throw new Error(`Format subtitle ${ext || ""} tidak didukung`);
+};
+
+const parseLangPreferences = (input) =>
+  String(input || "")
+    .split(",")
+    .map((token) => token.trim())
+    .filter(Boolean);
+
+const wildcardToRegex = (pattern) => {
+  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`^${escaped.replace(/\\\*/g, ".*")}$`, "i");
+};
+
+const SUPPORTED_SUB_EXTS = ["srt", "vtt", "webvtt", "ttml", "dfxp", "srv3", "srv2", "srv1", "json3"];
+
+const pickSourceFromCatalog = (catalog = {}, patterns = []) => {
+  const entries = Object.entries(catalog || {})
+    .map(([lang, sources]) => {
+      const list = Array.isArray(sources) ? sources : [sources];
+      const filtered = list
+        .map((item) => (item && item.url ? { ...item, ext: String(item.ext || "").toLowerCase() } : null))
+        .filter(Boolean);
+      return filtered.length ? { lang, sources: filtered } : null;
+    })
+    .filter(Boolean);
+  if (!entries.length) return null;
+
+  const pickByPattern = (pattern) => {
+    const rx = wildcardToRegex(pattern);
+    const match = entries.find((entry) => rx.test(entry.lang));
+    if (!match) return null;
+    for (const ext of SUPPORTED_SUB_EXTS) {
+      const src = match.sources.find((item) => item.ext === ext);
+      if (src) return { lang: match.lang, source: src };
+    }
+    return { lang: match.lang, source: match.sources[0] };
+  };
+
+  for (const pattern of patterns) {
+    const picked = pickByPattern(pattern);
+    if (picked) return picked;
+  }
+
+  const english = pickByPattern("en.*") || pickByPattern("en");
+  if (english) return english;
+
+  const fallback = entries[0];
+  for (const ext of SUPPORTED_SUB_EXTS) {
+    const src = fallback.sources.find((item) => item.ext === ext);
+    if (src) return { lang: fallback.lang, source: src };
+  }
+  return { lang: fallback.lang, source: fallback.sources[0] };
+};
+
+const sanitizeLangKey = (lang, auto) => {
+  const clean = String(lang || (auto ? "auto" : "subtitle"))
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  if (clean) return clean;
+  return auto ? "auto" : "subtitle";
+};
+
+const selectSubtitleTrack = (info, { patterns = [], preferAuto = true } = {}) => {
+  const entries = Array.isArray(info?.entries) ? info.entries : [info];
+  for (const entry of entries) {
+    if (!entry) continue;
+    const manual = pickSourceFromCatalog(entry.subtitles, patterns);
+    const auto = pickSourceFromCatalog(entry.automatic_captions, patterns);
+    if (manual && !preferAuto) {
+      return { ...manual.source, lang: manual.lang, auto: false };
+    }
+    if (preferAuto && auto) {
+      return { ...auto.source, lang: auto.lang, auto: true };
+    }
+    if (manual) {
+      return { ...manual.source, lang: manual.lang, auto: false };
+    }
+    if (auto) {
+      return { ...auto.source, lang: auto.lang, auto: true };
+    }
+  }
+  return null;
+};
+
+const fetchWithTimeout = async (url, { timeout = 15000, headers = {} } = {}) => {
+  if (typeof fetch !== "function") {
+    throw new Error("Lingkungan tidak mendukung fetch untuk subtitle");
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), Math.max(1000, timeout));
+  try {
+    const response = await fetch(url, {
+      signal: controller.signal,
+      redirect: "follow",
+      headers: {
+        "user-agent":
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0 Safari/537.36",
+        "accept-language": "id-ID,id;q=0.9,en-US;q=0.8,en;q=0.7",
+        ...headers,
+      },
+    });
+    return response;
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+const fetchSubtitleViaYtDlp = async ({ url, langOpt, preferAuto }) => {
+  const args = ["--dump-single-json", "--no-progress", "--skip-download", "--no-warnings"];
+  if (ffmpegPath) args.push("--ffmpeg-location", ffmpegPath);
+  if (existsSync(COOKIES_PATH)) args.push("--cookies", COOKIES_PATH);
+  args.push(url);
+
+  let stdout = "";
+  let stderr = "";
+  const logs = [`yt-dlp ${args.join(" ")}`];
+
+  try {
+    await new Promise((resolve, reject) => {
+      const proc = spawn("yt-dlp", args, { stdio: ["ignore", "pipe", "pipe"] });
+      proc.stdout.on("data", (d) => {
+        const chunk = d.toString();
+        stdout += chunk;
+      });
+      proc.stderr.on("data", (d) => {
+        const chunk = d.toString();
+        stderr += chunk;
+      });
+      proc.on("error", (err) => {
+        const error = new Error("yt-dlp tidak bisa dijalankan");
+        error.cause = err;
+        reject(error);
+      });
+      proc.on("close", (code) => {
+        if (code !== 0) {
+          const error = new Error("yt-dlp gagal mengambil metadata subtitle");
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
+    });
+  } catch (err) {
+    const error = new Error(err.message || "yt-dlp gagal");
+    error.logs = [...logs, stdout, stderr].filter(Boolean).join("\n");
+    throw error;
+  }
+
+  const patterns = parseLangPreferences(langOpt);
+  let info;
+  try {
+    info = JSON.parse(stdout || "{}");
+  } catch (err) {
+    const error = new Error("Respons yt-dlp tidak valid");
+    error.logs = [...logs, stderr, stdout].filter(Boolean).join("\n");
+    throw error;
+  }
+
+  const track = selectSubtitleTrack(info, { patterns, preferAuto });
+  if (!track || !track.url) {
+    const error = new Error("Subtitle tidak ditemukan");
+    error.logs = [...logs, stderr, stdout].filter(Boolean).join("\n");
+    throw error;
+  }
+
+  let body;
+  try {
+    const response = await fetchWithTimeout(track.url, {});
+    if (!response.ok) {
+      const error = new Error(`Gagal mengunduh subtitle (${response.status})`);
+      error.logs = [...logs, stderr, stdout, `HTTP ${response.status}`].filter(Boolean).join("\n");
+      throw error;
+    }
+    body = await response.text();
+  } catch (err) {
+    if (err.logs) throw err;
+    const error = new Error(err.message || "Gagal mengambil subtitle");
+    error.logs = [...logs, stderr, stdout].filter(Boolean).join("\n");
+    throw error;
+  }
+
+  let srt;
+  try {
+    srt = convertSubtitleToSrt(body, track.ext);
+  } catch (err) {
+    const error = new Error(err.message || "Gagal mengonversi subtitle");
+    error.logs = [...logs, stderr, stdout].filter(Boolean).join("\n");
+    throw error;
+  }
+
+  const safeLang = sanitizeLangKey(track.lang, track.auto);
+  return {
+    srt,
+    safeLang,
+    auto: Boolean(track.auto),
+    logs: [...logs, stderr].filter(Boolean).join("\n").slice(-8000),
+  };
+};
+
 const srtToPlainText = (input = "") => {
   const normalized = (input || "").replace(/\r/g, "");
   const blocks = normalized.split(/\n\n+/);
@@ -1241,116 +1631,41 @@ const downloadSubtitle = async (payload = {}) => {
   const downloadBase = baseOutput || "subtitle";
 
   const id = nanoid(10);
-  const outputTpl = join(JOBS_DIR, `${id}.%(ext)s`);
-
-  const args = ["--skip-download", "--no-progress", "--newline"];
-  if (ffmpegPath) args.push("--ffmpeg-location", ffmpegPath);
-  if (existsSync(COOKIES_PATH)) args.push("--cookies", COOKIES_PATH);
-  args.push("--write-sub");
-  if (preferAuto) args.push("--write-auto-sub");
-  args.push("--sub-format", "srt/best");
-  args.push("--convert-subs", "srt");
-  args.push("--sub-langs", langOpt);
-  args.push("-o", outputTpl);
-  args.push(url);
-
   let logs = "";
+  let finalSrtName = "";
+  let finalTxtName = "";
   try {
-    await new Promise((resolve, reject) => {
-      const proc = spawn("yt-dlp", args, { stdio: ["ignore", "pipe", "pipe"] });
-      proc.stdout.on("data", (d) => (logs += d.toString()));
-      proc.stderr.on("data", (d) => (logs += d.toString()));
-      proc.on("error", (err) => {
-        const error = new Error("yt-dlp tidak bisa dijalankan");
-        error.cause = err;
-        error.logs = logs;
-        reject(error);
-      });
-      proc.on("close", (code) => {
-        if (code !== 0) {
-          const error = new Error("yt-dlp gagal mengambil subtitle");
-          error.logs = logs;
-          reject(error);
-        } else {
-          resolve();
-        }
-      });
-    });
+    const result = await fetchSubtitleViaYtDlp({ url, langOpt, preferAuto });
+    logs = result.logs || "";
+    const finalStem = `${id}.${result.safeLang}`;
+    finalSrtName = `${finalStem}.srt`;
+    const srtPath = join(JOBS_DIR, finalSrtName);
+    await fsp.writeFile(srtPath, result.srt, "utf8");
 
-    const files = readdirSync(JOBS_DIR).filter((f) => f.startsWith(`${id}.`));
-    const candidates = files.filter((f) => f.endsWith(".srt") || f.endsWith(".vtt"));
-    if (!candidates.length) {
-      const error = new Error("Subtitle tidak ditemukan");
-      error.logs = logs;
-      throw error;
-    }
-
-    const autoCandidate = candidates.find((f) => /\.auto\./i.test(f));
-    const manualCandidate = candidates.find((f) => !/\.auto\./i.test(f));
-    let chosen = manualCandidate || candidates[0];
-    if (preferAuto && autoCandidate) chosen = autoCandidate;
-
-    const suffix = chosen.replace(`${id}.`, "");
-    const parts = suffix.split(".");
-    const ext = parts.pop();
-    let langKey = parts.join(".");
-    let autoDetected = /\.auto$/i.test(langKey) || /-auto$/i.test(langKey) || /\.auto\./i.test(chosen);
-    langKey = langKey.replace(/\.auto/gi, "-auto");
-    if (!langKey) langKey = autoDetected ? "auto" : "subtitle";
-    const safeLang = langKey.replace(/[^a-z0-9_-]+/gi, "-");
-    autoDetected = autoDetected || /-auto$/i.test(safeLang);
-
-    const chosenPath = join(JOBS_DIR, chosen);
-    const finalStem = `${id}.${safeLang}`;
-    const finalSrtName = `${finalStem}.srt`;
-    let srtPath = join(JOBS_DIR, finalSrtName);
-
-    if (ext === "vtt") {
-      const vttContent = await fsp.readFile(chosenPath, "utf8");
-      const srtContent = vttToSrt(vttContent);
-      if (!srtContent) {
-        const error = new Error("Subtitle VTT tidak bisa dikonversi");
-        error.logs = logs;
-        throw error;
-      }
-      await fsp.writeFile(srtPath, `${srtContent}\n`, "utf8");
-      try { await fsp.unlink(chosenPath); } catch {}
-    } else {
-      if (basename(chosenPath) !== finalSrtName) {
-        await fsp.rename(chosenPath, srtPath);
-      }
-    }
-
-    const srtContent = await fsp.readFile(srtPath, "utf8");
-    const plain = srtToPlainText(srtContent);
+    const plain = srtToPlainText(result.srt);
     const preview = buildSubtitlePreview(plain);
-    const finalTxtName = `${finalStem}.txt`;
+    finalTxtName = `${finalStem}.txt`;
     const txtPath = join(JOBS_DIR, finalTxtName);
     await fsp.writeFile(txtPath, `${plain}\n`, "utf8");
 
-    for (const file of files) {
-      if (file === finalSrtName || file === finalTxtName) continue;
-      try { await fsp.unlink(join(JOBS_DIR, file)); } catch {}
-    }
-
     return {
       ok: true,
-      logs: (logs || "").slice(-8000),
-      lang: safeLang,
-      auto: autoDetected,
+      logs,
+      lang: result.safeLang,
+      auto: Boolean(result.auto),
       srtUrl: `/public/jobs/${finalSrtName}`,
-      srtFileName: `${downloadBase}.${safeLang}.srt`,
+      srtFileName: `${downloadBase}.${result.safeLang}.srt`,
       txtUrl: `/public/jobs/${finalTxtName}`,
-      txtFileName: `${downloadBase}.${safeLang}.txt`,
+      txtFileName: `${downloadBase}.${result.safeLang}.txt`,
       preview,
     };
   } catch (err) {
-    try {
-      const leftovers = readdirSync(JOBS_DIR).filter((f) => f.startsWith(`${id}.`));
-      for (const file of leftovers) {
-        try { await fsp.unlink(join(JOBS_DIR, file)); } catch {}
-      }
-    } catch {}
+    if (finalSrtName) {
+      try { await fsp.unlink(join(JOBS_DIR, finalSrtName)); } catch {}
+    }
+    if (finalTxtName) {
+      try { await fsp.unlink(join(JOBS_DIR, finalTxtName)); } catch {}
+    }
     const error = new Error(err.message || "Gagal mengambil subtitle");
     error.logs = (logs + (err.logs || "")).slice(-8000);
     throw error;

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ import cors from "cors";
 import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, readdirSync, statSync } from "node:fs";
 import { promises as fsp } from "node:fs";
-import { join, dirname, basename } from "node:path";
+import { join, dirname, basename, resolve as pathResolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { nanoid } from "nanoid";
 // Tambahan untuk ffmpeg portable (opsional)
@@ -27,6 +27,23 @@ const JOBS_DIR   = join(PUBLIC_DIR, "jobs");
 if (!existsSync(PUBLIC_DIR)) mkdirSync(PUBLIC_DIR, { recursive: true });
 if (!existsSync(JOBS_DIR))   mkdirSync(JOBS_DIR,   { recursive: true });
 
+const PUBLIC_ROOT = pathResolve(PUBLIC_DIR);
+const THUMB_DIR = join(PUBLIC_ROOT, "thumbnails");
+const CLOUD_DIR = join(PUBLIC_ROOT, "cloud");
+const CLOUD_TARGETS = {
+  drive: { label: "Google Drive", dir: join(CLOUD_DIR, "drive") },
+  dropbox: { label: "Dropbox", dir: join(CLOUD_DIR, "dropbox") },
+  onedrive: { label: "OneDrive", dir: join(CLOUD_DIR, "onedrive") },
+};
+
+for (const dir of [THUMB_DIR, CLOUD_DIR, ...Object.values(CLOUD_TARGETS).map((t) => t.dir)]) {
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+}
+
+const backgroundJobs = new Map();
+const backgroundQueue = [];
+let backgroundProcessing = false;
+
 // ==== Util ====
 const abrToQ = (abr) => {
   const n = Number(abr) || 128;
@@ -47,16 +64,442 @@ const sanitizeFileName = (name = "") =>
     .replace(/\s+/g, " ")
     .trim();
 
+const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
+
+const escapeDrawText = (input = "") =>
+  (input || "")
+    .replace(/[\\:'\[\]]/g, (match) => `\\${match}`)
+    .replace(/\n/g, "\\n");
+
+const normalizeHex = (hex, fallback = "#0d6efd") => {
+  if (typeof hex !== "string") return fallback;
+  const clean = hex.trim();
+  return /^#?[0-9a-fA-F]{6}$/.test(clean)
+    ? (clean.startsWith("#") ? clean : `#${clean}`)
+    : fallback;
+};
+
+const hexToFfmpegColor = (hex) => `0x${hex.replace(/^#/, "").toUpperCase()}`;
+
+const findFontPath = () => {
+  const candidates = [
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+    "/usr/share/fonts/truetype/liberation/LiberationSans-Bold.ttf",
+    "/usr/share/fonts/truetype/freefont/FreeSansBold.ttf",
+  ];
+  for (const font of candidates) {
+    if (existsSync(font)) return font;
+  }
+  return null;
+};
+
+const DEFAULT_FONT = findFontPath();
+
+const resolvePublicPath = (urlPath = "") => {
+  if (typeof urlPath !== "string") return null;
+  const cleaned = urlPath.replace(/\\/g, "/").trim();
+  if (!cleaned.startsWith("/public/")) return null;
+  const relative = cleaned.slice("/public/".length);
+  const fullPath = pathResolve(PUBLIC_ROOT, relative);
+  if (!fullPath.startsWith(PUBLIC_ROOT)) return null;
+  return fullPath;
+};
+
+const ensureUniqueFileName = (dir, fileName) => {
+  const clean = fileName || "file";
+  const dot = clean.lastIndexOf(".");
+  const base = dot > 0 ? clean.slice(0, dot) : clean;
+  const ext = dot > 0 ? clean.slice(dot) : "";
+  let candidate = clean;
+  let counter = 1;
+  while (existsSync(join(dir, candidate))) {
+    candidate = `${base} (${counter})${ext}`;
+    counter += 1;
+  }
+  return candidate;
+};
+
+const GENRE_KEYWORDS = [
+  { rx: /(lo[-\s]?fi|study|chillhop|coffee shop)/i, value: "Lo-Fi" },
+  { rx: /(hip\s?hop|rap)/i, value: "Hip-Hop" },
+  { rx: /(trap|808|drill)/i, value: "Trap" },
+  { rx: /(edm|electro|dance|club|festival)/i, value: "EDM" },
+  { rx: /(rock|guitar|band)/i, value: "Rock" },
+  { rx: /(metal|screamo|hardcore)/i, value: "Metal" },
+  { rx: /(jazz|swing|sax)/i, value: "Jazz" },
+  { rx: /(lofi|sleep|relax|ambient|meditation)/i, value: "Ambient" },
+  { rx: /(piano|violin|orchestra|symphony)/i, value: "Classical" },
+  { rx: /(k\-?pop|kpop)/i, value: "K-Pop" },
+  { rx: /(dangdut|koplo)/i, value: "Dangdut" },
+];
+
+const MOOD_KEYWORDS = [
+  { rx: /(happy|joy|summer|sunshine)/i, value: "Happy" },
+  { rx: /(sad|heartbreak|galau|melancholy|cry)/i, value: "Melancholy" },
+  { rx: /(relax|calm|sleep|study|focus)/i, value: "Chill" },
+  { rx: /(epic|cinematic|battle|orchestra)/i, value: "Epic" },
+  { rx: /(rain|night|midnight|lofi)/i, value: "Midnight" },
+  { rx: /(pump|gym|workout|power)/i, value: "Hype" },
+];
+
+const ENERGY_KEYWORDS = [
+  { rx: /(sleep|ambient|relax|asmr)/i, value: "Low" },
+  { rx: /(lofi|study|chill|coffee)/i, value: "Medium" },
+  { rx: /(edm|nightcore|dance|club|hard|festival|live)/i, value: "High" },
+];
+
+const pickFromKeywords = (text, rules, fallback) => {
+  for (const rule of rules) {
+    if (rule.rx.test(text)) return rule.value;
+  }
+  return fallback;
+};
+
+const buildAiTags = ({ title = "", description = "", channel = "", duration } = {}) => {
+  const combined = `${title}\n${description}\n${channel}`;
+  const genre = pickFromKeywords(combined, GENRE_KEYWORDS, "Pop");
+  const mood = pickFromKeywords(combined, MOOD_KEYWORDS, duration && duration > 360 ? "Calm" : "Energetic");
+  let energy = pickFromKeywords(combined, ENERGY_KEYWORDS, duration && duration > 420 ? "Medium" : "High");
+  if (/acoustic|piano|ambient/i.test(combined)) energy = "Low";
+  const yearMatch = /(20\d{2}|19\d{2})/.exec(description) || /(20\d{2}|19\d{2})/.exec(title);
+  const year = yearMatch ? yearMatch[1] : undefined;
+
+  const cleanTitle = title.replace(/\[[^\]]+\]/g, "").replace(/\([^)]*official[^)]*\)/ig, "").trim();
+  const suggestedTitle = cleanTitle || title;
+  const suggestedAlbum = suggestedTitle;
+  const suggestedArtist = channel?.trim() || undefined;
+
+  const tags = {
+    title: suggestedTitle,
+    artist: suggestedArtist,
+    album: suggestedAlbum,
+    genre,
+    mood,
+    energy,
+  };
+  if (year) tags.year = year;
+  tags.comment = `AI tags · ${genre} · ${mood}${year ? ` · ${year}` : ""}`;
+  return tags;
+};
+
+const createStemsForSource = async (inputPath, baseName = "Audio") => {
+  if (!inputPath) throw new Error("Sumber audio tidak ditemukan");
+  const safeBase = sanitizeFileName(baseName) || "Audio";
+  const stemId = nanoid(10);
+  const vocalsFile = `${stemId}.vocals.mp3`;
+  const instrumentalFile = `${stemId}.instrumental.mp3`;
+  const zipFile = `${stemId}.stems.zip`;
+  const vocalsPath = join(JOBS_DIR, vocalsFile);
+  const instrumentalPath = join(JOBS_DIR, instrumentalFile);
+  const zipPath = join(JOBS_DIR, zipFile);
+
+  let vocalsLogs = "";
+  let instrumentalLogs = "";
+  try {
+    vocalsLogs = await runFfmpeg([
+      "-y",
+      "-i", inputPath,
+      "-filter:a", "pan=stereo|c0=c0+c1|c1=c0+c1,alimiter=limit=0.9",
+      "-codec:a", "libmp3lame",
+      "-qscale:a", "2",
+      vocalsPath,
+    ]);
+    instrumentalLogs = await runFfmpeg([
+      "-y",
+      "-i", inputPath,
+      "-filter:a", "pan=stereo|c0=c0-c1|c1=c1-c0,alimiter=limit=0.9",
+      "-codec:a", "libmp3lame",
+      "-qscale:a", "2",
+      instrumentalPath,
+    ]);
+
+    await new Promise((resolve, reject) => {
+      const zipProc = spawn("zip", ["-q", zipFile, vocalsFile, instrumentalFile], { cwd: JOBS_DIR });
+      let zipLogs = "";
+      zipProc.stdout.on("data", (d) => (zipLogs += d.toString()));
+      zipProc.stderr.on("data", (d) => (zipLogs += d.toString()));
+      zipProc.on("error", (err) => {
+        const error = new Error("zip command gagal dijalankan");
+        error.logs = zipLogs;
+        reject(error);
+      });
+      zipProc.on("close", (code) => {
+        if (code === 0) resolve();
+        else {
+          const error = new Error(`zip keluar dengan kode ${code}`);
+          error.logs = zipLogs;
+          reject(error);
+        }
+      });
+    });
+  } catch (err) {
+    try { await fsp.unlink(vocalsPath); } catch {}
+    try { await fsp.unlink(instrumentalPath); } catch {}
+    try { await fsp.unlink(zipPath); } catch {}
+    throw err;
+  }
+
+  const response = {
+    ok: true,
+    id: stemId,
+    baseName: safeBase,
+    vocals: {
+      downloadUrl: `/public/jobs/${vocalsFile}`,
+      fileName: `${safeBase} - Vocals.mp3`,
+      logs: vocalsLogs.slice(-6000),
+    },
+    instrumental: {
+      downloadUrl: `/public/jobs/${instrumentalFile}`,
+      fileName: `${safeBase} - Instrumental.mp3`,
+      logs: instrumentalLogs.slice(-6000),
+    },
+    zip: {
+      downloadUrl: `/public/jobs/${zipFile}`,
+      fileName: `${safeBase} - STEMS.zip`,
+    },
+  };
+  return response;
+};
+
+const generateThumbnailArt = async ({
+  imageUrl,
+  title,
+  subtitle,
+  accent = "#0d6efd",
+  style = "modern",
+}) => {
+  if (!imageUrl || !/^https?:\/\//i.test(imageUrl)) {
+    throw new Error("URL gambar tidak valid");
+  }
+  if (!DEFAULT_FONT) {
+    throw new Error("Font default tidak ditemukan untuk drawtext");
+  }
+
+  const response = await fetch(imageUrl);
+  if (!response.ok) {
+    throw new Error(`Gagal mengambil gambar (${response.status})`);
+  }
+  const buffer = Buffer.from(await response.arrayBuffer());
+  const thumbId = nanoid(10);
+  const inputPath = join(THUMB_DIR, `${thumbId}.src`);
+  const outputName = `${thumbId}.jpg`;
+  const outputPath = join(THUMB_DIR, outputName);
+
+  await fsp.writeFile(inputPath, buffer);
+
+  const accentHex = normalizeHex(accent);
+  const baseFilter = [
+    "scale=1280:720:force_original_aspect_ratio=decrease",
+    `pad=1280:720:(ow-iw)/2:(oh-ih)/2:${hexToFfmpegColor("#10121a")}`,
+    "format=rgba",
+  ];
+
+  if (style === "vibrant") {
+    baseFilter.push("eq=saturation=1.35:contrast=1.05");
+  } else if (style === "mono") {
+    baseFilter.push("hue=s=0");
+  }
+
+  baseFilter.push(`drawbox=x=0:y=h-220:w=iw:h=220:color=${accentHex}@0.75:t=fill`);
+
+  const titleText = escapeDrawText(title || "AI Generated Cover");
+  baseFilter.push(
+    `drawtext=fontfile='${DEFAULT_FONT}':text='${titleText}':fontsize=58:fontcolor=white:shadowx=2:shadowy=2:x=(w-text_w)/2:y=h-150`
+  );
+
+  if (subtitle && subtitle.trim()) {
+    const subText = escapeDrawText(subtitle.trim());
+    baseFilter.push(
+      `drawtext=fontfile='${DEFAULT_FONT}':text='${subText}':fontsize=34:fontcolor=white@0.9:shadowx=1:shadowy=1:x=(w-text_w)/2:y=h-80`
+    );
+  }
+
+  const filter = baseFilter.join(",");
+
+  try {
+    await runFfmpeg([
+      "-y",
+      "-i", inputPath,
+      "-vf", filter,
+      "-q:v", "2",
+      outputPath,
+    ]);
+  } finally {
+    try { await fsp.unlink(inputPath); } catch {}
+  }
+
+  return {
+    ok: true,
+    url: `/public/thumbnails/${outputName}`,
+    fileName: `${sanitizeFileName(title || "cover") || "cover"}.jpg`,
+  };
+};
+
+const validateConvertPayload = (payload = {}) => {
+  if (!payload || typeof payload !== "object") {
+    throw new Error("Payload tidak valid");
+  }
+  const url = typeof payload.url === "string" ? payload.url.trim() : "";
+  if (!/^https?:\/\//i.test(url)) {
+    throw new Error("URL tidak valid");
+  }
+  const format = String(payload.format || "mp3").toLowerCase();
+  if (!SUPPORTED_FORMATS.has(format)) {
+    throw new Error("Format tidak didukung");
+  }
+  const speedMode = payload.speedMode || "normal";
+  if (!VALID_SPEED_MODES.has(speedMode)) {
+    throw new Error("Mode kecepatan tidak dikenali");
+  }
+  if (payload.sampleRate !== undefined) {
+    const sr = Number(payload.sampleRate);
+    if (!Number.isFinite(sr) || sr <= 0) {
+      throw new Error("sampleRate tidak valid");
+    }
+  }
+  if (payload.trim && typeof payload.trim === "object") {
+    const { start, end } = payload.trim;
+    if (start !== undefined) {
+      const s = Number(start);
+      if (!Number.isFinite(s) || s < 0) throw new Error("trim.start tidak valid");
+    }
+    if (end !== undefined) {
+      const e = Number(end);
+      if (!Number.isFinite(e) || e < 0) throw new Error("trim.end tidak valid");
+    }
+    if (start !== undefined && end !== undefined) {
+      if (Number(end) < Number(start)) throw new Error("trim.end harus >= trim.start");
+    }
+  }
+  if (payload.volumeBoost !== undefined) {
+    const boost = Number(payload.volumeBoost);
+    if (!Number.isFinite(boost) || boost < -24 || boost > 24) {
+      throw new Error("volumeBoost di luar batas");
+    }
+  }
+  return {
+    ...payload,
+    url,
+    format,
+    speedMode,
+  };
+};
+
+const enqueueBackgroundJob = (payload = {}) => {
+  const normalized = validateConvertPayload(payload);
+  const id = nanoid(12);
+  const job = {
+    id,
+    status: "queued",
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    payload: normalized,
+    logs: "",
+  };
+  backgroundJobs.set(id, job);
+  backgroundQueue.push(id);
+  job.queuePosition = backgroundQueue.length;
+  processBackgroundQueue().catch(() => {});
+  return job;
+};
+
+const processBackgroundQueue = async () => {
+  if (backgroundProcessing) return;
+  backgroundProcessing = true;
+  while (backgroundQueue.length) {
+    const jobId = backgroundQueue.shift();
+    const job = backgroundJobs.get(jobId);
+    if (!job) continue;
+    job.queuePosition = 0;
+    job.status = "processing";
+    job.startedAt = Date.now();
+    job.updatedAt = Date.now();
+    try {
+      const result = await convertSingle({ ...job.payload, noPlaylist: true });
+      job.status = "done";
+      job.completedAt = Date.now();
+      job.result = {
+        downloadUrl: result.downloadUrl,
+        fileName: result.fileName,
+        format: result.format,
+        baseName: result.baseName,
+        ext: result.ext,
+      };
+      if (result.fullPath) job.result.fullPath = result.fullPath;
+      job.logs = (result.logs || "").slice(-8000);
+    } catch (err) {
+      job.status = "error";
+      job.completedAt = Date.now();
+      job.error = err.message || "Gagal memproses";
+      job.logs = (err.logs || "").slice(-8000);
+    }
+    job.updatedAt = Date.now();
+  }
+  backgroundProcessing = false;
+};
+
+const serializeJob = (job) => {
+  if (!job) return null;
+  const data = {
+    id: job.id,
+    status: job.status,
+    createdAt: job.createdAt,
+    updatedAt: job.updatedAt,
+    startedAt: job.startedAt,
+    completedAt: job.completedAt,
+    queuePosition: job.queuePosition,
+  };
+  if (job.error) data.error = job.error;
+  if (job.logs) data.logs = job.logs;
+  if (job.result) {
+    data.result = {
+      downloadUrl: job.result.downloadUrl,
+      fileName: job.result.fileName,
+      format: job.result.format,
+      baseName: job.result.baseName,
+      ext: job.result.ext,
+    };
+  }
+  return data;
+};
+
+const resolveJobFilePath = (job) => {
+  if (!job) return null;
+  if (job.result?.fullPath) return job.result.fullPath;
+  if (job.result?.downloadUrl) return resolvePublicPath(job.result.downloadUrl);
+  return null;
+};
+
 const SUPPORTED_FORMATS = new Set(["mp3", "m4a", "flac", "wav", "ogg"]);
 const VALID_SPEED_MODES = new Set(["normal", "nightcore", "slow_reverb"]);
 
-const buildAudioFilters = ({ normalize = false, speedMode = "normal" } = {}) => {
+const buildAudioFilters = ({
+  normalize = false,
+  speedMode = "normal",
+  denoise = false,
+  volumeBoost = 0,
+  enhancer = "none",
+} = {}) => {
   const filters = [];
   if (speedMode && speedMode !== "normal") {
     if (speedMode === "nightcore") {
       filters.push("asetrate=sample_rate*1.25", "aresample=sample_rate");
     } else if (speedMode === "slow_reverb") {
       filters.push("atempo=0.85", "aecho=0.6:0.6:1000:0.25");
+    }
+  }
+  if (denoise) filters.push("afftdn");
+  const boost = Number(volumeBoost);
+  if (!Number.isNaN(boost) && boost !== 0) {
+    filters.push(`volume=${clamp(boost, -20, 20)}dB`);
+  }
+  if (enhancer && typeof enhancer === "string" && enhancer !== "none") {
+    if (enhancer === "clarity") {
+      filters.push("acompressor=threshold=-18dB:ratio=2:attack=5:release=50", "equalizer=f=3200:t=h:w=2:g=3");
+    } else if (enhancer === "warm") {
+      filters.push("equalizer=f=160:t=h:w=2:g=4", "equalizer=f=6400:t=h:w=2:g=-3");
+    } else if (enhancer === "club") {
+      filters.push("acompressor=threshold=-16dB:ratio=3:attack=8:release=80", "equalizer=f=90:t=h:w=2:g=5", "equalizer=f=8500:t=h:w=2:g=2");
     }
   }
   if (normalize) filters.push("loudnorm");
@@ -68,6 +511,26 @@ const applyAudioFilters = (args, filters = []) => {
     args.push("-filter:a", filters.join(","));
   }
 };
+
+const runFfmpeg = (args) => new Promise((resolve, reject) => {
+  const ff = spawn(ffmpegPath || "ffmpeg", args, { stdio: ["ignore", "pipe", "pipe"] });
+  let logs = "";
+  ff.stdout.on("data", (d) => (logs += d.toString()));
+  ff.stderr.on("data", (d) => (logs += d.toString()));
+  ff.on("error", (err) => {
+    const error = new Error(err.code === "ENOENT" ? "ffmpeg tidak ditemukan" : err.message || "ffmpeg gagal");
+    error.logs = logs;
+    reject(error);
+  });
+  ff.on("close", (code) => {
+    if (code === 0) resolve(logs);
+    else {
+      const error = new Error(`ffmpeg exit ${code}`);
+      error.logs = logs;
+      reject(error);
+    }
+  });
+});
 
 const vttToSrt = (input = "") => {
   const clean = (input || "").replace(/^WEBVTT.*\n+/i, "").replace(/\r/g, "");
@@ -430,6 +893,9 @@ const convertSingle = async (payload = {}) => {
     coverUrl,
     atmos = false,
     speedMode = "normal",
+    denoise = false,
+    volumeBoost = 0,
+    enhancer = "none",
   } = payload;
 
   if (!url || !/^https?:\/\//.test(url)) {
@@ -442,6 +908,18 @@ const convertSingle = async (payload = {}) => {
   if (!VALID_SPEED_MODES.has(speedMode || "normal")) {
     throw new Error("Mode kecepatan tidak dikenali");
   }
+
+  const denoiseEnabled = typeof denoise === "string"
+    ? ["1", "true", "yes", "on"].includes(denoise.toLowerCase())
+    : !!denoise;
+
+  let boostValue = Number(volumeBoost);
+  if (Number.isNaN(boostValue)) boostValue = 0;
+  boostValue = clamp(boostValue, -20, 20);
+
+  const enhancerKey = typeof enhancer === "string" ? enhancer.trim().toLowerCase() : "none";
+  const VALID_ENHANCERS = new Set(["none", "clarity", "warm", "club"]);
+  const enhancerMode = VALID_ENHANCERS.has(enhancerKey) ? enhancerKey : "none";
 
   let sr;
   if (sampleRate !== undefined) {
@@ -483,7 +961,13 @@ const convertSingle = async (payload = {}) => {
     } catch {}
   }
 
-  const filters = buildAudioFilters({ normalize, speedMode });
+  const filters = buildAudioFilters({
+    normalize,
+    speedMode,
+    denoise: denoiseEnabled,
+    volumeBoost: boostValue,
+    enhancer: enhancerMode,
+  });
 
   const args = ["--newline", "--no-progress"];
   if (ffmpegPath) {
@@ -743,6 +1227,147 @@ app.post("/api/convert", async (req, res) => {
   } catch (e) {
     const msg = e?.message || "Gagal memproses";
     const status = /tidak valid|tidak dikenali/i.test(msg) ? 400 : 500;
+    return res.status(status).json({ error: msg, logs: e?.logs });
+  }
+});
+
+app.post("/api/background", (req, res) => {
+  try {
+    const job = enqueueBackgroundJob(req.body || {});
+    return res.json({ ok: true, job: serializeJob(job) });
+  } catch (e) {
+    const msg = e?.message || "Gagal membuat job";
+    const status = /tidak valid|tidak dikenali|batas/i.test(msg) ? 400 : 500;
+    return res.status(status).json({ error: msg });
+  }
+});
+
+app.get("/api/background", (req, res) => {
+  const jobs = Array.from(backgroundJobs.values())
+    .sort((a, b) => (b.createdAt || 0) - (a.createdAt || 0))
+    .slice(0, 25)
+    .map(serializeJob);
+  return res.json({ ok: true, jobs });
+});
+
+app.get("/api/background/:id", (req, res) => {
+  const job = backgroundJobs.get(req.params.id);
+  if (!job) return res.status(404).json({ error: "Job tidak ditemukan" });
+  return res.json({ ok: true, job: serializeJob(job) });
+});
+
+app.post("/api/ai-tags", (req, res) => {
+  try {
+    const body = req.body || {};
+    const tags = buildAiTags({
+      title: body.title,
+      description: body.description,
+      channel: body.channel,
+      duration: body.duration,
+    });
+    return res.json({ ok: true, tags });
+  } catch (e) {
+    const msg = e?.message || "Gagal membuat tag";
+    return res.status(400).json({ error: msg });
+  }
+});
+
+app.post("/api/thumbnail", async (req, res) => {
+  try {
+    const result = await generateThumbnailArt(req.body || {});
+    return res.json(result);
+  } catch (e) {
+    const msg = e?.message || "Gagal membuat thumbnail";
+    const status = /tidak valid|tidak ditemukan/i.test(msg) ? 400 : 500;
+    return res.status(status).json({ error: msg, logs: e?.logs });
+  }
+});
+
+app.post("/api/stems", async (req, res) => {
+  try {
+    const body = req.body || {};
+    let sourcePath = null;
+    let baseName = body.baseName;
+    if (body.downloadUrl) {
+      sourcePath = resolvePublicPath(body.downloadUrl);
+      if (!sourcePath) throw new Error("downloadUrl tidak valid");
+      baseName = baseName || basename(sourcePath).replace(/\.[^.]+$/, "");
+    } else if (body.jobId) {
+      const job = backgroundJobs.get(body.jobId);
+      if (!job || job.status !== "done") throw new Error("Job belum selesai");
+      sourcePath = resolveJobFilePath(job);
+      if (!sourcePath) throw new Error("File job tidak ditemukan");
+      baseName = baseName || job.result?.baseName || job.result?.fileName;
+    } else if (body.url) {
+      const convertPayload = { ...body };
+      delete convertPayload.jobId;
+      delete convertPayload.downloadUrl;
+      delete convertPayload.baseName;
+      const convertResult = await convertSingle({ ...convertPayload, format: body.format || "wav", noPlaylist: true });
+      sourcePath = convertResult.fullPath;
+      baseName = baseName || convertResult.baseName || convertResult.fileName;
+    } else {
+      return res.status(400).json({ error: "Perlu url, jobId, atau downloadUrl" });
+    }
+    if (!sourcePath) throw new Error("Sumber audio tidak ditemukan");
+    const result = await createStemsForSource(sourcePath, baseName);
+    if (!result.source && sourcePath.startsWith(JOBS_DIR)) {
+      const diskName = basename(sourcePath);
+      result.source = {
+        downloadUrl: `/public/jobs/${diskName}`,
+        fileName: `${sanitizeFileName(baseName || "Audio") || "Audio"}.${diskName.split(".").pop()}`,
+      };
+    }
+    return res.json(result);
+  } catch (e) {
+    const msg = e?.message || "Gagal membuat stems";
+    const status = /tidak valid|belum|perlu|tidak ditemukan/i.test(msg) ? 400 : 500;
+    return res.status(status).json({ error: msg, logs: e?.logs });
+  }
+});
+
+app.post("/api/cloud/save", async (req, res) => {
+  try {
+    const body = req.body || {};
+    const targetKey = typeof body.target === "string" ? body.target.toLowerCase() : "drive";
+    const target = CLOUD_TARGETS[targetKey];
+    if (!target) return res.status(400).json({ error: "Target cloud tidak dikenali" });
+
+    let sourcePath = null;
+    let fileName = typeof body.fileName === "string" && body.fileName.trim()
+      ? sanitizeFileName(body.fileName.trim())
+      : null;
+
+    if (body.jobId) {
+      const job = backgroundJobs.get(body.jobId);
+      if (!job || job.status !== "done") throw new Error("Job belum selesai");
+      sourcePath = resolveJobFilePath(job);
+      if (!sourcePath) throw new Error("File job tidak ditemukan");
+      if (!fileName) fileName = job.result?.fileName || job.result?.baseName;
+    } else if (body.downloadUrl) {
+      sourcePath = resolvePublicPath(body.downloadUrl);
+      if (!sourcePath) throw new Error("downloadUrl tidak valid");
+      if (!fileName) fileName = basename(sourcePath);
+    } else {
+      return res.status(400).json({ error: "Perlu jobId atau downloadUrl" });
+    }
+
+    if (!sourcePath) throw new Error("Sumber file tidak ditemukan");
+
+    const finalName = ensureUniqueFileName(target.dir, sanitizeFileName(fileName) || basename(sourcePath));
+    const destPath = join(target.dir, finalName);
+    await fsp.copyFile(sourcePath, destPath);
+
+    return res.json({
+      ok: true,
+      target: targetKey,
+      label: target.label,
+      downloadUrl: `/public/cloud/${targetKey}/${finalName}`,
+      fileName: finalName,
+    });
+  } catch (e) {
+    const msg = e?.message || "Gagal menyimpan ke cloud";
+    const status = /tidak valid|perlu|belum|tidak ditemukan/i.test(msg) ? 400 : 500;
     return res.status(status).json({ error: msg, logs: e?.logs });
   }
 });

--- a/index.js
+++ b/index.js
@@ -350,6 +350,173 @@ const buildAiPitch = ({
   };
 };
 
+const pickAudiophileProfile = (tags = {}) => {
+  const genre = (tags.genre || "").toLowerCase();
+  const mood = (tags.mood || "").toLowerCase();
+
+  if (/(hip[- ]?hop|trap|edm|house|dance|dubstep|electro|bass|club)/.test(genre) || /(energetic|hype|club)/.test(mood)) {
+    return {
+      focus: "Bass Impact & Groove",
+      summary: "{{TRACK}}: Fokus pada sub-bass rapat tanpa mengorbankan vokal utama.",
+      eq: [
+        "Low-shelf +3 dB di ~60 Hz (Q ≈ 1.0) untuk dorongan sub-bass.",
+        "Potong -1.5 dB di 250 Hz (Q ≈ 1.2) agar low-mid tidak muddy.",
+        "High-shelf +1 dB mulai 9 kHz supaya hi-hat tetap berkilau.",
+      ],
+      playback: [
+        "Gunakan headphone closed-back dengan seal rapat atau speaker + sub aktif.",
+        "Jaga level master sekitar -6 dBFS sebelum limiter agar transien kick tetap utuh.",
+      ],
+      enhancements: [
+        "Periksa fase L/R di bawah 80 Hz agar bass tetap terpusat.",
+      ],
+    };
+  }
+
+  if (/(jazz|acoustic|folk|classical|ambient|lo[- ]?fi|lofi|blues|soul|ballad|r\u0026b|r&b)/.test(genre) || /(calm|chill|midnight|melancholy)/.test(mood)) {
+    return {
+      focus: "Detail & Stage Depth",
+      summary: "{{TRACK}}: Prioritaskan midrange alami dan ruang ambience yang luas.",
+      eq: [
+        "High-pass lembut di 28 Hz (Q ≈ 0.7) untuk membersihkan rumble.",
+        "Angkat +2 dB di 3 kHz (Q ≈ 1.1) demi artikulasi vokal/instrumen utama.",
+        "Air boost +1.5 dB di 12 kHz dengan shelf lebar untuk nuansa udara.",
+      ],
+      playback: [
+        "Monitor memakai headphone open-back atau nearfield dengan tweeter halus untuk imaging akurat.",
+        "Posisikan diri membentuk segitiga sama sisi dengan speaker untuk kedalaman panggung terbaik.",
+      ],
+      enhancements: [
+        "Tambahkan reverb kamar <1.2s seperlunya agar kedalaman bertambah tanpa menutup detail.",
+      ],
+    };
+  }
+
+  if (/(rock|metal|punk|indie|alternative)/.test(genre) || /(epic)/.test(mood)) {
+    return {
+      focus: "Midrange Punch & Presence",
+      summary: "{{TRACK}}: Jaga serangan gitar dan vokal tanpa menusuk telinga.",
+      eq: [
+        "Cut -2 dB di 3.5 kHz (Q ≈ 2) bila gitar terlalu tajam.",
+        "Boost +2 dB di 120 Hz (Q ≈ 1.0) untuk menambah bobot kick & bass.",
+        "Shelf +1 dB di 8 kHz supaya cymbal tetap hidup.",
+      ],
+      playback: [
+        "Gunakan monitor dengan respon cepat atau headphone semi-open untuk mengecek distorsi.",
+        "Periksa kompatibilitas mono agar gitar ganda tidak saling membatalkan.",
+      ],
+      enhancements: [
+        "Kompresi bus 2–3 dB cukup untuk menjaga energi tanpa meratakan dinamika.",
+      ],
+    };
+  }
+
+  return {
+    focus: "Balanced Clarity",
+    summary: "{{TRACK}}: Pertahankan keseimbangan frekuensi yang nyaman di berbagai perangkat.",
+    eq: [
+      "High-pass 25 Hz untuk membuang subsonik yang tidak terdengar.",
+      "Tambahkan +1.5 dB di 2.5 kHz (Q ≈ 1.0) guna meningkatkan intelligibility.",
+      "High-shelf lembut +1 dB di 10 kHz agar udara tetap hadir.",
+    ],
+    playback: [
+      "Cross-check di speaker kecil atau earbuds supaya mid tetap jelas.",
+      "Kalibrasi level monitoring sekitar 79 dB SPL agar telinga tidak cepat lelah.",
+    ],
+    enhancements: [
+      "Aktifkan dither saat downsample untuk menjaga detail halus.",
+    ],
+  };
+};
+
+const buildAiAudiophileGuide = ({
+  title = "",
+  channel = "",
+  duration,
+  genre,
+  mood,
+  format = "",
+  sampleRate,
+  speedMode = "normal",
+  enhancer = "none",
+  denoise = false,
+  volumeBoost = 0,
+  normalize = false,
+} = {}) => {
+  const tags = buildAiTags({ title, channel, duration });
+  if (genre && typeof genre === "string" && genre.trim()) tags.genre = genre.trim();
+  if (mood && typeof mood === "string" && mood.trim()) tags.mood = mood.trim();
+
+  const profile = pickAudiophileProfile(tags);
+  const eq = [...(profile.eq || [])];
+  const playback = [...(profile.playback || [])];
+  const enhancements = [...(profile.enhancements || [])];
+
+  const trackTitle = tags.title || title || "Track";
+  const artist = tags.artist || channel || "Artist";
+  const summary = (profile.summary || "{{TRACK}}").replace(/\{\{TRACK\}\}/g, `${trackTitle} — ${artist}`);
+
+  const fmt = (format || "").toLowerCase();
+  const sr = Number(sampleRate);
+  let sampleAdvice;
+  if (fmt === "flac" || fmt === "wav") {
+    if (Number.isFinite(sr) && sr >= 96000) {
+      sampleAdvice = "Pertahankan 96 kHz lossless untuk headroom mixing dan arsip.";
+    } else {
+      sampleAdvice = "Render lossless minimal 48 kHz; gunakan 96 kHz bila sumber dan perangkat mendukung.";
+    }
+  } else if (fmt === "m4a") {
+    sampleAdvice = "Gunakan 44.1 kHz AAC agar encoder paling efisien dan kompatibel.";
+  } else if (fmt === "mp3") {
+    sampleAdvice = "Kunci di 48 kHz maksimum — MP3 tidak stabil di atas 48 kHz.";
+  } else if (Number.isFinite(sr) && sr > 0) {
+    sampleAdvice = `Jaga ${Math.round(sr)} Hz dan aktifkan dither saat downsample supaya detail terpelihara.`;
+  } else {
+    sampleAdvice = "Pertahankan minimal 48 kHz agar detail high-end tidak hilang di berbagai player.";
+  }
+
+  const durationLabel = formatDurationLabel(duration);
+  if (durationLabel) {
+    playback.push(`Durasi konten ${durationLabel} — cek konsistensi gain sepanjang track.`);
+  }
+  if (tags.mood) playback.push(`Mood terdeteksi: ${tags.mood}. Sesuaikan ambience ruangan agar nuansanya tersampaikan.`);
+  if (tags.energy) playback.push(`Level energi: ${tags.energy}. Atur volume playback supaya tidak melelahkan telinga.`);
+
+  if (speedMode === "nightcore") {
+    eq.push("Tambahkan low-shelf +1 dB di 120 Hz untuk mengisi tubuh setelah pitch-up nightcore.");
+    enhancements.push("Gunakan low-pass halus di 17 kHz bila terdengar aliasing akibat percepatan.");
+  } else if (speedMode === "slow_reverb") {
+    eq.push("High-shelf +1.5 dB di 10 kHz menjaga kilau setelah slowed + reverb.");
+    enhancements.push("High-pass 30 Hz pasca reverb untuk mencegah build-up frekuensi rendah.");
+  }
+
+  const boostVal = Number(volumeBoost);
+  if (Number.isFinite(boostVal) && boostVal > 0) {
+    enhancements.push(`Boost +${boostVal} dB telah diterapkan — sisakan headroom minimal 1 dBTP agar tidak clip.`);
+  }
+  if (normalize) enhancements.push("Normalisasi aktif — targetkan -14 LUFS untuk streaming atau -9 LUFS untuk club set.");
+  if (denoise) enhancements.push("Denoise aktif — setel threshold ringan agar high-hat tidak ikut hilang.");
+
+  if (enhancer && enhancer !== "none") {
+    const enhancerNotes = {
+      clarity: "Mode Clarity menonjolkan vokal & hi-hat — cocok untuk fokus detail.",
+      warm: "Mode Warm menambah harmonik mid, ideal untuk rekaman analog atau vokal mellow.",
+      club: "Mode Club menaikkan low-mid; awasi limiter agar punch tidak pecah.",
+    };
+    enhancements.push(enhancerNotes[enhancer] || `Gunakan enhancer ${enhancer} seperlunya.`);
+  }
+
+  return {
+    focus: profile.focus,
+    summary,
+    sampleRate: sampleAdvice,
+    eq,
+    playback,
+    enhancements,
+    tags,
+  };
+};
+
 const validateConvertPayload = (payload = {}) => {
   if (!payload || typeof payload !== "object") {
     throw new Error("Payload tidak valid");
@@ -1719,6 +1886,18 @@ const downloadSubtitle = async (payload = {}) => {
     await fsp.writeFile(srtPath, result.srt, "utf8");
 
     const plain = srtToPlainText(result.srt);
+    const lines = plain
+      ? plain
+          .split(/\n+/)
+          .map((line) => line.trim())
+          .filter(Boolean)
+      : [];
+    const words = plain
+      ? plain
+          .trim()
+          .split(/\s+/)
+          .filter(Boolean)
+      : [];
     const preview = buildSubtitlePreview(plain);
     finalTxtName = `${finalStem}.txt`;
     const txtPath = join(JOBS_DIR, finalTxtName);
@@ -1734,6 +1913,9 @@ const downloadSubtitle = async (payload = {}) => {
       txtUrl: `/public/jobs/${finalTxtName}`,
       txtFileName: `${downloadBase}.${safeLang}.txt`,
       preview,
+      text: plain,
+      lineCount: lines.length,
+      wordCount: words.length,
     };
   } catch (err) {
     if (finalSrtName) {
@@ -1846,6 +2028,30 @@ app.post("/api/ai-pitch", (req, res) => {
     });
   } catch (e) {
     const msg = e?.message || "Gagal membuat pitch";
+    return res.status(400).json({ error: msg });
+  }
+});
+
+app.post("/api/ai-audiophile", (req, res) => {
+  try {
+    const body = req.body || {};
+    const result = buildAiAudiophileGuide({
+      title: body.title,
+      channel: body.channel,
+      duration: body.duration,
+      genre: body.genre,
+      mood: body.mood,
+      format: body.format,
+      sampleRate: body.sampleRate,
+      speedMode: body.speedMode,
+      enhancer: body.enhancer,
+      denoise: body.denoise,
+      volumeBoost: body.volumeBoost,
+      normalize: body.normalize,
+    });
+    return res.json({ ok: true, guide: result });
+  } catch (e) {
+    const msg = e?.message || "Gagal membuat panduan audiophile";
     return res.status(400).json({ error: msg });
   }
 });

--- a/index.js
+++ b/index.js
@@ -1054,9 +1054,68 @@ const fetchSubtitleViaYtDlp = async ({ url, langOpt, preferAuto }) => {
   return {
     srt,
     safeLang,
+    lang: track.lang || safeLang,
     auto: Boolean(track.auto),
     logs: [...logs, stderr].filter(Boolean).join("\n").slice(-8000),
   };
+};
+
+const fetchSubtitleViaPyTube = async ({ url, langOpt, preferAuto }) => {
+  const args = [
+    join(__dirname, "download_subtitle.py"),
+    url,
+    langOpt || "",
+    preferAuto ? "1" : "0",
+  ];
+  let stdout = "";
+  let stderr = "";
+  const logs = [`python3 ${args.map((arg) => (arg.includes(" ") ? `"${arg}"` : arg)).join(" ")}`];
+  try {
+    await new Promise((resolve, reject) => {
+      const proc = spawn("python3", args, { stdio: ["ignore", "pipe", "pipe"] });
+      proc.stdout.on("data", (d) => {
+        stdout += d.toString();
+      });
+      proc.stderr.on("data", (d) => {
+        stderr += d.toString();
+      });
+      proc.on("error", (err) => {
+        const error = new Error("PyTube tidak bisa dijalankan");
+        error.cause = err;
+        reject(error);
+      });
+      proc.on("close", (code) => {
+        if (code !== 0) {
+          const error = new Error("PyTube gagal mengambil subtitle");
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
+    });
+  } catch (err) {
+    const error = new Error(err.message || "PyTube gagal mengambil subtitle");
+    error.logs = [...logs, stderr].filter(Boolean).join("\n");
+    throw error;
+  }
+
+  try {
+    const parsed = JSON.parse(stdout || "{}");
+    if (!parsed.srt) {
+      throw new Error("Subtitle kosong");
+    }
+    return {
+      srt: parsed.srt,
+      lang: parsed.lang,
+      safeLang: sanitizeLangKey(parsed.lang, parsed.auto),
+      auto: Boolean(parsed.auto),
+      logs: [...logs, stderr].filter(Boolean).join("\n").slice(-8000),
+    };
+  } catch (err) {
+    const error = new Error(err.message || "PyTube menghasilkan data tidak valid");
+    error.logs = [...logs, stderr, stdout].filter(Boolean).join("\n");
+    throw error;
+  }
 };
 
 const srtToPlainText = (input = "") => {
@@ -1634,10 +1693,27 @@ const downloadSubtitle = async (payload = {}) => {
   let logs = "";
   let finalSrtName = "";
   let finalTxtName = "";
+  let fetchError = null;
+  let result;
   try {
-    const result = await fetchSubtitleViaYtDlp({ url, langOpt, preferAuto });
+    result = await fetchSubtitleViaYtDlp({ url, langOpt, preferAuto });
     logs = result.logs || "";
-    const finalStem = `${id}.${result.safeLang}`;
+  } catch (err) {
+    fetchError = err;
+    logs = err.logs || "";
+    try {
+      result = await fetchSubtitleViaPyTube({ url, langOpt, preferAuto });
+      logs = [logs, result.logs || ""].filter(Boolean).join("\n").slice(-8000);
+    } catch (pyErr) {
+      const error = new Error(pyErr.message || err.message || "Gagal mengambil subtitle");
+      error.logs = [logs, pyErr.logs || ""].filter(Boolean).join("\n").slice(-8000);
+      throw error;
+    }
+  }
+
+  try {
+    const safeLang = result.safeLang || sanitizeLangKey(result.lang, result.auto);
+    const finalStem = `${id}.${safeLang}`;
     finalSrtName = `${finalStem}.srt`;
     const srtPath = join(JOBS_DIR, finalSrtName);
     await fsp.writeFile(srtPath, result.srt, "utf8");
@@ -1651,12 +1727,12 @@ const downloadSubtitle = async (payload = {}) => {
     return {
       ok: true,
       logs,
-      lang: result.safeLang,
+      lang: safeLang,
       auto: Boolean(result.auto),
       srtUrl: `/public/jobs/${finalSrtName}`,
-      srtFileName: `${downloadBase}.${result.safeLang}.srt`,
+      srtFileName: `${downloadBase}.${safeLang}.srt`,
       txtUrl: `/public/jobs/${finalTxtName}`,
-      txtFileName: `${downloadBase}.${result.safeLang}.txt`,
+      txtFileName: `${downloadBase}.${safeLang}.txt`,
       preview,
     };
   } catch (err) {
@@ -1666,8 +1742,9 @@ const downloadSubtitle = async (payload = {}) => {
     if (finalTxtName) {
       try { await fsp.unlink(join(JOBS_DIR, finalTxtName)); } catch {}
     }
-    const error = new Error(err.message || "Gagal mengambil subtitle");
-    error.logs = (logs + (err.logs || "")).slice(-8000);
+    const message = err.message || fetchError?.message || "Gagal mengambil subtitle";
+    const error = new Error(message);
+    error.logs = [logs, err.logs || ""].filter(Boolean).join("\n").slice(-8000);
     throw error;
   }
 };

--- a/index.js
+++ b/index.js
@@ -47,8 +47,30 @@ const sanitizeFileName = (name = "") =>
     .replace(/\s+/g, " ")
     .trim();
 
+const SUPPORTED_FORMATS = new Set(["mp3", "m4a", "flac", "wav", "ogg"]);
+const VALID_SPEED_MODES = new Set(["normal", "nightcore", "slow_reverb"]);
+
+const buildAudioFilters = ({ normalize = false, speedMode = "normal" } = {}) => {
+  const filters = [];
+  if (speedMode && speedMode !== "normal") {
+    if (speedMode === "nightcore") {
+      filters.push("asetrate=sample_rate*1.25", "aresample=sample_rate");
+    } else if (speedMode === "slow_reverb") {
+      filters.push("atempo=0.85", "aecho=0.6:0.6:1000:0.25");
+    }
+  }
+  if (normalize) filters.push("loudnorm");
+  return filters;
+};
+
+const applyAudioFilters = (args, filters = []) => {
+  if (filters && filters.length) {
+    args.push("-filter:a", filters.join(","));
+  }
+};
+
 const ffmpegToMp3 = (input, output, opts = {}) => {
-  const { abr = 192, id3 = {}, trim = {}, normalize = false, sampleRate, cover } = opts;
+  const { abr = 192, id3 = {}, trim = {}, sampleRate, cover, filters = [] } = opts;
   return new Promise((resolve, reject) => {
     const args = ["-y"];
     const { start, end } = trim || {};
@@ -61,7 +83,7 @@ const ffmpegToMp3 = (input, output, opts = {}) => {
       if (hasStart) args.push("-t", String(end - start));
       else args.push("-to", String(end));
     }
-    if (normalize) args.push("-af", "loudnorm");
+    applyAudioFilters(args, filters);
     for (const [k, v] of Object.entries(id3 || {})) {
       if (v !== undefined && v !== null && String(v).trim() !== "") {
         args.push("-metadata", `${k}=${v}`);
@@ -97,7 +119,7 @@ const ffmpegToMp3 = (input, output, opts = {}) => {
 };
 
 const ffmpegToFlac = (input, output, opts = {}) => {
-  const { id3 = {}, trim = {}, normalize = false, sampleRate, cover } = opts;
+  const { id3 = {}, trim = {}, sampleRate, cover, filters = [] } = opts;
   return new Promise((resolve, reject) => {
     const args = ["-y"];
     const { start, end } = trim || {};
@@ -110,7 +132,7 @@ const ffmpegToFlac = (input, output, opts = {}) => {
       if (hasStart) args.push("-t", String(end - start));
       else args.push("-to", String(end));
     }
-    if (normalize) args.push("-af", "loudnorm");
+    applyAudioFilters(args, filters);
     for (const [k, v] of Object.entries(id3 || {})) {
       if (v !== undefined && v !== null && String(v).trim() !== "") {
         args.push("-metadata", `${k}=${v}`);
@@ -145,7 +167,7 @@ const ffmpegToFlac = (input, output, opts = {}) => {
 };
 
 const ffmpegToM4a = (input, output, opts = {}) => {
-  const { id3 = {}, trim = {}, normalize = false, sampleRate, cover } = opts;
+  const { id3 = {}, trim = {}, sampleRate, cover, filters = [] } = opts;
   return new Promise((resolve, reject) => {
     const args = ["-y"];
     const { start, end } = trim || {};
@@ -158,7 +180,7 @@ const ffmpegToM4a = (input, output, opts = {}) => {
       if (hasStart) args.push("-t", String(end - start));
       else args.push("-to", String(end));
     }
-    if (normalize) args.push("-af", "loudnorm");
+    applyAudioFilters(args, filters);
     for (const [k, v] of Object.entries(id3 || {})) {
       if (v !== undefined && v !== null && String(v).trim() !== "") {
         args.push("-metadata", `${k}=${v}`);
@@ -192,7 +214,335 @@ const ffmpegToM4a = (input, output, opts = {}) => {
   });
 };
 
+const ffmpegToWav = (input, output, opts = {}) => {
+  const { trim = {}, sampleRate, filters = [] } = opts;
+  return new Promise((resolve, reject) => {
+    const args = ["-y"];
+    const { start, end } = trim || {};
+    const hasStart = typeof start === "number" && !isNaN(start);
+    const hasEnd = typeof end === "number" && !isNaN(end);
+    if (hasStart) args.push("-ss", String(start));
+    args.push("-i", input);
+    if (hasEnd) {
+      if (hasStart) args.push("-t", String(end - start));
+      else args.push("-to", String(end));
+    }
+    if (sampleRate) args.push("-ar", String(sampleRate));
+    applyAudioFilters(args, filters);
+    args.push("-map", "0:a", "-vn", "-codec:a", "pcm_s16le", output);
+    const ff = spawn(ffmpegPath || "ffmpeg", args, { stdio: ["ignore", "pipe", "pipe"] });
+    let logs = "";
+    ff.stdout.on("data", (d) => (logs += d.toString()));
+    ff.stderr.on("data", (d) => (logs += d.toString()));
+    ff.on("error", (err) => {
+      if (err.code === "ENOENT") return reject(new Error("ffmpeg tidak ditemukan"));
+      reject(err);
+    });
+    ff.on("close", (code) => {
+      if (code === 0) resolve(logs);
+      else reject(new Error(logs));
+    });
+  });
+};
+
+const ffmpegToOgg = (input, output, opts = {}) => {
+  const { trim = {}, sampleRate, filters = [] } = opts;
+  return new Promise((resolve, reject) => {
+    const args = ["-y"];
+    const { start, end } = trim || {};
+    const hasStart = typeof start === "number" && !isNaN(start);
+    const hasEnd = typeof end === "number" && !isNaN(end);
+    if (hasStart) args.push("-ss", String(start));
+    args.push("-i", input);
+    if (hasEnd) {
+      if (hasStart) args.push("-t", String(end - start));
+      else args.push("-to", String(end));
+    }
+    if (sampleRate) args.push("-ar", String(sampleRate));
+    applyAudioFilters(args, filters);
+    args.push("-map", "0:a", "-vn", "-codec:a", "libvorbis", "-qscale:a", "5", output);
+    const ff = spawn(ffmpegPath || "ffmpeg", args, { stdio: ["ignore", "pipe", "pipe"] });
+    let logs = "";
+    ff.stdout.on("data", (d) => (logs += d.toString()));
+    ff.stderr.on("data", (d) => (logs += d.toString()));
+    ff.on("error", (err) => {
+      if (err.code === "ENOENT") return reject(new Error("ffmpeg tidak ditemukan"));
+      reject(err);
+    });
+    ff.on("close", (code) => {
+      if (code === 0) resolve(logs);
+      else reject(new Error(logs));
+    });
+  });
+};
+
 const COOKIES_PATH = "/tmp/cookies.txt"; // endpoint admin di bawah akan nulis ke sini
+
+const runYtDlpDownload = ({ args, id }) =>
+  new Promise((resolve, reject) => {
+    const proc = spawn("yt-dlp", args, { stdio: ["ignore", "pipe", "pipe"] });
+    let logs = "";
+    proc.stdout.on("data", (d) => (logs += d.toString()));
+    proc.stderr.on("data", (d) => (logs += d.toString()));
+    proc.on("error", (err) => {
+      const error = new Error("yt-dlp tidak bisa dijalankan");
+      error.cause = err;
+      error.logs = logs;
+      reject(error);
+    });
+    proc.on("close", (code) => {
+      if (code !== 0) {
+        const error = new Error("yt-dlp gagal");
+        error.logs = logs;
+        return reject(error);
+      }
+      const files = readdirSync(JOBS_DIR).filter(
+        (f) => f.startsWith(`${id}.`) && !f.endsWith(".cover.jpg")
+      );
+      if (!files.length) {
+        const error = new Error("Output tidak ditemukan");
+        error.logs = logs;
+        return reject(error);
+      }
+      const filename = files[0];
+      const fullPath = join(JOBS_DIR, filename);
+      const ext = filename.split(".").pop();
+      resolve({ filename, fullPath, ext, logs });
+    });
+  });
+
+const runPyTubeDownload = ({ url, id, baseLogs = "" }) =>
+  new Promise((resolve, reject) => {
+    let pyLogs = "";
+    let pyOut = "";
+    const py = spawn("python3", [
+      join(__dirname, "download_audio.py"),
+      url,
+      JOBS_DIR,
+      id,
+    ], { stdio: ["ignore", "pipe", "pipe"] });
+
+    py.stdout.on("data", (d) => {
+      const s = d.toString();
+      pyLogs += s;
+      pyOut += s;
+    });
+    py.stderr.on("data", (d) => (pyLogs += d.toString()));
+
+    py.on("error", (err) => {
+      const error = new Error("PyTube tidak bisa dijalankan");
+      error.cause = err;
+      error.logs = baseLogs + pyLogs;
+      reject(error);
+    });
+
+    py.on("close", async (code) => {
+      if (code !== 0) {
+        const error = new Error("PyTube gagal");
+        error.logs = baseLogs + pyLogs;
+        return reject(error);
+      }
+      try {
+        const dlPath = pyOut.trim().split("\n").pop().trim();
+        let ext = dlPath.split(".").pop();
+        let filename = `${id}.${ext}`;
+        let fullPath = join(JOBS_DIR, filename);
+        if (dlPath !== fullPath) await fsp.rename(dlPath, fullPath);
+        resolve({ filename, fullPath, ext, logs: baseLogs + pyLogs });
+      } catch (err) {
+        const error = new Error(err.message || "PyTube output tidak valid");
+        error.logs = baseLogs + pyLogs;
+        reject(error);
+      }
+    });
+  });
+
+const convertSingle = async (payload = {}) => {
+  const {
+    url,
+    format = "mp3",
+    abr = 192,
+    sampleRate,
+    fileName,
+    noPlaylist = true,
+    id3 = {},
+    trim,
+    normalize = false,
+    coverUrl,
+    atmos = false,
+    speedMode = "normal",
+  } = payload;
+
+  if (!url || !/^https?:\/\//.test(url)) {
+    throw new Error("URL tidak valid");
+  }
+  const fmt = String(format || "").toLowerCase();
+  if (!SUPPORTED_FORMATS.has(fmt)) {
+    throw new Error("Format tidak didukung");
+  }
+  if (!VALID_SPEED_MODES.has(speedMode || "normal")) {
+    throw new Error("Mode kecepatan tidak dikenali");
+  }
+
+  let sr;
+  if (sampleRate !== undefined) {
+    sr = Number(sampleRate);
+    if (Number.isNaN(sr) || sr <= 0) {
+      throw new Error("sampleRate tidak valid");
+    }
+  }
+
+  let trimOpt = null;
+  if (trim && (trim.start !== undefined || trim.end !== undefined)) {
+    const hasStart = trim.start !== undefined;
+    const hasEnd = trim.end !== undefined;
+    const start = hasStart ? Number(trim.start) : 0;
+    const end = hasEnd ? Number(trim.end) : undefined;
+    if ((hasStart && Number.isNaN(start)) ||
+        (hasEnd && Number.isNaN(end)) ||
+        (hasStart && hasEnd && end < start)) {
+      throw new Error("trim tidak valid");
+    }
+    trimOpt = {};
+    if (hasStart) trimOpt.start = start;
+    if (hasEnd) trimOpt.end = end;
+  }
+
+  const id = nanoid(10);
+  const outTpl = join(JOBS_DIR, `${id}.%(ext)s`);
+  const baseName = sanitizeFileName(fileName || id3.title || id) || id;
+
+  let coverPath = null;
+  if (coverUrl && /^https?:\/\//.test(coverUrl) && ["mp3", "m4a", "flac"].includes(fmt)) {
+    try {
+      const imgResp = await fetch(coverUrl);
+      if (imgResp.ok) {
+        const buf = Buffer.from(await imgResp.arrayBuffer());
+        coverPath = join(JOBS_DIR, `${id}.cover.jpg`);
+        await fsp.writeFile(coverPath, buf);
+      }
+    } catch {}
+  }
+
+  const filters = buildAudioFilters({ normalize, speedMode });
+
+  const args = ["--newline", "--no-progress"];
+  if (ffmpegPath) {
+    args.push("--ffmpeg-location", ffmpegPath);
+  }
+  if (existsSync(COOKIES_PATH)) {
+    args.push("--cookies", COOKIES_PATH);
+  }
+  if (noPlaylist) args.push("--no-playlist");
+  if (atmos) args.push("-f", "bestaudio[channels>2]/bestaudio");
+  args.push("-o", outTpl);
+
+  if (fmt === "m4a") {
+    args.push("-f", "bestaudio[ext=m4a]/bestaudio");
+  } else if (fmt === "flac") {
+    args.push("-x", "--audio-format", "flac");
+  } else if (fmt === "mp3") {
+    args.push("-x", "--audio-format", "mp3", "--audio-quality", abrToQ(abr));
+  } else if (fmt === "wav") {
+    args.push("-x", "--audio-format", "wav");
+  } else if (fmt === "ogg") {
+    args.push("-x", "--audio-format", "ogg");
+  }
+  args.push(url);
+
+  let logs = "";
+  let downloadResult;
+
+  try {
+    downloadResult = await runYtDlpDownload({ args, id });
+    logs = downloadResult.logs || "";
+  } catch (err) {
+    const baseLogs = err.logs || "";
+    try {
+      downloadResult = await runPyTubeDownload({ url, id, baseLogs });
+      logs = downloadResult.logs || baseLogs;
+    } catch (pyErr) {
+      if (coverPath) try { await fsp.unlink(coverPath); } catch {}
+      const finalError = new Error(pyErr.message || err.message || "Gagal mengunduh");
+      finalError.logs = (pyErr.logs || baseLogs || "").slice(-8000);
+      throw finalError;
+    }
+  }
+
+  let { filename, fullPath, ext } = downloadResult;
+  logs = downloadResult.logs || logs;
+
+  const id3Clean = Object.entries(id3 || {}).reduce((acc, [k, v]) => {
+    if (v !== undefined && v !== null && String(v).trim() !== "") acc[k] = v;
+    return acc;
+  }, {});
+  const hasId3 = Object.keys(id3Clean).length > 0;
+  const hasTrim = !!trimOpt && Object.keys(trimOpt).length > 0;
+  const hasFilters = filters.length > 0;
+  const hasCover = !!coverPath;
+  const needSampleRate = sr !== undefined;
+
+  const finalize = async (targetExt, converter, extraOpts = {}) => {
+    const tmpOut = join(JOBS_DIR, `${id}.tmp.${targetExt}`);
+    await converter(fullPath, tmpOut, { ...extraOpts, trim: trimOpt || {}, sampleRate: sr, filters });
+    await fsp.unlink(fullPath);
+    filename = `${id}.${targetExt}`;
+    fullPath = join(JOBS_DIR, filename);
+    await fsp.rename(tmpOut, fullPath);
+    ext = targetExt;
+  };
+
+  try {
+    if (fmt === "mp3") {
+      const needConvert = ext !== "mp3" || hasId3 || hasTrim || hasFilters || hasCover || needSampleRate;
+      if (needConvert) {
+        await finalize("mp3", ffmpegToMp3, { abr, id3: id3Clean, cover: coverPath });
+      }
+    } else if (fmt === "flac") {
+      const needConvert = ext !== "flac" || hasId3 || hasTrim || hasFilters || hasCover || needSampleRate;
+      if (needConvert) {
+        await finalize("flac", ffmpegToFlac, { id3: id3Clean, cover: coverPath });
+      }
+    } else if (fmt === "m4a") {
+      const needConvert = ext !== "m4a" || hasId3 || hasTrim || hasFilters || hasCover || needSampleRate;
+      if (needConvert) {
+        await finalize("m4a", ffmpegToM4a, { id3: id3Clean, cover: coverPath });
+      }
+    } else if (fmt === "wav") {
+      const needConvert = ext !== "wav" || hasTrim || hasFilters || needSampleRate;
+      if (needConvert) {
+        await finalize("wav", ffmpegToWav, {});
+      }
+    } else if (fmt === "ogg") {
+      const needConvert = ext !== "ogg" || hasTrim || hasFilters || needSampleRate;
+      if (needConvert) {
+        await finalize("ogg", ffmpegToOgg, {});
+      }
+    }
+  } catch (err) {
+    if (coverPath) try { await fsp.unlink(coverPath); } catch {}
+    const error = new Error(err.message || "ffmpeg gagal");
+    error.logs = (logs + (err.logs || "")).slice(-8000);
+    throw error;
+  }
+
+  if (coverPath) try { await fsp.unlink(coverPath); } catch {}
+
+  const downloadUrl = `/public/jobs/${filename}`;
+  const finalExt = ext;
+  const downloadFileName = `${baseName}.${finalExt}`;
+  return {
+    ok: true,
+    id,
+    format: finalExt,
+    downloadUrl,
+    fileName: downloadFileName,
+    logs: (logs || "").slice(-8000),
+    baseName,
+    fullPath,
+    ext: finalExt,
+  };
+};
 
 // ==== Serve static UI & hasil unduhan ====
 app.use("/", express.static(join(__dirname, "public-ui")));
@@ -201,243 +551,116 @@ app.use("/public", express.static(PUBLIC_DIR));
 // ==== API convert ====
 app.post("/api/convert", async (req, res) => {
   try {
-    const { url, format = "mp3", abr = 192, sampleRate, fileName, noPlaylist = true, id3 = {}, trim, normalize = false, coverUrl, atmos = false } = req.body || {};
-    if (!url || !/^https?:\/\//.test(url)) {
-      return res.status(400).json({ error: "URL tidak valid" });
+    const result = await convertSingle(req.body || {});
+    return res.json(result);
+  } catch (e) {
+    const msg = e?.message || "Gagal memproses";
+    const status = /tidak valid|tidak dikenali/i.test(msg) ? 400 : 500;
+    return res.status(status).json({ error: msg, logs: e?.logs });
+  }
+});
+
+// ==== API convert playlist (ZIP) ====
+app.post("/api/convert-playlist", async (req, res) => {
+  try {
+    const body = req.body || {};
+    const rawItems = Array.isArray(body.items)
+      ? body.items
+      : Array.isArray(body.urls)
+        ? body.urls.map((url) => ({ url }))
+        : [];
+    if (!rawItems.length) {
+      return res.status(400).json({ error: "Daftar URL kosong" });
     }
 
-    let sr;
-    if (sampleRate !== undefined) {
-      sr = Number(sampleRate);
-      if (Number.isNaN(sr) || sr <= 0) {
-        return res.status(400).json({ error: "sampleRate tidak valid" });
-      }
-    }
-
-    let trimOpt = null;
-    if (trim && (trim.start !== undefined || trim.end !== undefined)) {
-      const hasStart = trim.start !== undefined;
-      const hasEnd = trim.end !== undefined;
-      const start = hasStart ? Number(trim.start) : 0;
-      const end = hasEnd ? Number(trim.end) : undefined;
-      if ((hasStart && Number.isNaN(start)) ||
-          (hasEnd && Number.isNaN(end)) ||
-          (hasStart && hasEnd && end < start)) {
-        return res.status(400).json({ error: "trim tidak valid" });
-      }
-      trimOpt = {};
-      if (hasStart) trimOpt.start = start;
-      if (hasEnd) trimOpt.end = end;
-    }
-
-    const id = nanoid(10);
-    const outTpl = join(JOBS_DIR, `${id}.%(ext)s`);
-    const baseName = sanitizeFileName(fileName || id3.title || id) || id;
-
-    let coverPath = null;
-    if (coverUrl && /^https?:\/\//.test(coverUrl)) {
-      try {
-        const imgResp = await fetch(coverUrl);
-        if (imgResp.ok) {
-          const buf = Buffer.from(await imgResp.arrayBuffer());
-          coverPath = join(JOBS_DIR, `${id}.cover.jpg`);
-          await fsp.writeFile(coverPath, buf);
-        }
-      } catch {}
-    }
-
-    // Argumen dasar yt-dlp
-    const args = ["--newline", "--no-progress"];
-
-    // Pakai ffmpeg portable kalau ada
-    if (ffmpegPath) {
-      args.push("--ffmpeg-location", ffmpegPath);
-    }
-
-    // Cookies kalau ada (buat age gate / bot check)
-    if (existsSync(COOKIES_PATH)) {
-      args.push("--cookies", COOKIES_PATH);
-    }
-
-    if (noPlaylist) args.push("--no-playlist");
-    if (atmos) args.push("-f", "bestaudio[channels>2]/bestaudio");
-
-    // Mode cepat: m4a tanpa re-encode (paling ngebut)
-    if (format === "m4a") {
-      args.push("-f", "bestaudio[ext=m4a]/bestaudio");
-      args.push("-o", outTpl);
-      args.push(url);
-    } else if (format === "flac") {
-      args.push("-x", "--audio-format", "flac");
-      args.push("-o", outTpl);
-      args.push(url);
-    } else {
-      // MP3 (re-encode, sedikit lebih lama)
-      args.push("-x", "--audio-format", "mp3", "--audio-quality", abrToQ(abr));
-      args.push("-o", outTpl);
-      args.push(url);
-    }
-
-    const proc = spawn("yt-dlp", args, { stdio: ["ignore", "pipe", "pipe"] });
-
-    let logs = "";
-    proc.stdout.on("data", (d) => (logs += d.toString()));
-    proc.stderr.on("data", (d) => (logs += d.toString()));
-
-    const runPyTubeFallback = (errMsg, baseLogs = "") => {
-      let pyLogs = "";
-      let pyOut  = "";
-      try {
-        const py = spawn("python3", [
-          join(__dirname, "download_audio.py"),
-          url,
-          JOBS_DIR,
-          id,
-        ], { stdio: ["ignore", "pipe", "pipe"] });
-
-        py.stdout.on("data", (d) => {
-          const s = d.toString();
-          pyLogs += s;
-          pyOut  += s;
-        });
-        py.stderr.on("data", (d) => (pyLogs += d.toString()));
-
-        py.on("error", (err) => {
-          if (!res.headersSent) {
-            res.status(500).json({
-              error: `${errMsg} & PyTube tidak bisa dijalankan`,
-              logs: baseLogs + pyLogs,
-              detail: err.message,
-            });
-          }
-        });
-
-        py.on("close", async (code) => {
-          if (code !== 0) {
-            if (!res.headersSent) {
-              res.status(500).json({
-                error: `${errMsg} & PyTube gagal`,
-                logs: baseLogs + pyLogs,
-              });
-            }
-            return;
-          }
-          try {
-              const dlPath = pyOut.trim().split("\n").pop().trim();
-              let ext = dlPath.split(".").pop();
-              let filename = `${id}.${ext}`;
-              let fullPath = join(JOBS_DIR, filename);
-              if (dlPath !== fullPath) await fsp.rename(dlPath, fullPath);
-
-              if (format === "mp3") {
-                const needConvert = normalize || trimOpt || Object.keys(id3).length || ext !== "mp3" || coverPath || sr;
-                if (needConvert) {
-                  const tmpOut = join(JOBS_DIR, `${id}.tmp.mp3`);
-                await ffmpegToMp3(fullPath, tmpOut, { abr, id3, trim: trimOpt || {}, normalize, sampleRate: sr, cover: coverPath });
-                  await fsp.unlink(fullPath);
-                  filename = `${id}.mp3`;
-                  fullPath = join(JOBS_DIR, filename);
-                  await fsp.rename(tmpOut, fullPath);
-                  ext = "mp3";
-                }
-              } else if (format === "flac") {
-                const tmpOut = join(JOBS_DIR, `${id}.tmp.flac`);
-                await ffmpegToFlac(fullPath, tmpOut, { id3, trim: trimOpt || {}, normalize, sampleRate: sr, cover: coverPath });
-                await fsp.unlink(fullPath);
-                filename = `${id}.flac`;
-                fullPath = join(JOBS_DIR, filename);
-                await fsp.rename(tmpOut, fullPath);
-                ext = "flac";
-              } else if (format === "m4a") {
-                const tmpOut = join(JOBS_DIR, `${id}.tmp.m4a`);
-                await ffmpegToM4a(fullPath, tmpOut, { id3, trim: trimOpt || {}, normalize, sampleRate: sr, cover: coverPath });
-                await fsp.unlink(fullPath);
-                filename = `${id}.m4a`;
-                fullPath = join(JOBS_DIR, filename);
-                await fsp.rename(tmpOut, fullPath);
-                ext = "m4a";
-              }
-
-              const downloadUrl = `/public/jobs/${filename}`;
-              const finalExt = ext;
-              const downloadFileName = `${baseName}.${finalExt}`;
-            if (!res.headersSent) {
-              res.json({ ok: true, id, format: finalExt, downloadUrl, fileName: downloadFileName, logs: (baseLogs + pyLogs).slice(-8000) });
-            }
-            if (coverPath) try { await fsp.unlink(coverPath); } catch {}
-          } catch (err) {
-            if (!res.headersSent) {
-              res.status(500).json({ error: err.message || "ffmpeg gagal", logs: baseLogs + pyLogs + err.message });
-            }
-          }
-        });
-      } catch (e) {
-        if (!res.headersSent) {
-          res.status(500).json({
-            error: `${errMsg} & PyTube tidak tersedia`,
-            logs: baseLogs,
-            detail: e.message,
-          });
-        }
-      }
+    const commonOpts = {
+      format: body.format,
+      abr: body.abr,
+      sampleRate: body.sampleRate,
+      noPlaylist: true,
+      normalize: body.normalize,
+      trim: body.trim,
+      coverUrl: body.coverUrl,
+      atmos: body.atmos,
+      speedMode: body.speedMode,
     };
 
-    proc.on("error", () => runPyTubeFallback("yt-dlp tidak bisa dijalankan", logs));
-
-    proc.on("close", async (code) => {
-      if (code !== 0) {
-        return runPyTubeFallback("yt-dlp gagal", logs);
+    const results = [];
+    for (let i = 0; i < rawItems.length; i += 1) {
+      const item = rawItems[i];
+      const url = typeof item === "string" ? item : item?.url;
+      if (!url || !/^https?:\/\//.test(url)) {
+        return res.status(400).json({ error: `URL tidak valid pada entri ${i + 1}` });
       }
-      // Cari file hasil (id.*) tapi abaikan file cover
-      const files = readdirSync(JOBS_DIR).filter(
-        f => f.startsWith(id + ".") && !f.endsWith(".cover.jpg")
-      );
-      if (!files.length) return res.status(500).json({ error: "Output tidak ditemukan", logs });
+      const perId3 = (item && typeof item.id3 === "object") ? item.id3 : body.id3;
+      const perFileName = sanitizeFileName(item?.fileName || item?.title || "");
+      const singleResult = await convertSingle({
+        ...commonOpts,
+        url,
+        id3: perId3,
+        fileName: perFileName,
+      });
+      results.push({ ...singleResult, sourceUrl: url, providedName: perFileName });
+    }
 
-      let filename   = files[0];
-      let fullPath   = join(JOBS_DIR, filename);
-      let ext = filename.split(".").pop();
+    const zipId = nanoid(10);
+    const safeBase = sanitizeFileName(body.zipName || `playlist-${zipId}`) || `playlist-${zipId}`;
+    const zipFileName = `${safeBase}.zip`;
+    const zipPath = join(JOBS_DIR, zipFileName);
 
-      try {
-        if (format === "mp3" && (normalize || trimOpt || Object.keys(id3).length || coverPath || sr)) {
-          const tmpOut = join(JOBS_DIR, `${id}.tmp.mp3`);
-          await ffmpegToMp3(fullPath, tmpOut, { abr, id3, trim: trimOpt || {}, normalize, sampleRate: sr, cover: coverPath });
-          await fsp.unlink(fullPath);
-          filename = `${id}.mp3`;
-          fullPath = join(JOBS_DIR, filename);
-          await fsp.rename(tmpOut, fullPath);
-          ext = "mp3";
-        } else if (format === "flac" && (normalize || trimOpt || Object.keys(id3).length || coverPath || sr)) {
-          const tmpOut = join(JOBS_DIR, `${id}.tmp.flac`);
-          await ffmpegToFlac(fullPath, tmpOut, { id3, trim: trimOpt || {}, normalize, sampleRate: sr, cover: coverPath });
-          await fsp.unlink(fullPath);
-          filename = `${id}.flac`;
-          fullPath = join(JOBS_DIR, filename);
-          await fsp.rename(tmpOut, fullPath);
-          ext = "flac";
-        } else if (format === "m4a" && (normalize || trimOpt || Object.keys(id3).length || coverPath || sr)) {
-          const tmpOut = join(JOBS_DIR, `${id}.tmp.m4a`);
-          await ffmpegToM4a(fullPath, tmpOut, { id3, trim: trimOpt || {}, normalize, sampleRate: sr, cover: coverPath });
-          await fsp.unlink(fullPath);
-          filename = `${id}.m4a`;
-          fullPath = join(JOBS_DIR, filename);
-          await fsp.rename(tmpOut, fullPath);
-          ext = "m4a";
-        }
-      } catch (e) {
-        if (coverPath) try { await fsp.unlink(coverPath); } catch {}
-        return res.status(500).json({ error: e.message || "ffmpeg gagal", logs: logs + e.message });
-      }
+    const width = String(results.length).length;
+    const tempDir = join(JOBS_DIR, `${zipId}_tmp`);
+    await fsp.mkdir(tempDir, { recursive: true });
 
-      if (coverPath) try { await fsp.unlink(coverPath); } catch {}
+    const entryNames = [];
+    for (let idx = 0; idx < results.length; idx += 1) {
+      const item = results[idx];
+      const trackNo = String(idx + 1).padStart(width, "0");
+      const base = sanitizeFileName(item.baseName) || item.providedName || `Track ${idx + 1}`;
+      const entryName = `${trackNo} - ${base}.${item.ext}`;
+      entryNames.push(entryName);
+      await fsp.copyFile(item.fullPath, join(tempDir, entryName));
+    }
 
-      const downloadUrl = `/public/jobs/${filename}`;
-      const finalExt = ext;
-      const downloadFileName = `${baseName}.${finalExt}`;
-      return res.json({ ok: true, id, format: finalExt, downloadUrl, fileName: downloadFileName, logs: logs.slice(-8000) });
+    try {
+      await new Promise((resolve, reject) => {
+        const zipProc = spawn("zip", ["-q", "-j", zipPath, ...entryNames], { cwd: tempDir });
+        let zipLogs = "";
+        zipProc.stdout.on("data", (d) => (zipLogs += d.toString()));
+        zipProc.stderr.on("data", (d) => (zipLogs += d.toString()));
+        zipProc.on("error", (err) => {
+          const error = new Error("zip command gagal dijalankan");
+          error.logs = zipLogs;
+          reject(error);
+        });
+        zipProc.on("close", (code) => {
+          if (code === 0) resolve();
+          else {
+            const error = new Error(`zip keluar dengan kode ${code}`);
+            error.logs = zipLogs;
+            reject(error);
+          }
+        });
+      });
+    } finally {
+      try { await fsp.rm(tempDir, { recursive: true, force: true }); } catch {}
+    }
+
+    return res.json({
+      ok: true,
+      id: zipId,
+      count: results.length,
+      downloadUrl: `/public/jobs/${zipFileName}`,
+      fileName: zipFileName,
+      entries: results.map((item, idx) => ({
+        url: item.sourceUrl,
+        fileName: `${String(idx + 1).padStart(width, "0")} - ${(sanitizeFileName(item.baseName) || item.providedName || `Track ${idx + 1}`)}.${item.ext}`,
+        format: item.format,
+      })),
     });
   } catch (e) {
-    return res.status(500).json({ error: e.message });
+    const msg = e?.message || "Gagal memproses playlist";
+    return res.status(500).json({ error: msg });
   }
 });
 

--- a/index.js
+++ b/index.js
@@ -8,10 +8,20 @@ import { fileURLToPath } from "node:url";
 import { nanoid } from "nanoid";
 // Tambahan untuk ffmpeg portable (opsional)
 let ffmpegPath = null;
+const ffprobeEnv = process.env.FFPROBE_PATH || null;
+let ffprobePath = ffprobeEnv;
 try {
   ffmpegPath = (await import("ffmpeg-static")).default;
 } catch {
   ffmpegPath = null;
+}
+if (!ffprobePath) {
+  try {
+    const probeMod = await import("ffprobe-static");
+    ffprobePath = probeMod?.path || probeMod?.default?.path || null;
+  } catch {
+    ffprobePath = null;
+  }
 }
 
 const __filename = fileURLToPath(import.meta.url);
@@ -193,25 +203,50 @@ const createStemsForSource = async (inputPath, baseName = "Audio") => {
   const instrumentalPath = join(JOBS_DIR, instrumentalFile);
   const zipPath = join(JOBS_DIR, zipFile);
 
+  const audioInfo = await probeAudioStream(inputPath);
+  const channelCount = Number(audioInfo?.channels) || 0;
+  const channelLayout = audioInfo?.channelLayout || null;
+  const isStereo = channelCount >= 2;
+  const strategy = isStereo ? "stereo_mid_side" : "mono_adaptive";
+
+  const vocalsFilterParts = [];
+  const instrumentalFilterParts = [];
+
+  if (isStereo) {
+    vocalsFilterParts.push("pan=stereo|c0=0.5*c0+0.5*c1|c1=0.5*c0+0.5*c1");
+    vocalsFilterParts.push("alimiter=limit=0.9");
+    instrumentalFilterParts.push("pan=stereo|c0=c0-c1|c1=c1-c0");
+    instrumentalFilterParts.push("alimiter=limit=0.9");
+  } else {
+    vocalsFilterParts.push("pan=stereo|c0=c0|c1=c0");
+    vocalsFilterParts.push("highpass=f=120");
+    vocalsFilterParts.push("lowpass=f=7600");
+    vocalsFilterParts.push("acompressor=threshold=-20dB:ratio=2:attack=12:release=120");
+    vocalsFilterParts.push("alimiter=limit=0.9");
+
+    instrumentalFilterParts.push("pan=stereo|c0=c0|c1=c0");
+    instrumentalFilterParts.push("lowpass=f=180");
+    instrumentalFilterParts.push("equalizer=f=320:t=h:w=2.5:g=4");
+    instrumentalFilterParts.push("equalizer=f=1100:t=h:w=2.5:g=-6");
+    instrumentalFilterParts.push("equalizer=f=3500:t=h:w=2.5:g=-9");
+    instrumentalFilterParts.push("alimiter=limit=0.9");
+  }
+
+  const vocalsFilters = vocalsFilterParts.join(",");
+  const instrumentalFilters = instrumentalFilterParts.join(",");
+
   let vocalsLogs = "";
   let instrumentalLogs = "";
   try {
-    vocalsLogs = await runFfmpeg([
-      "-y",
-      "-i", inputPath,
-      "-filter:a", "pan=stereo|c0=c0+c1|c1=c0+c1,alimiter=limit=0.9",
-      "-codec:a", "libmp3lame",
-      "-qscale:a", "2",
-      vocalsPath,
-    ]);
-    instrumentalLogs = await runFfmpeg([
-      "-y",
-      "-i", inputPath,
-      "-filter:a", "pan=stereo|c0=c0-c1|c1=c1-c0,alimiter=limit=0.9",
-      "-codec:a", "libmp3lame",
-      "-qscale:a", "2",
-      instrumentalPath,
-    ]);
+    const vocalsArgs = ["-y", "-i", inputPath];
+    if (vocalsFilters) vocalsArgs.push("-filter:a", vocalsFilters);
+    vocalsArgs.push("-ac", "2", "-codec:a", "libmp3lame", "-qscale:a", "2", vocalsPath);
+    vocalsLogs = await runFfmpeg(vocalsArgs);
+
+    const instrumentalArgs = ["-y", "-i", inputPath];
+    if (instrumentalFilters) instrumentalArgs.push("-filter:a", instrumentalFilters);
+    instrumentalArgs.push("-ac", "2", "-codec:a", "libmp3lame", "-qscale:a", "2", instrumentalPath);
+    instrumentalLogs = await runFfmpeg(instrumentalArgs);
 
     await new Promise((resolve, reject) => {
       const zipProc = spawn("zip", ["-q", zipFile, vocalsFile, instrumentalFile], { cwd: JOBS_DIR });
@@ -256,6 +291,11 @@ const createStemsForSource = async (inputPath, baseName = "Audio") => {
     zip: {
       downloadUrl: `/public/jobs/${zipFile}`,
       fileName: `${safeBase} - STEMS.zip`,
+    },
+    meta: {
+      channels: channelCount,
+      channelLayout,
+      strategy,
     },
   };
   return response;
@@ -590,6 +630,51 @@ const runFfmpeg = (args) => new Promise((resolve, reject) => {
     }
   });
 });
+
+const runFfprobe = (args) => new Promise((resolve, reject) => {
+  const ff = spawn(ffprobePath || "ffprobe", args, { stdio: ["ignore", "pipe", "pipe"] });
+  let stdout = "";
+  let stderr = "";
+  ff.stdout.on("data", (d) => (stdout += d.toString()));
+  ff.stderr.on("data", (d) => (stderr += d.toString()));
+  ff.on("error", (err) => {
+    const error = new Error(err.code === "ENOENT" ? "ffprobe tidak ditemukan" : err.message || "ffprobe gagal");
+    error.logs = stderr;
+    reject(error);
+  });
+  ff.on("close", (code) => {
+    if (code === 0) resolve(stdout);
+    else {
+      const error = new Error(`ffprobe exit ${code}`);
+      error.logs = stderr;
+      reject(error);
+    }
+  });
+});
+
+const probeAudioStream = async (inputPath) => {
+  try {
+    const output = await runFfprobe([
+      "-v",
+      "error",
+      "-select_streams",
+      "a:0",
+      "-show_entries",
+      "stream=channels,channel_layout",
+      "-of",
+      "json",
+      inputPath,
+    ]);
+    const data = JSON.parse(output || "{}") || {};
+    const stream = Array.isArray(data.streams) ? data.streams[0] : data.stream || {};
+    const channels = Number(stream?.channels) || 0;
+    const channelLayout = typeof stream?.channel_layout === "string" ? stream.channel_layout : null;
+    return { channels, channelLayout };
+  } catch (err) {
+    console.warn("ffprobe gagal membaca informasi audio", err?.message || err);
+    return { channels: 0, channelLayout: null };
+  }
+};
 
 const vttToSrt = (input = "") => {
   const clean = (input || "").replace(/^WEBVTT.*\n+/i, "").replace(/\r/g, "");

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ import cors from "cors";
 import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, readdirSync, statSync } from "node:fs";
 import { promises as fsp } from "node:fs";
-import { join, dirname } from "node:path";
+import { join, dirname, basename } from "node:path";
 import { fileURLToPath } from "node:url";
 import { nanoid } from "nanoid";
 // Tambahan untuk ffmpeg portable (opsional)
@@ -68,6 +68,65 @@ const applyAudioFilters = (args, filters = []) => {
     args.push("-filter:a", filters.join(","));
   }
 };
+
+const vttToSrt = (input = "") => {
+  const clean = (input || "").replace(/^WEBVTT.*\n+/i, "").replace(/\r/g, "");
+  const blocks = clean.split(/\n\n+/);
+  const lines = [];
+  let idx = 1;
+  for (const block of blocks) {
+    const parts = block.split(/\n+/).map((line) => line.trim());
+    if (!parts.length) continue;
+    let cursor = 0;
+    if (/^\d+$/.test(parts[cursor])) cursor += 1;
+    if (cursor >= parts.length) continue;
+    const timeLine = parts[cursor];
+    if (!timeLine.includes("-->")) continue;
+    const [rawStart, rawEndWithMeta] = timeLine.split("-->");
+    if (!rawEndWithMeta) continue;
+    const start = rawStart.trim().replace(/\./g, ",");
+    const end = rawEndWithMeta.trim().split(/\s+/)[0]?.replace(/\./g, ",");
+    if (!start || !end) continue;
+    const textLines = parts.slice(cursor + 1).map((line) => line.replace(/<[^>]+>/g, "").trim()).filter(Boolean);
+    if (!textLines.length) continue;
+    lines.push(String(idx));
+    lines.push(`${start} --> ${end}`);
+    lines.push(...textLines);
+    lines.push("");
+    idx += 1;
+  }
+  return lines.join("\n").trim();
+};
+
+const srtToPlainText = (input = "") => {
+  const normalized = (input || "").replace(/\r/g, "");
+  const blocks = normalized.split(/\n\n+/);
+  const texts = [];
+  for (const block of blocks) {
+    const lines = block.split(/\n+/).map((line) => line.trim());
+    if (!lines.length) continue;
+    let cursor = 0;
+    if (/^\d+$/.test(lines[cursor])) cursor += 1;
+    if (cursor < lines.length && lines[cursor].includes("-->")) cursor += 1;
+    const content = lines
+      .slice(cursor)
+      .map((line) => line.replace(/<[^>]+>/g, "").trim())
+      .filter(Boolean)
+      .join(" ")
+      .replace(/\s+/g, " ")
+      .trim();
+    if (content) texts.push(content);
+  }
+  return texts.join("\n");
+};
+
+const buildSubtitlePreview = (text = "") =>
+  (text || "")
+    .split(/\n+/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .slice(0, 4)
+    .join("\n");
 
 const ffmpegToMp3 = (input, output, opts = {}) => {
   const { abr = 192, id3 = {}, trim = {}, sampleRate, cover, filters = [] } = opts;
@@ -544,6 +603,134 @@ const convertSingle = async (payload = {}) => {
   };
 };
 
+const downloadSubtitle = async (payload = {}) => {
+  const url = typeof payload.url === "string" ? payload.url.trim() : "";
+  if (!/^https?:\/\//i.test(url)) {
+    throw new Error("URL tidak valid");
+  }
+
+  const preferAuto = payload.preferAuto !== false;
+  const langOpt = typeof payload.lang === "string" && payload.lang.trim() ? payload.lang.trim() : "id.*,en.*,en";
+  const baseOutput = sanitizeFileName(payload.fileName || payload.title || "subtitle");
+  const downloadBase = baseOutput || "subtitle";
+
+  const id = nanoid(10);
+  const outputTpl = join(JOBS_DIR, `${id}.%(ext)s`);
+
+  const args = ["--skip-download", "--no-progress", "--newline"];
+  if (ffmpegPath) args.push("--ffmpeg-location", ffmpegPath);
+  if (existsSync(COOKIES_PATH)) args.push("--cookies", COOKIES_PATH);
+  args.push("--write-sub");
+  if (preferAuto) args.push("--write-auto-sub");
+  args.push("--sub-format", "srt/best");
+  args.push("--convert-subs", "srt");
+  args.push("--sub-langs", langOpt);
+  args.push("-o", outputTpl);
+  args.push(url);
+
+  let logs = "";
+  try {
+    await new Promise((resolve, reject) => {
+      const proc = spawn("yt-dlp", args, { stdio: ["ignore", "pipe", "pipe"] });
+      proc.stdout.on("data", (d) => (logs += d.toString()));
+      proc.stderr.on("data", (d) => (logs += d.toString()));
+      proc.on("error", (err) => {
+        const error = new Error("yt-dlp tidak bisa dijalankan");
+        error.cause = err;
+        error.logs = logs;
+        reject(error);
+      });
+      proc.on("close", (code) => {
+        if (code !== 0) {
+          const error = new Error("yt-dlp gagal mengambil subtitle");
+          error.logs = logs;
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
+    });
+
+    const files = readdirSync(JOBS_DIR).filter((f) => f.startsWith(`${id}.`));
+    const candidates = files.filter((f) => f.endsWith(".srt") || f.endsWith(".vtt"));
+    if (!candidates.length) {
+      const error = new Error("Subtitle tidak ditemukan");
+      error.logs = logs;
+      throw error;
+    }
+
+    const autoCandidate = candidates.find((f) => /\.auto\./i.test(f));
+    const manualCandidate = candidates.find((f) => !/\.auto\./i.test(f));
+    let chosen = manualCandidate || candidates[0];
+    if (preferAuto && autoCandidate) chosen = autoCandidate;
+
+    const suffix = chosen.replace(`${id}.`, "");
+    const parts = suffix.split(".");
+    const ext = parts.pop();
+    let langKey = parts.join(".");
+    let autoDetected = /\.auto$/i.test(langKey) || /-auto$/i.test(langKey) || /\.auto\./i.test(chosen);
+    langKey = langKey.replace(/\.auto/gi, "-auto");
+    if (!langKey) langKey = autoDetected ? "auto" : "subtitle";
+    const safeLang = langKey.replace(/[^a-z0-9_-]+/gi, "-");
+    autoDetected = autoDetected || /-auto$/i.test(safeLang);
+
+    const chosenPath = join(JOBS_DIR, chosen);
+    const finalStem = `${id}.${safeLang}`;
+    const finalSrtName = `${finalStem}.srt`;
+    let srtPath = join(JOBS_DIR, finalSrtName);
+
+    if (ext === "vtt") {
+      const vttContent = await fsp.readFile(chosenPath, "utf8");
+      const srtContent = vttToSrt(vttContent);
+      if (!srtContent) {
+        const error = new Error("Subtitle VTT tidak bisa dikonversi");
+        error.logs = logs;
+        throw error;
+      }
+      await fsp.writeFile(srtPath, `${srtContent}\n`, "utf8");
+      try { await fsp.unlink(chosenPath); } catch {}
+    } else {
+      if (basename(chosenPath) !== finalSrtName) {
+        await fsp.rename(chosenPath, srtPath);
+      }
+    }
+
+    const srtContent = await fsp.readFile(srtPath, "utf8");
+    const plain = srtToPlainText(srtContent);
+    const preview = buildSubtitlePreview(plain);
+    const finalTxtName = `${finalStem}.txt`;
+    const txtPath = join(JOBS_DIR, finalTxtName);
+    await fsp.writeFile(txtPath, `${plain}\n`, "utf8");
+
+    for (const file of files) {
+      if (file === finalSrtName || file === finalTxtName) continue;
+      try { await fsp.unlink(join(JOBS_DIR, file)); } catch {}
+    }
+
+    return {
+      ok: true,
+      logs: (logs || "").slice(-8000),
+      lang: safeLang,
+      auto: autoDetected,
+      srtUrl: `/public/jobs/${finalSrtName}`,
+      srtFileName: `${downloadBase}.${safeLang}.srt`,
+      txtUrl: `/public/jobs/${finalTxtName}`,
+      txtFileName: `${downloadBase}.${safeLang}.txt`,
+      preview,
+    };
+  } catch (err) {
+    try {
+      const leftovers = readdirSync(JOBS_DIR).filter((f) => f.startsWith(`${id}.`));
+      for (const file of leftovers) {
+        try { await fsp.unlink(join(JOBS_DIR, file)); } catch {}
+      }
+    } catch {}
+    const error = new Error(err.message || "Gagal mengambil subtitle");
+    error.logs = (logs + (err.logs || "")).slice(-8000);
+    throw error;
+  }
+};
+
 // ==== Serve static UI & hasil unduhan ====
 app.use("/", express.static(join(__dirname, "public-ui")));
 app.use("/public", express.static(PUBLIC_DIR));
@@ -556,6 +743,17 @@ app.post("/api/convert", async (req, res) => {
   } catch (e) {
     const msg = e?.message || "Gagal memproses";
     const status = /tidak valid|tidak dikenali/i.test(msg) ? 400 : 500;
+    return res.status(status).json({ error: msg, logs: e?.logs });
+  }
+});
+
+app.post("/api/subtitle", async (req, res) => {
+  try {
+    const result = await downloadSubtitle(req.body || {});
+    return res.json(result);
+  } catch (e) {
+    const msg = e?.message || "Gagal mengambil subtitle";
+    const status = /tidak valid/i.test(msg) ? 400 : 500;
     return res.status(status).json({ error: msg, logs: e?.logs });
   }
 });

--- a/index.js
+++ b/index.js
@@ -261,6 +261,63 @@ const createStemsForSource = async (inputPath, baseName = "Audio") => {
   return response;
 };
 
+const SUPPORTED_THUMBNAIL_STYLES = new Set(["modern", "vibrant", "mono"]);
+
+const readImageBuffer = async (imageUrl) => {
+  if (!imageUrl || typeof imageUrl !== "string") {
+    const err = new Error("URL gambar tidak valid");
+    err.statusCode = 400;
+    throw err;
+  }
+
+  const trimmed = imageUrl.trim();
+  if (trimmed.startsWith("data:")) {
+    const match = /^data:(image\/[^;]+);base64,(.+)$/i.exec(trimmed);
+    if (!match) {
+      const err = new Error("Data URL gambar tidak valid");
+      err.statusCode = 400;
+      throw err;
+    }
+    return Buffer.from(match[2], "base64");
+  }
+
+  if (!/^https?:\/\//i.test(trimmed)) {
+    const err = new Error("URL gambar harus http/https");
+    err.statusCode = 400;
+    throw err;
+  }
+
+  let response;
+  try {
+    response = await fetch(trimmed, {
+      headers: {
+        "user-agent": "Mozilla/5.0 (compatible; ytmp3/1.0; +https://github.com/)",
+        accept: "image/avif,image/webp,image/apng,image/*,*/*;q=0.8",
+      },
+    });
+  } catch (cause) {
+    const err = new Error("Tidak bisa mengunduh gambar sumber. Periksa koneksi jaringan atau coba URL lain.");
+    err.statusCode = 502;
+    err.cause = cause;
+    throw err;
+  }
+
+  if (!response.ok) {
+    const err = new Error(`Gagal mengambil gambar (status ${response.status})`);
+    err.statusCode = response.status >= 400 && response.status < 500 ? 400 : 502;
+    throw err;
+  }
+
+  const contentType = response.headers.get("content-type") || "";
+  if (!/image\//i.test(contentType)) {
+    const err = new Error("Respons bukan file gambar");
+    err.statusCode = 400;
+    throw err;
+  }
+
+  return Buffer.from(await response.arrayBuffer());
+};
+
 const generateThumbnailArt = async ({
   imageUrl,
   title,
@@ -268,18 +325,13 @@ const generateThumbnailArt = async ({
   accent = "#0d6efd",
   style = "modern",
 }) => {
-  if (!imageUrl || !/^https?:\/\//i.test(imageUrl)) {
-    throw new Error("URL gambar tidak valid");
-  }
   if (!DEFAULT_FONT) {
-    throw new Error("Font default tidak ditemukan untuk drawtext");
+    const err = new Error("Font default tidak ditemukan untuk drawtext");
+    err.statusCode = 500;
+    throw err;
   }
 
-  const response = await fetch(imageUrl);
-  if (!response.ok) {
-    throw new Error(`Gagal mengambil gambar (${response.status})`);
-  }
-  const buffer = Buffer.from(await response.arrayBuffer());
+  const buffer = await readImageBuffer(imageUrl);
   const thumbId = nanoid(10);
   const inputPath = join(THUMB_DIR, `${thumbId}.src`);
   const outputName = `${thumbId}.jpg`;
@@ -288,15 +340,18 @@ const generateThumbnailArt = async ({
   await fsp.writeFile(inputPath, buffer);
 
   const accentHex = normalizeHex(accent);
+  const styleKey = SUPPORTED_THUMBNAIL_STYLES.has((style || "").toLowerCase())
+    ? (style || "").toLowerCase()
+    : "modern";
   const baseFilter = [
     "scale=1280:720:force_original_aspect_ratio=decrease",
     `pad=1280:720:(ow-iw)/2:(oh-ih)/2:${hexToFfmpegColor("#10121a")}`,
     "format=rgba",
   ];
 
-  if (style === "vibrant") {
+  if (styleKey === "vibrant") {
     baseFilter.push("eq=saturation=1.35:contrast=1.05");
-  } else if (style === "mono") {
+  } else if (styleKey === "mono") {
     baseFilter.push("hue=s=0");
   }
 
@@ -1278,7 +1333,11 @@ app.post("/api/thumbnail", async (req, res) => {
     return res.json(result);
   } catch (e) {
     const msg = e?.message || "Gagal membuat thumbnail";
-    const status = /tidak valid|tidak ditemukan/i.test(msg) ? 400 : 500;
+    const status = Number.isInteger(e?.statusCode)
+      ? e.statusCode
+      : /tidak valid|tidak ditemukan/i.test(msg)
+        ? 400
+        : 500;
     return res.status(status).json({ error: msg, logs: e?.logs });
   }
 });

--- a/index.js
+++ b/index.js
@@ -8,20 +8,10 @@ import { fileURLToPath } from "node:url";
 import { nanoid } from "nanoid";
 // Tambahan untuk ffmpeg portable (opsional)
 let ffmpegPath = null;
-const ffprobeEnv = process.env.FFPROBE_PATH || null;
-let ffprobePath = ffprobeEnv;
 try {
   ffmpegPath = (await import("ffmpeg-static")).default;
 } catch {
   ffmpegPath = null;
-}
-if (!ffprobePath) {
-  try {
-    const probeMod = await import("ffprobe-static");
-    ffprobePath = probeMod?.path || probeMod?.default?.path || null;
-  } catch {
-    ffprobePath = null;
-  }
 }
 
 const __filename = fileURLToPath(import.meta.url);
@@ -38,17 +28,7 @@ if (!existsSync(PUBLIC_DIR)) mkdirSync(PUBLIC_DIR, { recursive: true });
 if (!existsSync(JOBS_DIR))   mkdirSync(JOBS_DIR,   { recursive: true });
 
 const PUBLIC_ROOT = pathResolve(PUBLIC_DIR);
-const THUMB_DIR = join(PUBLIC_ROOT, "thumbnails");
-const CLOUD_DIR = join(PUBLIC_ROOT, "cloud");
-const CLOUD_TARGETS = {
-  drive: { label: "Google Drive", dir: join(CLOUD_DIR, "drive") },
-  dropbox: { label: "Dropbox", dir: join(CLOUD_DIR, "dropbox") },
-  onedrive: { label: "OneDrive", dir: join(CLOUD_DIR, "onedrive") },
-};
-
-for (const dir of [THUMB_DIR, CLOUD_DIR, ...Object.values(CLOUD_TARGETS).map((t) => t.dir)]) {
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-}
+// direktori tambahan seperti thumbnail/cloud sudah dihapus
 
 const backgroundJobs = new Map();
 const backgroundQueue = [];
@@ -76,35 +56,6 @@ const sanitizeFileName = (name = "") =>
 
 const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
 
-const escapeDrawText = (input = "") =>
-  (input || "")
-    .replace(/[\\:'\[\]]/g, (match) => `\\${match}`)
-    .replace(/\n/g, "\\n");
-
-const normalizeHex = (hex, fallback = "#0d6efd") => {
-  if (typeof hex !== "string") return fallback;
-  const clean = hex.trim();
-  return /^#?[0-9a-fA-F]{6}$/.test(clean)
-    ? (clean.startsWith("#") ? clean : `#${clean}`)
-    : fallback;
-};
-
-const hexToFfmpegColor = (hex) => `0x${hex.replace(/^#/, "").toUpperCase()}`;
-
-const findFontPath = () => {
-  const candidates = [
-    "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
-    "/usr/share/fonts/truetype/liberation/LiberationSans-Bold.ttf",
-    "/usr/share/fonts/truetype/freefont/FreeSansBold.ttf",
-  ];
-  for (const font of candidates) {
-    if (existsSync(font)) return font;
-  }
-  return null;
-};
-
-const DEFAULT_FONT = findFontPath();
-
 const resolvePublicPath = (urlPath = "") => {
   if (typeof urlPath !== "string") return null;
   const cleaned = urlPath.replace(/\\/g, "/").trim();
@@ -113,20 +64,6 @@ const resolvePublicPath = (urlPath = "") => {
   const fullPath = pathResolve(PUBLIC_ROOT, relative);
   if (!fullPath.startsWith(PUBLIC_ROOT)) return null;
   return fullPath;
-};
-
-const ensureUniqueFileName = (dir, fileName) => {
-  const clean = fileName || "file";
-  const dot = clean.lastIndexOf(".");
-  const base = dot > 0 ? clean.slice(0, dot) : clean;
-  const ext = dot > 0 ? clean.slice(dot) : "";
-  let candidate = clean;
-  let counter = 1;
-  while (existsSync(join(dir, candidate))) {
-    candidate = `${base} (${counter})${ext}`;
-    counter += 1;
-  }
-  return candidate;
 };
 
 const GENRE_KEYWORDS = [
@@ -190,244 +127,6 @@ const buildAiTags = ({ title = "", description = "", channel = "", duration } = 
   if (year) tags.year = year;
   tags.comment = `AI tags · ${genre} · ${mood}${year ? ` · ${year}` : ""}`;
   return tags;
-};
-
-const createStemsForSource = async (inputPath, baseName = "Audio") => {
-  if (!inputPath) throw new Error("Sumber audio tidak ditemukan");
-  const safeBase = sanitizeFileName(baseName) || "Audio";
-  const stemId = nanoid(10);
-  const vocalsFile = `${stemId}.vocals.mp3`;
-  const instrumentalFile = `${stemId}.instrumental.mp3`;
-  const zipFile = `${stemId}.stems.zip`;
-  const vocalsPath = join(JOBS_DIR, vocalsFile);
-  const instrumentalPath = join(JOBS_DIR, instrumentalFile);
-  const zipPath = join(JOBS_DIR, zipFile);
-
-  const audioInfo = await probeAudioStream(inputPath);
-  const channelCount = Number(audioInfo?.channels) || 0;
-  const channelLayout = audioInfo?.channelLayout || null;
-  const isStereo = channelCount >= 2;
-  const strategy = isStereo ? "stereo_mid_side" : "mono_adaptive";
-
-  const vocalsFilterParts = [];
-  const instrumentalFilterParts = [];
-
-  if (isStereo) {
-    vocalsFilterParts.push("pan=stereo|c0=0.5*c0+0.5*c1|c1=0.5*c0+0.5*c1");
-    vocalsFilterParts.push("alimiter=limit=0.9");
-    instrumentalFilterParts.push("pan=stereo|c0=c0-c1|c1=c1-c0");
-    instrumentalFilterParts.push("alimiter=limit=0.9");
-  } else {
-    vocalsFilterParts.push("pan=stereo|c0=c0|c1=c0");
-    vocalsFilterParts.push("highpass=f=120");
-    vocalsFilterParts.push("lowpass=f=7600");
-    vocalsFilterParts.push("acompressor=threshold=-20dB:ratio=2:attack=12:release=120");
-    vocalsFilterParts.push("alimiter=limit=0.9");
-
-    instrumentalFilterParts.push("pan=stereo|c0=c0|c1=c0");
-    instrumentalFilterParts.push("lowpass=f=180");
-    instrumentalFilterParts.push("equalizer=f=320:t=h:w=2.5:g=4");
-    instrumentalFilterParts.push("equalizer=f=1100:t=h:w=2.5:g=-6");
-    instrumentalFilterParts.push("equalizer=f=3500:t=h:w=2.5:g=-9");
-    instrumentalFilterParts.push("alimiter=limit=0.9");
-  }
-
-  const vocalsFilters = vocalsFilterParts.join(",");
-  const instrumentalFilters = instrumentalFilterParts.join(",");
-
-  let vocalsLogs = "";
-  let instrumentalLogs = "";
-  try {
-    const vocalsArgs = ["-y", "-i", inputPath];
-    if (vocalsFilters) vocalsArgs.push("-filter:a", vocalsFilters);
-    vocalsArgs.push("-ac", "2", "-codec:a", "libmp3lame", "-qscale:a", "2", vocalsPath);
-    vocalsLogs = await runFfmpeg(vocalsArgs);
-
-    const instrumentalArgs = ["-y", "-i", inputPath];
-    if (instrumentalFilters) instrumentalArgs.push("-filter:a", instrumentalFilters);
-    instrumentalArgs.push("-ac", "2", "-codec:a", "libmp3lame", "-qscale:a", "2", instrumentalPath);
-    instrumentalLogs = await runFfmpeg(instrumentalArgs);
-
-    await new Promise((resolve, reject) => {
-      const zipProc = spawn("zip", ["-q", zipFile, vocalsFile, instrumentalFile], { cwd: JOBS_DIR });
-      let zipLogs = "";
-      zipProc.stdout.on("data", (d) => (zipLogs += d.toString()));
-      zipProc.stderr.on("data", (d) => (zipLogs += d.toString()));
-      zipProc.on("error", (err) => {
-        const error = new Error("zip command gagal dijalankan");
-        error.logs = zipLogs;
-        reject(error);
-      });
-      zipProc.on("close", (code) => {
-        if (code === 0) resolve();
-        else {
-          const error = new Error(`zip keluar dengan kode ${code}`);
-          error.logs = zipLogs;
-          reject(error);
-        }
-      });
-    });
-  } catch (err) {
-    try { await fsp.unlink(vocalsPath); } catch {}
-    try { await fsp.unlink(instrumentalPath); } catch {}
-    try { await fsp.unlink(zipPath); } catch {}
-    throw err;
-  }
-
-  const response = {
-    ok: true,
-    id: stemId,
-    baseName: safeBase,
-    vocals: {
-      downloadUrl: `/public/jobs/${vocalsFile}`,
-      fileName: `${safeBase} - Vocals.mp3`,
-      logs: vocalsLogs.slice(-6000),
-    },
-    instrumental: {
-      downloadUrl: `/public/jobs/${instrumentalFile}`,
-      fileName: `${safeBase} - Instrumental.mp3`,
-      logs: instrumentalLogs.slice(-6000),
-    },
-    zip: {
-      downloadUrl: `/public/jobs/${zipFile}`,
-      fileName: `${safeBase} - STEMS.zip`,
-    },
-    meta: {
-      channels: channelCount,
-      channelLayout,
-      strategy,
-    },
-  };
-  return response;
-};
-
-const SUPPORTED_THUMBNAIL_STYLES = new Set(["modern", "vibrant", "mono"]);
-
-const readImageBuffer = async (imageUrl) => {
-  if (!imageUrl || typeof imageUrl !== "string") {
-    const err = new Error("URL gambar tidak valid");
-    err.statusCode = 400;
-    throw err;
-  }
-
-  const trimmed = imageUrl.trim();
-  if (trimmed.startsWith("data:")) {
-    const match = /^data:(image\/[^;]+);base64,(.+)$/i.exec(trimmed);
-    if (!match) {
-      const err = new Error("Data URL gambar tidak valid");
-      err.statusCode = 400;
-      throw err;
-    }
-    return Buffer.from(match[2], "base64");
-  }
-
-  if (!/^https?:\/\//i.test(trimmed)) {
-    const err = new Error("URL gambar harus http/https");
-    err.statusCode = 400;
-    throw err;
-  }
-
-  let response;
-  try {
-    response = await fetch(trimmed, {
-      headers: {
-        "user-agent": "Mozilla/5.0 (compatible; ytmp3/1.0; +https://github.com/)",
-        accept: "image/avif,image/webp,image/apng,image/*,*/*;q=0.8",
-      },
-    });
-  } catch (cause) {
-    const err = new Error("Tidak bisa mengunduh gambar sumber. Periksa koneksi jaringan atau coba URL lain.");
-    err.statusCode = 502;
-    err.cause = cause;
-    throw err;
-  }
-
-  if (!response.ok) {
-    const err = new Error(`Gagal mengambil gambar (status ${response.status})`);
-    err.statusCode = response.status >= 400 && response.status < 500 ? 400 : 502;
-    throw err;
-  }
-
-  const contentType = response.headers.get("content-type") || "";
-  if (!/image\//i.test(contentType)) {
-    const err = new Error("Respons bukan file gambar");
-    err.statusCode = 400;
-    throw err;
-  }
-
-  return Buffer.from(await response.arrayBuffer());
-};
-
-const generateThumbnailArt = async ({
-  imageUrl,
-  title,
-  subtitle,
-  accent = "#0d6efd",
-  style = "modern",
-}) => {
-  if (!DEFAULT_FONT) {
-    const err = new Error("Font default tidak ditemukan untuk drawtext");
-    err.statusCode = 500;
-    throw err;
-  }
-
-  const buffer = await readImageBuffer(imageUrl);
-  const thumbId = nanoid(10);
-  const inputPath = join(THUMB_DIR, `${thumbId}.src`);
-  const outputName = `${thumbId}.jpg`;
-  const outputPath = join(THUMB_DIR, outputName);
-
-  await fsp.writeFile(inputPath, buffer);
-
-  const accentHex = normalizeHex(accent);
-  const styleKey = SUPPORTED_THUMBNAIL_STYLES.has((style || "").toLowerCase())
-    ? (style || "").toLowerCase()
-    : "modern";
-  const baseFilter = [
-    "scale=1280:720:force_original_aspect_ratio=decrease",
-    `pad=1280:720:(ow-iw)/2:(oh-ih)/2:${hexToFfmpegColor("#10121a")}`,
-    "format=rgba",
-  ];
-
-  if (styleKey === "vibrant") {
-    baseFilter.push("eq=saturation=1.35:contrast=1.05");
-  } else if (styleKey === "mono") {
-    baseFilter.push("hue=s=0");
-  }
-
-  baseFilter.push(`drawbox=x=0:y=h-220:w=iw:h=220:color=${accentHex}@0.75:t=fill`);
-
-  const titleText = escapeDrawText(title || "AI Generated Cover");
-  baseFilter.push(
-    `drawtext=fontfile='${DEFAULT_FONT}':text='${titleText}':fontsize=58:fontcolor=white:shadowx=2:shadowy=2:x=(w-text_w)/2:y=h-150`
-  );
-
-  if (subtitle && subtitle.trim()) {
-    const subText = escapeDrawText(subtitle.trim());
-    baseFilter.push(
-      `drawtext=fontfile='${DEFAULT_FONT}':text='${subText}':fontsize=34:fontcolor=white@0.9:shadowx=1:shadowy=1:x=(w-text_w)/2:y=h-80`
-    );
-  }
-
-  const filter = baseFilter.join(",");
-
-  try {
-    await runFfmpeg([
-      "-y",
-      "-i", inputPath,
-      "-vf", filter,
-      "-q:v", "2",
-      outputPath,
-    ]);
-  } finally {
-    try { await fsp.unlink(inputPath); } catch {}
-  }
-
-  return {
-    ok: true,
-    url: `/public/thumbnails/${outputName}`,
-    fileName: `${sanitizeFileName(title || "cover") || "cover"}.jpg`,
-  };
 };
 
 const validateConvertPayload = (payload = {}) => {
@@ -630,51 +329,6 @@ const runFfmpeg = (args) => new Promise((resolve, reject) => {
     }
   });
 });
-
-const runFfprobe = (args) => new Promise((resolve, reject) => {
-  const ff = spawn(ffprobePath || "ffprobe", args, { stdio: ["ignore", "pipe", "pipe"] });
-  let stdout = "";
-  let stderr = "";
-  ff.stdout.on("data", (d) => (stdout += d.toString()));
-  ff.stderr.on("data", (d) => (stderr += d.toString()));
-  ff.on("error", (err) => {
-    const error = new Error(err.code === "ENOENT" ? "ffprobe tidak ditemukan" : err.message || "ffprobe gagal");
-    error.logs = stderr;
-    reject(error);
-  });
-  ff.on("close", (code) => {
-    if (code === 0) resolve(stdout);
-    else {
-      const error = new Error(`ffprobe exit ${code}`);
-      error.logs = stderr;
-      reject(error);
-    }
-  });
-});
-
-const probeAudioStream = async (inputPath) => {
-  try {
-    const output = await runFfprobe([
-      "-v",
-      "error",
-      "-select_streams",
-      "a:0",
-      "-show_entries",
-      "stream=channels,channel_layout",
-      "-of",
-      "json",
-      inputPath,
-    ]);
-    const data = JSON.parse(output || "{}") || {};
-    const stream = Array.isArray(data.streams) ? data.streams[0] : data.stream || {};
-    const channels = Number(stream?.channels) || 0;
-    const channelLayout = typeof stream?.channel_layout === "string" ? stream.channel_layout : null;
-    return { channels, channelLayout };
-  } catch (err) {
-    console.warn("ffprobe gagal membaca informasi audio", err?.message || err);
-    return { channels: 0, channelLayout: null };
-  }
-};
 
 const vttToSrt = (input = "") => {
   const clean = (input || "").replace(/^WEBVTT.*\n+/i, "").replace(/\r/g, "");
@@ -1414,110 +1068,6 @@ app.post("/api/ai-tags", (req, res) => {
   } catch (e) {
     const msg = e?.message || "Gagal membuat tag";
     return res.status(400).json({ error: msg });
-  }
-});
-
-app.post("/api/thumbnail", async (req, res) => {
-  try {
-    const result = await generateThumbnailArt(req.body || {});
-    return res.json(result);
-  } catch (e) {
-    const msg = e?.message || "Gagal membuat thumbnail";
-    const status = Number.isInteger(e?.statusCode)
-      ? e.statusCode
-      : /tidak valid|tidak ditemukan/i.test(msg)
-        ? 400
-        : 500;
-    return res.status(status).json({ error: msg, logs: e?.logs });
-  }
-});
-
-app.post("/api/stems", async (req, res) => {
-  try {
-    const body = req.body || {};
-    let sourcePath = null;
-    let baseName = body.baseName;
-    if (body.downloadUrl) {
-      sourcePath = resolvePublicPath(body.downloadUrl);
-      if (!sourcePath) throw new Error("downloadUrl tidak valid");
-      baseName = baseName || basename(sourcePath).replace(/\.[^.]+$/, "");
-    } else if (body.jobId) {
-      const job = backgroundJobs.get(body.jobId);
-      if (!job || job.status !== "done") throw new Error("Job belum selesai");
-      sourcePath = resolveJobFilePath(job);
-      if (!sourcePath) throw new Error("File job tidak ditemukan");
-      baseName = baseName || job.result?.baseName || job.result?.fileName;
-    } else if (body.url) {
-      const convertPayload = { ...body };
-      delete convertPayload.jobId;
-      delete convertPayload.downloadUrl;
-      delete convertPayload.baseName;
-      const convertResult = await convertSingle({ ...convertPayload, format: body.format || "wav", noPlaylist: true });
-      sourcePath = convertResult.fullPath;
-      baseName = baseName || convertResult.baseName || convertResult.fileName;
-    } else {
-      return res.status(400).json({ error: "Perlu url, jobId, atau downloadUrl" });
-    }
-    if (!sourcePath) throw new Error("Sumber audio tidak ditemukan");
-    const result = await createStemsForSource(sourcePath, baseName);
-    if (!result.source && sourcePath.startsWith(JOBS_DIR)) {
-      const diskName = basename(sourcePath);
-      result.source = {
-        downloadUrl: `/public/jobs/${diskName}`,
-        fileName: `${sanitizeFileName(baseName || "Audio") || "Audio"}.${diskName.split(".").pop()}`,
-      };
-    }
-    return res.json(result);
-  } catch (e) {
-    const msg = e?.message || "Gagal membuat stems";
-    const status = /tidak valid|belum|perlu|tidak ditemukan/i.test(msg) ? 400 : 500;
-    return res.status(status).json({ error: msg, logs: e?.logs });
-  }
-});
-
-app.post("/api/cloud/save", async (req, res) => {
-  try {
-    const body = req.body || {};
-    const targetKey = typeof body.target === "string" ? body.target.toLowerCase() : "drive";
-    const target = CLOUD_TARGETS[targetKey];
-    if (!target) return res.status(400).json({ error: "Target cloud tidak dikenali" });
-
-    let sourcePath = null;
-    let fileName = typeof body.fileName === "string" && body.fileName.trim()
-      ? sanitizeFileName(body.fileName.trim())
-      : null;
-
-    if (body.jobId) {
-      const job = backgroundJobs.get(body.jobId);
-      if (!job || job.status !== "done") throw new Error("Job belum selesai");
-      sourcePath = resolveJobFilePath(job);
-      if (!sourcePath) throw new Error("File job tidak ditemukan");
-      if (!fileName) fileName = job.result?.fileName || job.result?.baseName;
-    } else if (body.downloadUrl) {
-      sourcePath = resolvePublicPath(body.downloadUrl);
-      if (!sourcePath) throw new Error("downloadUrl tidak valid");
-      if (!fileName) fileName = basename(sourcePath);
-    } else {
-      return res.status(400).json({ error: "Perlu jobId atau downloadUrl" });
-    }
-
-    if (!sourcePath) throw new Error("Sumber file tidak ditemukan");
-
-    const finalName = ensureUniqueFileName(target.dir, sanitizeFileName(fileName) || basename(sourcePath));
-    const destPath = join(target.dir, finalName);
-    await fsp.copyFile(sourcePath, destPath);
-
-    return res.json({
-      ok: true,
-      target: targetKey,
-      label: target.label,
-      downloadUrl: `/public/cloud/${targetKey}/${finalName}`,
-      fileName: finalName,
-    });
-  } catch (e) {
-    const msg = e?.message || "Gagal menyimpan ke cloud";
-    const status = /tidak valid|perlu|belum|tidak ditemukan/i.test(msg) ? 400 : 500;
-    return res.status(status).json({ error: msg, logs: e?.logs });
   }
 });
 

--- a/index.js
+++ b/index.js
@@ -217,6 +217,32 @@ const MOOD_EMOJIS = {
   Energetic: "🚀",
 };
 
+const MOOD_PLAYLIST_HINTS = {
+  Happy: ["Feel Good Hits", "Sunrise Drive"],
+  Chill: ["Focus Flow", "Coffee & Beats"],
+  Melancholy: ["Late Night Lyrics", "Deep Focus"],
+  Epic: ["Cinematic Adventure", "Boss Battle"],
+  Midnight: ["Midnight Lounge", "Night Riders"],
+  Hype: ["Beast Mode", "Workout Bangers"],
+  Calm: ["Peaceful Piano", "Sleep Tight"],
+  Energetic: ["Dance Party", "Cardio Boost"],
+};
+
+const GENRE_PLAYLIST_HINTS = {
+  "Lo-Fi": ["Lo-Fi Cafe", "Study Session"],
+  "Hip-Hop": ["Rap Radar"],
+  Trap: ["Trap Nation"],
+  EDM: ["Festival Bangers"],
+  Rock: ["Alternative Anthems"],
+  Metal: ["Heavy Rotation"],
+  Jazz: ["Late Night Jazz"],
+  Ambient: ["Deep Focus"],
+  Classical: ["Cinematic Scores"],
+  "K-Pop": ["K-Pop Now"],
+  Dangdut: ["Dangdut Hits"],
+  Pop: ["Today's Top Hits"],
+};
+
 const buildAiCaption = ({
   title = "",
   channel = "",
@@ -276,6 +302,52 @@ const buildAiCaption = ({
 
   const hashtagList = Array.from(hashtags).filter(Boolean).slice(0, 8);
   return { caption: captionLines.join("\n"), hashtags: hashtagList, tags };
+};
+
+const buildAiPitch = ({
+  title = "",
+  description = "",
+  channel = "",
+  duration,
+  genre,
+  mood,
+} = {}) => {
+  const tags = buildAiTags({ title, description, channel, duration });
+  if (genre && typeof genre === "string" && genre.trim()) tags.genre = genre.trim();
+  if (mood && typeof mood === "string" && mood.trim()) tags.mood = mood.trim();
+  const trackTitle = tags.title || title || "Track Baru";
+  const artist = tags.artist || channel || "Creator";
+  const descriptorParts = [tags.genre, tags.mood, tags.energy].filter(Boolean);
+  const descriptor = descriptorParts.length ? descriptorParts.join(" · ") : null;
+  const durationLabel = formatDurationLabel(duration);
+  const playlistHints = new Set();
+  if (tags.mood && MOOD_PLAYLIST_HINTS[tags.mood]) {
+    for (const item of MOOD_PLAYLIST_HINTS[tags.mood]) playlistHints.add(item);
+  }
+  if (tags.genre && GENRE_PLAYLIST_HINTS[tags.genre]) {
+    for (const item of GENRE_PLAYLIST_HINTS[tags.genre]) playlistHints.add(item);
+  }
+  const playlists = Array.from(playlistHints).slice(0, 4);
+  const hookMood = tags.mood ? tags.mood.toLowerCase() : "fresh";
+  const hookGenre = tags.genre ? `${tags.genre.toLowerCase()} groove` : "sonic palette";
+  const hook = `${trackTitle} menghadirkan nuansa ${hookMood} dengan ${hookGenre}${durationLabel ? ` dalam ${durationLabel}` : ""}.`;
+  const pitchLines = [];
+  if (descriptor) {
+    pitchLines.push(`${trackTitle} oleh ${artist} memadukan ${descriptor}${durationLabel ? ` sepanjang ${durationLabel}` : ""}.`);
+  } else {
+    pitchLines.push(`${trackTitle} oleh ${artist}${durationLabel ? ` (${durationLabel})` : ""}.`);
+  }
+  if (playlists.length) {
+    pitchLines.push(`Cocok untuk playlist ${playlists.join(", ")}.`);
+  } else {
+    pitchLines.push("Siap melengkapi daftar putar favoritmu.");
+  }
+  return {
+    pitch: pitchLines.join(" "),
+    hook,
+    playlists,
+    tags,
+  };
 };
 
 const validateConvertPayload = (payload = {}) => {
@@ -406,6 +478,7 @@ const serializeJob = (job) => {
     };
     if (job.result.sampleRate !== undefined) data.result.sampleRate = job.result.sampleRate;
     if (job.result.channels !== undefined) data.result.channels = job.result.channels;
+    if (job.result.speedMode) data.result.speedMode = job.result.speedMode;
   }
   return data;
 };
@@ -420,21 +493,83 @@ const resolveJobFilePath = (job) => {
 const SUPPORTED_FORMATS = new Set(["mp3", "m4a", "flac", "wav", "ogg"]);
 const VALID_SPEED_MODES = new Set(["normal", "nightcore", "slow_reverb"]);
 
-const FORMAT_PREFERRED_SAMPLE_RATES = {
-  mp3: 44100,
-  m4a: 44100,
-  flac: 48000,
-  wav: 48000,
-  ogg: 48000,
+const FORMAT_RULES = {
+  mp3: {
+    abr: [320, 256, 192, 128, 64],
+    sampleRates: [44100, 48000],
+    speedModes: ["normal", "nightcore", "slow_reverb"],
+  },
+  m4a: {
+    abr: [192],
+    sampleRates: [44100],
+    speedModes: ["normal"],
+  },
+  flac: {
+    abr: [320, 256, 192],
+    sampleRates: [96000],
+    speedModes: ["normal"],
+  },
+  wav: {
+    abr: [],
+    sampleRates: [48000, 44100, 96000],
+    speedModes: ["normal"],
+  },
+  ogg: {
+    abr: [256, 192, 160, 128],
+    sampleRates: [48000, 44100],
+    speedModes: ["normal", "nightcore"],
+  },
 };
 
-const pickFormatSampleRate = (fmt) => FORMAT_PREFERRED_SAMPLE_RATES[fmt] || 44100;
+const pickFormatSampleRate = (fmt) => {
+  const rule = FORMAT_RULES[fmt];
+  if (rule?.sampleRates?.length) return rule.sampleRates[0];
+  return 44100;
+};
+
+const sanitizeFormatOptions = (fmt, { abr, sampleRate, speedMode }) => {
+  const rule = FORMAT_RULES[fmt] || {};
+  let cleanedAbr = abr;
+  if (Array.isArray(rule.abr)) {
+    const abrNumber = Number(abr);
+    cleanedAbr = rule.abr.includes(abrNumber) ? abrNumber : (rule.abr[0] ?? null);
+    if (!rule.abr.length) cleanedAbr = null;
+  }
+
+  let cleanedSampleRate = undefined;
+  if (sampleRate !== undefined) {
+    const srNumber = parseSampleRate(sampleRate);
+    if (Array.isArray(rule.sampleRates) && rule.sampleRates.length) {
+      cleanedSampleRate = rule.sampleRates.includes(srNumber) ? srNumber : rule.sampleRates[0];
+    } else {
+      cleanedSampleRate = srNumber || undefined;
+    }
+  }
+
+  let cleanedSpeed = speedMode;
+  if (Array.isArray(rule.speedModes) && rule.speedModes.length) {
+    cleanedSpeed = rule.speedModes.includes(speedMode) ? speedMode : rule.speedModes[0];
+  }
+
+  return {
+    abr: cleanedAbr,
+    sampleRate: cleanedSampleRate,
+    speedMode: cleanedSpeed,
+  };
+};
 
 const deriveFilterSampleRate = (fmt, requested, detected) => {
   const requestedRate = parseSampleRate(requested);
-  if (requestedRate) return requestedRate;
+  const rule = FORMAT_RULES[fmt];
+  if (requestedRate) {
+    if (!rule?.sampleRates?.length || rule.sampleRates.includes(requestedRate)) return requestedRate;
+    return rule.sampleRates[0];
+  }
   const detectedRate = parseSampleRate(detected);
-  if (detectedRate) return detectedRate;
+  if (detectedRate && (!rule?.sampleRates?.length || rule.sampleRates.includes(detectedRate))) {
+    return detectedRate;
+  }
+  if (rule?.sampleRates?.length) return rule.sampleRates[0];
   return pickFormatSampleRate(fmt);
 };
 
@@ -662,7 +797,7 @@ const ffmpegToFlac = (input, output, opts = {}) => {
 };
 
 const ffmpegToM4a = (input, output, opts = {}) => {
-  const { id3 = {}, trim = {}, sampleRate, cover, filters = [] } = opts;
+  const { id3 = {}, trim = {}, sampleRate, cover, filters = [], abr = 192 } = opts;
   return new Promise((resolve, reject) => {
     const args = ["-y"];
     const { start, end } = trim || {};
@@ -693,7 +828,8 @@ const ffmpegToM4a = (input, output, opts = {}) => {
     } else {
       args.push("-map","0:a","-vn");
     }
-    args.push("-codec:a","aac","-b:a","192k", output);
+    const targetAbr = Number(abr) || 192;
+    args.push("-codec:a","aac","-b:a",`${targetAbr}k`, output);
     const ff = spawn(ffmpegPath || "ffmpeg", args, { stdio: ["ignore", "pipe", "pipe"] });
     let logs = "";
     ff.stdout.on("data", (d) => (logs += d.toString()));
@@ -902,6 +1038,11 @@ const convertSingle = async (payload = {}) => {
     }
   }
 
+  const sanitizedOptions = sanitizeFormatOptions(fmt, { abr, sampleRate: sr, speedMode });
+  const effectiveSpeedMode = sanitizedOptions.speedMode || "normal";
+  const targetAbr = sanitizedOptions.abr != null ? sanitizedOptions.abr : (fmt === "mp3" ? Number(abr) || 192 : null);
+  sr = sanitizedOptions.sampleRate !== undefined ? sanitizedOptions.sampleRate : sr;
+
   let trimOpt = null;
   if (trim && (trim.start !== undefined || trim.end !== undefined)) {
     const hasStart = trim.start !== undefined;
@@ -945,12 +1086,14 @@ const convertSingle = async (payload = {}) => {
   if (atmos) args.push("-f", "bestaudio[channels>2]/bestaudio");
   args.push("-o", outTpl);
 
+  const sanitizedAbrForDownload = targetAbr || Number(abr) || undefined;
+
   if (fmt === "m4a") {
     args.push("-f", "bestaudio[ext=m4a]/bestaudio");
   } else if (fmt === "flac") {
     args.push("-x", "--audio-format", "flac");
   } else if (fmt === "mp3") {
-    args.push("-x", "--audio-format", "mp3", "--audio-quality", abrToQ(abr));
+    args.push("-x", "--audio-format", "mp3", "--audio-quality", abrToQ(sanitizedAbrForDownload));
   } else if (fmt === "wav") {
     args.push("-x", "--audio-format", "wav");
   } else if (fmt === "ogg") {
@@ -985,7 +1128,7 @@ const convertSingle = async (payload = {}) => {
   const filterSampleRate = deriveFilterSampleRate(fmt, sr, detectedSampleRate);
   const filters = buildAudioFilters({
     normalize,
-    speedMode,
+    speedMode: effectiveSpeedMode,
     denoise: denoiseEnabled,
     volumeBoost: boostValue,
     enhancer: enhancerMode,
@@ -997,15 +1140,30 @@ const convertSingle = async (payload = {}) => {
     if (v !== undefined && v !== null && String(v).trim() !== "") acc[k] = v;
     return acc;
   }, {});
+  if (!id3Clean.genre) {
+    const autoGenre = buildAiTags({
+      title: id3Clean.title || baseName,
+      channel: id3Clean.artist || "",
+    }).genre;
+    if (autoGenre) id3Clean.genre = autoGenre;
+  }
   const hasId3 = Object.keys(id3Clean).length > 0;
   const hasTrim = !!trimOpt && Object.keys(trimOpt).length > 0;
   const hasFilters = filters.length > 0;
   const hasCover = !!coverPath;
-  const needSampleRate = sr !== undefined;
+  const rule = FORMAT_RULES[fmt];
+  const detectedRate = parseSampleRate(detectedSampleRate);
+  const needSampleRate = sr !== undefined || (!!rule?.sampleRates?.length && !rule.sampleRates.includes(detectedRate));
+  const finalSamplePreference = sr !== undefined ? sr : (needSampleRate ? filterSampleRate : undefined);
 
   const finalize = async (targetExt, converter, extraOpts = {}) => {
     const tmpOut = join(JOBS_DIR, `${id}.tmp.${targetExt}`);
-    await converter(fullPath, tmpOut, { ...extraOpts, trim: trimOpt || {}, sampleRate: sr, filters });
+    await converter(fullPath, tmpOut, {
+      ...extraOpts,
+      trim: trimOpt || {},
+      sampleRate: finalSamplePreference,
+      filters,
+    });
     await fsp.unlink(fullPath);
     filename = `${id}.${targetExt}`;
     fullPath = join(JOBS_DIR, filename);
@@ -1017,7 +1175,7 @@ const convertSingle = async (payload = {}) => {
     if (fmt === "mp3") {
       const needConvert = ext !== "mp3" || hasId3 || hasTrim || hasFilters || hasCover || needSampleRate;
       if (needConvert) {
-        await finalize("mp3", ffmpegToMp3, { abr, id3: id3Clean, cover: coverPath });
+        await finalize("mp3", ffmpegToMp3, { abr: targetAbr || 192, id3: id3Clean, cover: coverPath });
       }
     } else if (fmt === "flac") {
       const needConvert = ext !== "flac" || hasId3 || hasTrim || hasFilters || hasCover || needSampleRate;
@@ -1027,7 +1185,7 @@ const convertSingle = async (payload = {}) => {
     } else if (fmt === "m4a") {
       const needConvert = ext !== "m4a" || hasId3 || hasTrim || hasFilters || hasCover || needSampleRate;
       if (needConvert) {
-        await finalize("m4a", ffmpegToM4a, { id3: id3Clean, cover: coverPath });
+        await finalize("m4a", ffmpegToM4a, { id3: id3Clean, cover: coverPath, abr: targetAbr || 192 });
       }
     } else if (fmt === "wav") {
       const needConvert = ext !== "wav" || hasTrim || hasFilters || needSampleRate;
@@ -1052,8 +1210,8 @@ const convertSingle = async (payload = {}) => {
   const downloadUrl = `/public/jobs/${filename}`;
   const finalExt = ext;
   const downloadFileName = `${baseName}.${finalExt}`;
-  const finalSampleRate = sr
-    ? Math.round(sr)
+  const finalSampleRate = finalSamplePreference
+    ? Math.round(finalSamplePreference)
     : (filters.some((f) => /^aresample=/.test(f)) ? filterSampleRate : detectedSampleRate) || null;
   return {
     ok: true,
@@ -1067,6 +1225,7 @@ const convertSingle = async (payload = {}) => {
     ext: finalExt,
     sampleRate: finalSampleRate,
     channels: audioProbe?.channels || null,
+    speedMode: effectiveSpeedMode,
   };
 };
 
@@ -1271,6 +1430,30 @@ app.post("/api/ai-caption", (req, res) => {
     return res.json({ ok: true, caption: result.caption, hashtags: result.hashtags, tags: result.tags });
   } catch (e) {
     const msg = e?.message || "Gagal membuat caption";
+    return res.status(400).json({ error: msg });
+  }
+});
+
+app.post("/api/ai-pitch", (req, res) => {
+  try {
+    const body = req.body || {};
+    const result = buildAiPitch({
+      title: body.title,
+      description: body.description,
+      channel: body.channel,
+      duration: body.duration,
+      genre: body.genre,
+      mood: body.mood,
+    });
+    return res.json({
+      ok: true,
+      pitch: result.pitch,
+      hook: result.hook,
+      playlists: result.playlists,
+      tags: result.tags,
+    });
+  } catch (e) {
+    const msg = e?.message || "Gagal membuat pitch";
     return res.status(400).json({ error: msg });
   }
 });

--- a/index.js
+++ b/index.js
@@ -14,6 +14,13 @@ try {
   ffmpegPath = null;
 }
 
+let ffprobePath = null;
+try {
+  ffprobePath = (await import("ffprobe-static")).path;
+} catch {
+  ffprobePath = null;
+}
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = dirname(__filename);
 
@@ -56,6 +63,14 @@ const sanitizeFileName = (name = "") =>
 
 const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
 
+const toPositiveInt = (value) => {
+  const num = Number(value);
+  if (!Number.isFinite(num) || num <= 0) return null;
+  return Math.round(num);
+};
+
+const parseSampleRate = (value) => toPositiveInt(value);
+
 const resolvePublicPath = (urlPath = "") => {
   if (typeof urlPath !== "string") return null;
   const cleaned = urlPath.replace(/\\/g, "/").trim();
@@ -64,6 +79,43 @@ const resolvePublicPath = (urlPath = "") => {
   const fullPath = pathResolve(PUBLIC_ROOT, relative);
   if (!fullPath.startsWith(PUBLIC_ROOT)) return null;
   return fullPath;
+};
+
+const probeAudioStream = async (inputPath) => {
+  if (!inputPath) return null;
+  const args = [
+    "-v",
+    "error",
+    "-select_streams",
+    "a:0",
+    "-show_entries",
+    "stream=sample_rate,channels",
+    "-of",
+    "json",
+    inputPath,
+  ];
+  return await new Promise((resolve) => {
+    const ffprobeBin = ffprobePath || "ffprobe";
+    const proc = spawn(ffprobeBin, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let output = "";
+    proc.stdout.on("data", (d) => {
+      output += d.toString();
+    });
+    proc.on("error", () => resolve(null));
+    proc.on("close", (code) => {
+      if (code !== 0) return resolve(null);
+      try {
+        const json = JSON.parse(output || "{}");
+        const stream = Array.isArray(json.streams) ? json.streams[0] : null;
+        if (!stream) return resolve(null);
+        const sampleRate = parseSampleRate(stream.sample_rate);
+        const channels = toPositiveInt(stream.channels);
+        resolve({ sampleRate, channels });
+      } catch {
+        resolve(null);
+      }
+    });
+  });
 };
 
 const GENRE_KEYWORDS = [
@@ -127,6 +179,103 @@ const buildAiTags = ({ title = "", description = "", channel = "", duration } = 
   if (year) tags.year = year;
   tags.comment = `AI tags · ${genre} · ${mood}${year ? ` · ${year}` : ""}`;
   return tags;
+};
+
+const formatDurationLabel = (seconds) => {
+  const value = Number(seconds);
+  if (!Number.isFinite(value) || value <= 0) return null;
+  if (value < 60) return `${Math.round(value)}s`;
+  const minutes = Math.floor(value / 60);
+  const secs = Math.round(value % 60);
+  if (minutes >= 60) {
+    const hours = Math.floor(minutes / 60);
+    const mins = minutes % 60;
+    return `${hours}h${mins ? ` ${mins}m` : ""}`.trim();
+  }
+  return `${minutes}m${secs ? ` ${secs}s` : ""}`.trim();
+};
+
+const slugifyTag = (value) => {
+  if (!value) return null;
+  const slug = value
+    .toString()
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "");
+  return slug || null;
+};
+
+const MOOD_EMOJIS = {
+  Happy: "😊",
+  Chill: "😌",
+  Melancholy: "💜",
+  Epic: "🔥",
+  Midnight: "🌙",
+  Hype: "⚡️",
+  Calm: "🌿",
+  Energetic: "🚀",
+};
+
+const buildAiCaption = ({
+  title = "",
+  channel = "",
+  duration,
+  speedMode = "normal",
+  denoise = false,
+  volumeBoost = 0,
+  enhancer = "none",
+  format = "",
+} = {}) => {
+  const tags = buildAiTags({ title, channel, duration });
+  const trackTitle = tags.title || title || "Track Baru";
+  const artist = tags.artist || channel || "Creator";
+  const moodEmoji = MOOD_EMOJIS[tags.mood] || "🎧";
+  const detailParts = [];
+  if (tags.genre) detailParts.push(tags.genre);
+  if (tags.mood) detailParts.push(tags.mood);
+  if (tags.energy) detailParts.push(tags.energy);
+  const durationLabel = formatDurationLabel(duration);
+  if (durationLabel) detailParts.push(durationLabel);
+
+  const tweaks = [];
+  if (speedMode === "nightcore") tweaks.push("Nightcore tempo");
+  else if (speedMode === "slow_reverb") tweaks.push("Slowed + reverb vibes");
+  if (denoise) tweaks.push("Noise cleaned");
+  const boostVal = Number(volumeBoost);
+  if (Number.isFinite(boostVal) && boostVal > 0) tweaks.push(`+${boostVal} dB boost`);
+  if (enhancer && enhancer !== "none") {
+    const enhancerLabels = {
+      clarity: "Clarity enhancer",
+      warm: "Warm tone",
+      club: "Club lift",
+    };
+    tweaks.push(enhancerLabels[enhancer] || `Enhancer: ${enhancer}`);
+  }
+
+  const captionLines = [`${moodEmoji} ${trackTitle} — ${artist}`];
+  if (detailParts.length) captionLines.push(detailParts.join(" · "));
+  if (tweaks.length) captionLines.push(`Tweak: ${tweaks.join(", ")}`);
+  captionLines.push("Scan QR di web atau klik link buat dengar sekarang.");
+
+  const hashtags = new Set(["#music"]);
+  const pushTag = (value) => {
+    const slug = slugifyTag(value);
+    if (!slug) return;
+    hashtags.add(`#${slug}`);
+  };
+
+  [tags.genre, tags.mood, tags.energy, artist, format].forEach(pushTag);
+  if (speedMode === "nightcore") hashtags.add("#nightcore");
+  else if (speedMode === "slow_reverb") hashtags.add("#slowedreverb");
+  if (denoise) hashtags.add("#noiseclean");
+  if (boostVal > 0) hashtags.add("#volumeboost");
+
+  const titleParts = trackTitle.split(/\s+/).slice(0, 2);
+  titleParts.forEach(pushTag);
+
+  const hashtagList = Array.from(hashtags).filter(Boolean).slice(0, 8);
+  return { caption: captionLines.join("\n"), hashtags: hashtagList, tags };
 };
 
 const validateConvertPayload = (payload = {}) => {
@@ -218,6 +367,8 @@ const processBackgroundQueue = async () => {
         format: result.format,
         baseName: result.baseName,
         ext: result.ext,
+        sampleRate: result.sampleRate,
+        channels: result.channels,
       };
       if (result.fullPath) job.result.fullPath = result.fullPath;
       job.logs = (result.logs || "").slice(-8000);
@@ -253,6 +404,8 @@ const serializeJob = (job) => {
       baseName: job.result.baseName,
       ext: job.result.ext,
     };
+    if (job.result.sampleRate !== undefined) data.result.sampleRate = job.result.sampleRate;
+    if (job.result.channels !== undefined) data.result.channels = job.result.channels;
   }
   return data;
 };
@@ -267,6 +420,24 @@ const resolveJobFilePath = (job) => {
 const SUPPORTED_FORMATS = new Set(["mp3", "m4a", "flac", "wav", "ogg"]);
 const VALID_SPEED_MODES = new Set(["normal", "nightcore", "slow_reverb"]);
 
+const FORMAT_PREFERRED_SAMPLE_RATES = {
+  mp3: 44100,
+  m4a: 44100,
+  flac: 48000,
+  wav: 48000,
+  ogg: 48000,
+};
+
+const pickFormatSampleRate = (fmt) => FORMAT_PREFERRED_SAMPLE_RATES[fmt] || 44100;
+
+const deriveFilterSampleRate = (fmt, requested, detected) => {
+  const requestedRate = parseSampleRate(requested);
+  if (requestedRate) return requestedRate;
+  const detectedRate = parseSampleRate(detected);
+  if (detectedRate) return detectedRate;
+  return pickFormatSampleRate(fmt);
+};
+
 const buildAudioFilters = ({
   normalize = false,
   speedMode = "normal",
@@ -274,14 +445,18 @@ const buildAudioFilters = ({
   volumeBoost = 0,
   enhancer = "none",
   sampleRate,
+  sourceSampleRate,
 } = {}) => {
   const filters = [];
-  const srValue = Number(sampleRate);
-  const baseSampleRate = Number.isFinite(srValue) && srValue > 0 ? Math.round(srValue) : null;
+  const baseSampleRate =
+    parseSampleRate(sampleRate) ||
+    parseSampleRate(sourceSampleRate) ||
+    44100;
   if (speedMode && speedMode !== "normal") {
     if (speedMode === "nightcore") {
       const refSampleRate = baseSampleRate || 44100;
-      filters.push(`asetrate=${refSampleRate}*1.25`, `aresample=${refSampleRate}`);
+      const boosted = Math.max(8000, Math.round(refSampleRate * 1.25));
+      filters.push(`asetrate=${boosted}`, `aresample=${refSampleRate}`);
     } else if (speedMode === "slow_reverb") {
       filters.push("atempo=0.85", "aecho=0.6:0.6:1000:0.25");
     }
@@ -759,15 +934,6 @@ const convertSingle = async (payload = {}) => {
     } catch {}
   }
 
-  const filters = buildAudioFilters({
-    normalize,
-    speedMode,
-    denoise: denoiseEnabled,
-    volumeBoost: boostValue,
-    enhancer: enhancerMode,
-    sampleRate: sr,
-  });
-
   const args = ["--newline", "--no-progress"];
   if (ffmpegPath) {
     args.push("--ffmpeg-location", ffmpegPath);
@@ -813,6 +979,19 @@ const convertSingle = async (payload = {}) => {
 
   let { filename, fullPath, ext } = downloadResult;
   logs = downloadResult.logs || logs;
+
+  const audioProbe = await probeAudioStream(fullPath).catch(() => null);
+  const detectedSampleRate = audioProbe?.sampleRate;
+  const filterSampleRate = deriveFilterSampleRate(fmt, sr, detectedSampleRate);
+  const filters = buildAudioFilters({
+    normalize,
+    speedMode,
+    denoise: denoiseEnabled,
+    volumeBoost: boostValue,
+    enhancer: enhancerMode,
+    sampleRate: filterSampleRate,
+    sourceSampleRate: detectedSampleRate,
+  });
 
   const id3Clean = Object.entries(id3 || {}).reduce((acc, [k, v]) => {
     if (v !== undefined && v !== null && String(v).trim() !== "") acc[k] = v;
@@ -873,6 +1052,9 @@ const convertSingle = async (payload = {}) => {
   const downloadUrl = `/public/jobs/${filename}`;
   const finalExt = ext;
   const downloadFileName = `${baseName}.${finalExt}`;
+  const finalSampleRate = sr
+    ? Math.round(sr)
+    : (filters.some((f) => /^aresample=/.test(f)) ? filterSampleRate : detectedSampleRate) || null;
   return {
     ok: true,
     id,
@@ -883,6 +1065,8 @@ const convertSingle = async (payload = {}) => {
     baseName,
     fullPath,
     ext: finalExt,
+    sampleRate: finalSampleRate,
+    channels: audioProbe?.channels || null,
   };
 };
 
@@ -1067,6 +1251,26 @@ app.post("/api/ai-tags", (req, res) => {
     return res.json({ ok: true, tags });
   } catch (e) {
     const msg = e?.message || "Gagal membuat tag";
+    return res.status(400).json({ error: msg });
+  }
+});
+
+app.post("/api/ai-caption", (req, res) => {
+  try {
+    const body = req.body || {};
+    const result = buildAiCaption({
+      title: body.title,
+      channel: body.channel,
+      duration: body.duration,
+      speedMode: body.speedMode,
+      denoise: body.denoise,
+      volumeBoost: body.volumeBoost,
+      enhancer: body.enhancer,
+      format: body.format,
+    });
+    return res.json({ ok: true, caption: result.caption, hashtags: result.hashtags, tags: result.tags });
+  } catch (e) {
+    const msg = e?.message || "Gagal membuat caption";
     return res.status(400).json({ error: msg });
   }
 });

--- a/index.js
+++ b/index.js
@@ -534,11 +534,15 @@ const buildAudioFilters = ({
   denoise = false,
   volumeBoost = 0,
   enhancer = "none",
+  sampleRate,
 } = {}) => {
   const filters = [];
+  const srValue = Number(sampleRate);
+  const baseSampleRate = Number.isFinite(srValue) && srValue > 0 ? Math.round(srValue) : null;
   if (speedMode && speedMode !== "normal") {
     if (speedMode === "nightcore") {
-      filters.push("asetrate=sample_rate*1.25", "aresample=sample_rate");
+      const refSampleRate = baseSampleRate || 44100;
+      filters.push(`asetrate=${refSampleRate}*1.25`, `aresample=${refSampleRate}`);
     } else if (speedMode === "slow_reverb") {
       filters.push("atempo=0.85", "aecho=0.6:0.6:1000:0.25");
     }
@@ -1022,6 +1026,7 @@ const convertSingle = async (payload = {}) => {
     denoise: denoiseEnabled,
     volumeBoost: boostValue,
     enhancer: enhancerMode,
+    sampleRate: sr,
   });
 
   const args = ["--newline", "--no-progress"];

--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -162,6 +162,7 @@
                   <option value="128">128 kbps</option>
                   <option value="64">64 kbps</option>
                 </select>
+                <div class="form-text" id="abrHelp">Pilih kualitas sesuai format.</div>
               </div>
               <div class="col-md-3">
                 <label for="sampleRate" class="form-label">Sample Rate</label>
@@ -170,6 +171,7 @@
                   <option value="48000">48 kHz</option>
                   <option value="96000">96 kHz (Hi-Res)</option>
                 </select>
+                <div class="form-text" id="sampleRateHelp">Sesuaikan dengan kebutuhan.</div>
               </div>
               <div class="col-md-3">
                 <label for="speedMode" class="form-label">Mode Kecepatan</label>
@@ -178,6 +180,7 @@
                   <option value="nightcore">Nightcore ⚡</option>
                   <option value="slow_reverb">Slowed + Reverb</option>
                 </select>
+                <div class="form-text" id="speedHelp">Beberapa format mungkin membatasi pilihan.</div>
               </div>
             </div>
 
@@ -231,7 +234,8 @@
               <label class="form-label">Metadata ID3</label>
               <input id="id3Title" type="text" class="form-control mb-2" placeholder="Judul" />
               <input id="id3Artist" type="text" class="form-control mb-2" placeholder="Artis" />
-              <input id="id3Album" type="text" class="form-control" placeholder="Album" />
+              <input id="id3Album" type="text" class="form-control mb-2" placeholder="Album" />
+              <input id="id3Genre" type="text" class="form-control" placeholder="Genre" />
             </div>
 
             <div class="form-check form-switch mb-3">
@@ -296,6 +300,7 @@
                 <div class="d-grid d-sm-flex gap-2">
                   <button class="btn btn-outline-primary flex-grow-1" id="autoTagBtn" type="button"><i class="bi bi-stars"></i> Auto Music Tags</button>
                   <button class="btn btn-outline-secondary flex-grow-1" id="aiCaptionBtn" type="button"><i class="bi bi-megaphone"></i> AI Caption Sosial</button>
+                  <button class="btn btn-outline-success flex-grow-1" id="aiPitchBtn" type="button"><i class="bi bi-broadcast"></i> AI Playlist Pitch</button>
                 </div>
                 <div class="mt-3" id="aiCaptionWrap" hidden>
                   <label for="aiCaptionText" class="form-label small text-uppercase text-secondary">Caption &amp; Hashtag</label>
@@ -304,6 +309,15 @@
                     <button class="btn btn-outline-secondary" id="aiCaptionCopy" type="button" aria-label="Salin caption"><i class="bi bi-clipboard"></i></button>
                   </div>
                   <div class="small text-secondary mt-2" id="aiCaptionMeta"></div>
+                </div>
+                <div class="mt-3" id="aiPitchWrap" hidden>
+                  <label for="aiPitchText" class="form-label small text-uppercase text-secondary">Playlist Pitch</label>
+                  <div class="input-group input-group-sm">
+                    <textarea id="aiPitchText" class="form-control" rows="3" readonly spellcheck="false"></textarea>
+                    <button class="btn btn-outline-secondary" id="aiPitchCopy" type="button" aria-label="Salin pitch"><i class="bi bi-clipboard"></i></button>
+                  </div>
+                  <div class="small text-secondary mt-2" id="aiPitchHook"></div>
+                  <div class="small text-secondary" id="aiPitchPlaylists"></div>
                 </div>
                 <div class="alert alert-info mt-3 small" id="aiStatus" hidden></div>
               </div>
@@ -661,6 +675,12 @@
   const aiCaptionText = $('#aiCaptionText');
   const aiCaptionCopy = $('#aiCaptionCopy');
   const aiCaptionMeta = $('#aiCaptionMeta');
+  const aiPitchBtn = $('#aiPitchBtn');
+  const aiPitchWrap = $('#aiPitchWrap');
+  const aiPitchText = $('#aiPitchText');
+  const aiPitchCopy = $('#aiPitchCopy');
+  const aiPitchHook = $('#aiPitchHook');
+  const aiPitchPlaylists = $('#aiPitchPlaylists');
   const playlistResultWrap = $('#playlistResultWrap');
   const playlistDownloadLink = $('#playlistDownloadLink');
   const playlistInfo = $('#playlistInfo');
@@ -691,6 +711,17 @@
   const subtitleShareBtn = $('#subtitleShareBtn');
   const subtitleStatus = $('#subtitleStatus');
   const subtitleBtnDefault = subtitleBtn ? subtitleBtn.innerHTML : '';
+  const formatSelect = $('#format');
+  const abrSelect = $('#abr');
+  const sampleRateSelect = $('#sampleRate');
+  const speedModeSelect = $('#speedMode');
+  const abrHelp = $('#abrHelp');
+  const sampleRateHelp = $('#sampleRateHelp');
+  const speedHelp = $('#speedHelp');
+  const abrLabel = document.querySelector('label[for="abr"]');
+  const sampleRateLabel = document.querySelector('label[for="sampleRate"]');
+  const speedLabel = document.querySelector('label[for="speedMode"]');
+  const id3Genre = $('#id3Genre');
 
   const storage = {
     get k(){ return 'ytmp3.settings.v1'; },
@@ -701,6 +732,105 @@
   const state = {
     backendUrl: '',
     adminBearer: ''
+  };
+
+  const FORMAT_POLICIES = {
+    mp3: {
+      labelAbr: 'Kualitas (MP3)',
+      labelSampleRate: 'Sample Rate (MP3)',
+      labelSpeed: 'Mode Kecepatan',
+      abr: ['320', '256', '192', '128', '64'],
+      abrHint: 'Pilih 64–320 kbps.',
+      sampleRates: ['44100', '48000'],
+      sampleRateHint: '44.1 kHz atau 48 kHz.',
+      speedModes: ['normal', 'nightcore', 'slow_reverb'],
+      speedHint: 'Semua mode tersedia.',
+    },
+    m4a: {
+      labelAbr: 'Kualitas (M4A)',
+      labelSampleRate: 'Sample Rate (M4A)',
+      labelSpeed: 'Mode Kecepatan',
+      abr: ['192'],
+      abrHint: 'Terkunci di 192 kbps.',
+      sampleRates: ['44100'],
+      sampleRateHint: 'Hanya 44.1 kHz.',
+      speedModes: ['normal'],
+      speedHint: 'Nightcore & Slowed dinonaktifkan.',
+    },
+    flac: {
+      labelAbr: 'Kualitas (FLAC)',
+      labelSampleRate: 'Sample Rate (FLAC)',
+      labelSpeed: 'Mode Kecepatan',
+      abr: ['320', '256', '192'],
+      abrHint: 'Rentang 192–320 kbps untuk tagging.',
+      sampleRates: ['96000'],
+      sampleRateHint: 'Hi-Res 96 kHz.',
+      speedModes: ['normal'],
+      speedHint: 'Gunakan playback normal untuk lossless.',
+    },
+    wav: {
+      labelAbr: 'Kualitas (WAV)',
+      labelSampleRate: 'Sample Rate (WAV)',
+      labelSpeed: 'Mode Kecepatan',
+      abr: [],
+      abrHint: 'Bitrate tidak berlaku untuk WAV.',
+      sampleRates: ['48000', '44100', '96000'],
+      sampleRateHint: '48 kHz default (bisa 44.1 / 96 kHz).',
+      speedModes: ['normal'],
+      speedHint: 'Tidak ada pengubah kecepatan.',
+    },
+    ogg: {
+      labelAbr: 'Kualitas (OGG)',
+      labelSampleRate: 'Sample Rate (OGG)',
+      labelSpeed: 'Mode Kecepatan',
+      abr: ['256', '192', '160', '128'],
+      abrHint: 'Pilih 128–256 kbps.',
+      sampleRates: ['48000', '44100'],
+      sampleRateHint: '44.1 kHz atau 48 kHz.',
+      speedModes: ['normal', 'nightcore'],
+      speedHint: 'Nightcore tersedia, Slowed dimatikan.',
+    },
+  };
+
+  const updateSelectForPolicy = (select, allowedValues) => {
+    if (!select) return null;
+    const options = Array.from(select.options);
+    const allowed = Array.isArray(allowedValues) ? allowedValues.map(String) : null;
+    let fallback = allowed && allowed.length ? allowed[0] : (options[0]?.value || '');
+    options.forEach((opt) => {
+      const isAllowed = !allowed || !allowed.length || allowed.includes(opt.value);
+      opt.disabled = !isAllowed;
+    });
+    if (allowed) {
+      if (!allowed.length) {
+        select.disabled = true;
+      } else {
+        select.disabled = allowed.length <= 1;
+        if (!allowed.includes(select.value)) select.value = allowed[0];
+      }
+    } else {
+      select.disabled = false;
+    }
+    if (!select.value) select.value = fallback;
+    return select.value;
+  };
+
+  const applyFormatPolicy = () => {
+    if (!formatSelect) return;
+    const fmt = formatSelect.value || 'mp3';
+    const policy = FORMAT_POLICIES[fmt] || FORMAT_POLICIES.mp3;
+    if (abrLabel && policy.labelAbr) abrLabel.textContent = policy.labelAbr;
+    if (sampleRateLabel && policy.labelSampleRate) sampleRateLabel.textContent = policy.labelSampleRate;
+    if (speedLabel && policy.labelSpeed) speedLabel.textContent = policy.labelSpeed;
+    updateSelectForPolicy(abrSelect, policy.abr);
+    if (abrHelp) abrHelp.textContent = policy.abrHint || '';
+    updateSelectForPolicy(sampleRateSelect, policy.sampleRates);
+    if (sampleRateHelp) sampleRateHelp.textContent = policy.sampleRateHint || '';
+    const appliedSpeed = updateSelectForPolicy(speedModeSelect, policy.speedModes);
+    if (speedHelp) speedHelp.textContent = policy.speedHint || '';
+    if (speedModeSelect && appliedSpeed && policy.speedModes?.length === 1) {
+      speedModeSelect.value = policy.speedModes[0];
+    }
   };
 
   let audioCtx = null;
@@ -771,6 +901,13 @@
     if (aiCaptionWrap) aiCaptionWrap.hidden = true;
     if (aiCaptionText) aiCaptionText.value = '';
     if (aiCaptionMeta) aiCaptionMeta.textContent = '';
+  };
+
+  const resetAiPitch = () => {
+    if (aiPitchWrap) aiPitchWrap.hidden = true;
+    if (aiPitchText) aiPitchText.value = '';
+    if (aiPitchHook) aiPitchHook.textContent = '';
+    if (aiPitchPlaylists) aiPitchPlaylists.textContent = '';
   };
 
   const updateBackendBadge = () => {
@@ -885,6 +1022,7 @@
     lastPreviewMeta = {};
     updateAiStatus('');
     resetAiCaption();
+    resetAiPitch();
     if (equalizerWrap) equalizerWrap.hidden = true;
     if (eqBass) eqBass.value = 0;
     if (eqMid) eqMid.value = 0;
@@ -1585,6 +1723,7 @@ $('#queueList')?.addEventListener('click', (e) => {
       $('#id3Title').value = data.title;
       $('#id3Artist').value = data.author_name || '';
       $('#id3Album').value = data.title;
+      if (id3Genre) id3Genre.value = '';
       $('#fileName').value = sanitizeFileName(data.title);
       lastVideoMeta = {
         title: data.title,
@@ -1606,6 +1745,7 @@ $('#queueList')?.addEventListener('click', (e) => {
     updatePreview();
   });
   $('#url').addEventListener('change', updatePreview);
+  if (formatSelect) formatSelect.addEventListener('change', applyFormatPolicy);
   if (autoTagBtn) autoTagBtn.addEventListener('click', async () => {
     const title = $('#id3Title').value.trim() || lastVideoMeta.title || $('#videoTitle').textContent.trim();
     if (!title) { setToast('Isi judul terlebih dahulu'); return; }
@@ -1626,7 +1766,8 @@ $('#queueList')?.addEventListener('click', (e) => {
       if (tags.title) $('#id3Title').value = tags.title;
       if (tags.artist) $('#id3Artist').value = tags.artist;
       if (tags.album) $('#id3Album').value = tags.album;
-      updateAiStatus(`Genre: <strong>${tags.genre || '-'}</strong> · Mood: <strong>${tags.mood || '-'}</strong>`, 'success');
+      if (tags.genre && id3Genre) id3Genre.value = tags.genre;
+      updateAiStatus(`Genre ID3: <strong>${tags.genre || '-'}</strong>${tags.mood ? ` · Mood: <strong>${tags.mood}</strong>` : ''}`, 'success');
       setToast('Metadata diperbarui otomatis');
     } catch (err) {
       updateAiStatus(err.message, 'danger');
@@ -1683,6 +1824,55 @@ $('#queueList')?.addEventListener('click', (e) => {
     try {
       await navigator.clipboard.writeText(text);
       setToast('Caption disalin ke clipboard');
+    } catch {
+      setToast('Clipboard tidak tersedia');
+    }
+  });
+
+  if (aiPitchBtn) aiPitchBtn.addEventListener('click', async () => {
+    const title = $('#id3Title').value.trim() || lastVideoMeta.title || $('#videoTitle').textContent.trim();
+    if (!title) { setToast('Isi judul terlebih dahulu'); return; }
+    updateAiStatus('Menyusun pitch playlist…', 'info');
+    resetAiPitch();
+    try {
+      const payload = {
+        title,
+        channel: $('#id3Artist').value.trim() || lastVideoMeta.author || '',
+        duration: Number(previewPlayer?.duration || 0) || undefined,
+        genre: id3Genre ? id3Genre.value.trim() || undefined : undefined,
+      };
+      const resp = await fetch(api('/api/ai-pitch'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const data = await resp.json();
+      if (!resp.ok) throw new Error(data.error || 'Gagal membuat pitch');
+      const pitch = (data.pitch || '').trim();
+      if (aiPitchText) aiPitchText.value = pitch;
+      if (aiPitchHook) aiPitchHook.textContent = data.hook ? `Hook: ${data.hook}` : '';
+      if (aiPitchPlaylists) {
+        const list = Array.isArray(data.playlists) ? data.playlists.filter(Boolean) : [];
+        aiPitchPlaylists.textContent = list.length ? `Target playlist: ${list.join(', ')}` : '';
+      }
+      if (id3Genre && !id3Genre.value.trim() && data.tags?.genre) {
+        id3Genre.value = data.tags.genre;
+      }
+      if (aiPitchWrap) aiPitchWrap.hidden = false;
+      updateAiStatus('Pitch playlist siap dipakai ✅', 'success');
+      setToast('Pitch siap disalin ke proposal playlist');
+    } catch (err) {
+      updateAiStatus(err.message, 'danger');
+      setToast('Gagal AI pitch: ' + err.message);
+    }
+  });
+
+  if (aiPitchCopy) aiPitchCopy.addEventListener('click', async () => {
+    const text = aiPitchText?.value?.trim();
+    if (!text) { setToast('Belum ada pitch untuk disalin'); return; }
+    try {
+      await navigator.clipboard.writeText(text);
+      setToast('Pitch disalin ke clipboard');
     } catch {
       setToast('Clipboard tidak tersedia');
     }
@@ -1754,6 +1944,7 @@ $('#queueList')?.addEventListener('click', (e) => {
     $('#id3Title').value='';
     $('#id3Artist').value='';
     $('#id3Album').value='';
+    if (id3Genre) id3Genre.value = '';
     $('#normalize').checked=false;
     $('#atmos').checked=false;
     $('#previewWrap').hidden=true; $('#thumb').src=''; $('#videoTitle').textContent='';
@@ -1799,7 +1990,8 @@ $('#queueList')?.addEventListener('click', (e) => {
     const id3 = {
       title: $('#id3Title').value.trim(),
       artist: $('#id3Artist').value.trim(),
-      album: $('#id3Album').value.trim()
+      album: $('#id3Album').value.trim(),
+      genre: id3Genre ? id3Genre.value.trim() : ''
     };
     Object.keys(id3).forEach(k => { if(!id3[k]) delete id3[k]; });
     if(Object.keys(id3).length) body.id3 = id3;
@@ -1907,6 +2099,7 @@ $('#queueList')?.addEventListener('click', (e) => {
       $('#id3Title').value='';
       $('#id3Artist').value='';
       $('#id3Album').value='';
+      if (id3Genre) id3Genre.value = '';
       $('#fileName').value='';
       await updatePreview();
       setToast(`Memproses ${i+1}/${urls.length}`);
@@ -1935,7 +2128,8 @@ $('#queueList')?.addEventListener('click', (e) => {
     const id3 = {
       title: $('#id3Title').value.trim(),
       artist: $('#id3Artist').value.trim(),
-      album: $('#id3Album').value.trim()
+      album: $('#id3Album').value.trim(),
+      genre: id3Genre ? id3Genre.value.trim() : ''
     };
     Object.keys(id3).forEach(k => { if(!id3[k]) delete id3[k]; });
 
@@ -2082,6 +2276,7 @@ $('#queueList')?.addEventListener('click', (e) => {
     loadSettings();
     renderHistory();
     renderQueue();
+    applyFormatPolicy();
     updateBackendBadge();
     updatePreview();
     renderBackgroundJobs();

--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -57,6 +57,14 @@
     #subtitleResult pre { max-height: 160px; overflow:auto; background: var(--bs-body-bg); border-radius: .75rem; padding: .75rem; }
     #subtitleResult .btn { border-radius: .75rem; }
     #subtitleResult .badge { border-radius: .75rem; }
+    #stemResultCard { background: color-mix(in srgb, var(--bs-body-bg) 90%, rgba(13,110,253,.05)); border: 1px solid color-mix(in srgb, var(--bs-primary) 12%, transparent); border-radius: 1.15rem; padding: 1.25rem; box-shadow: 0 12px 32px rgba(13,110,253,.06); }
+    .stem-preview { background: var(--bs-secondary-bg); border-radius: 1rem; border: 1px solid color-mix(in srgb, var(--bs-border-color) 70%, transparent); padding: 1rem; display: flex; flex-direction: column; gap: .75rem; height: 100%; }
+    .stem-preview audio { width: 100%; border-radius: .85rem; background: var(--bs-body-bg); }
+    .stem-preview .btn { border-radius: .75rem; }
+    #stemMeta { font-size: .75rem; color: var(--bs-secondary); }
+    #stemLoading { font-size: .8rem; color: var(--bs-secondary); }
+    html[data-bs-theme='dark'] #stemResultCard { background: color-mix(in srgb, var(--bs-body-bg) 75%, rgba(13,110,253,.08)); border-color: color-mix(in srgb, var(--bs-primary) 20%, transparent); box-shadow: 0 12px 32px rgba(13,110,253,.12); }
+    html[data-bs-theme='dark'] .stem-preview { background: color-mix(in srgb, var(--bs-secondary-bg) 80%, rgba(255,255,255,.04)); border-color: color-mix(in srgb, rgba(255,255,255,.08) 40%, transparent); }
     .mini-player { position: fixed; left: 0; right: 0; bottom: 1rem; display: flex; justify-content: center; pointer-events: none; z-index: 1090; }
     .mini-player-card { pointer-events: auto; border-radius: 1rem; width: min(420px, calc(100% - 2.5rem)); }
     .mini-player .btn { border-radius: 50%; }
@@ -312,14 +320,44 @@
                 </div>
                 <div class="alert alert-info mt-3 small" id="aiStatus" hidden></div>
                 <div class="mt-3" id="stemResult" hidden>
-                  <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
-                    <strong>Stems siap</strong>
-                    <button class="btn btn-sm btn-outline-secondary" id="stemClearBtn" type="button"><i class="bi bi-x"></i> Tutup</button>
-                  </div>
-                  <div class="d-flex flex-wrap gap-2">
-                    <a id="stemVocalsLink" class="btn btn-sm btn-primary" href="#" download>Vocals</a>
-                    <a id="stemInstrumentalLink" class="btn btn-sm btn-outline-primary" href="#" download>Instrumental</a>
-                    <a id="stemZipLink" class="btn btn-sm btn-outline-secondary" href="#" download>ZIP</a>
+                  <div id="stemResultCard">
+                    <div class="d-flex flex-wrap align-items-center gap-2 mb-3">
+                      <div class="d-flex align-items-center gap-2">
+                        <span class="badge rounded-pill text-bg-primary"><i class="bi bi-sliders"></i></span>
+                        <strong>Stems siap</strong>
+                      </div>
+                      <span class="badge rounded-pill bg-body-tertiary text-secondary" id="stemMeta" hidden></span>
+                      <button class="btn btn-sm btn-outline-secondary ms-auto" id="stemClearBtn" type="button"><i class="bi bi-x"></i> Tutup</button>
+                    </div>
+                    <div class="row g-3 align-items-stretch" id="stemPreviewWrap">
+                      <div class="col-12 col-lg-6">
+                        <div class="stem-preview">
+                          <div class="d-flex align-items-center gap-2">
+                            <span class="badge rounded-pill text-bg-primary"><i class="bi bi-mic-fill"></i> Vocals</span>
+                            <a id="stemVocalsLink" class="btn btn-sm btn-primary ms-auto" href="#" download><i class="bi bi-download"></i> Download</a>
+                          </div>
+                          <audio id="stemVocalsPlayer" controls preload="none"></audio>
+                        </div>
+                      </div>
+                      <div class="col-12 col-lg-6">
+                        <div class="stem-preview">
+                          <div class="d-flex align-items-center gap-2">
+                            <span class="badge rounded-pill text-bg-info text-dark"><i class="bi bi-music-note-beamed"></i> Instrumental</span>
+                            <a id="stemInstrumentalLink" class="btn btn-sm btn-outline-primary ms-auto" href="#" download><i class="bi bi-download"></i> Download</a>
+                          </div>
+                          <audio id="stemInstrumentalPlayer" controls preload="none"></audio>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="d-flex flex-wrap align-items-center gap-2 mt-3">
+                      <a id="stemZipLink" class="btn btn-outline-secondary" href="#" download><i class="bi bi-file-earmark-zip"></i> Unduh ZIP</a>
+                      <div class="ms-auto" id="stemLoading" hidden>
+                        <div class="d-inline-flex align-items-center gap-2 small text-secondary">
+                          <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                          <span>Sedang memproses…</span>
+                        </div>
+                      </div>
+                    </div>
                   </div>
                 </div>
               </div>
@@ -698,6 +736,51 @@
   const stemInstrumentalLink = $('#stemInstrumentalLink');
   const stemZipLink = $('#stemZipLink');
   const stemClearBtn = $('#stemClearBtn');
+  const stemVocalsPlayer = $('#stemVocalsPlayer');
+  const stemInstrumentalPlayer = $('#stemInstrumentalPlayer');
+  const stemMeta = $('#stemMeta');
+  const stemLoading = $('#stemLoading');
+
+  const bustCache = (href) => {
+    if (!href || typeof href !== 'string') return href;
+    const [base, hash] = href.split('#');
+    const timed = `${base}${base.includes('?') ? '&' : '?'}t=${Date.now()}`;
+    return hash ? `${timed}#${hash}` : timed;
+  };
+
+  const applyStemMeta = (meta) => {
+    if (!stemMeta) return;
+    if (!meta) { stemMeta.textContent = ''; stemMeta.hidden = true; return; }
+    const bits = [];
+    if (meta.strategy === 'stereo_mid_side') bits.push('Stereo split');
+    else if (meta.strategy === 'mono_adaptive') bits.push('Mono adaptif');
+    else if (typeof meta.strategy === 'string' && meta.strategy.trim()) bits.push(meta.strategy);
+    const channelCount = Number(meta.channels);
+    if (Number.isFinite(channelCount) && channelCount > 0) {
+      const layout = typeof meta.channelLayout === 'string' && meta.channelLayout.trim() ? ` (${meta.channelLayout})` : '';
+      bits.push(`${channelCount} ch${layout}`);
+    } else if (typeof meta.channelLayout === 'string' && meta.channelLayout.trim()) {
+      bits.push(meta.channelLayout);
+    }
+    stemMeta.textContent = bits.join(' · ');
+    stemMeta.hidden = !stemMeta.textContent.trim();
+  };
+
+  const pauseStemPlayers = () => {
+    [stemVocalsPlayer, stemInstrumentalPlayer].forEach((player) => {
+      if (!player) return;
+      try { player.pause(); } catch {}
+    });
+  };
+
+  const clearStemPlayers = () => {
+    [stemVocalsPlayer, stemInstrumentalPlayer].forEach((player) => {
+      if (!player) return;
+      try { player.pause(); } catch {}
+      player.removeAttribute('src');
+      try { player.load(); } catch {}
+    });
+  };
   const cloudDriveBtn = $('#cloudDriveBtn');
   const cloudDropboxBtn = $('#cloudDropboxBtn');
   const cloudOnedriveBtn = $('#cloudOnedriveBtn');
@@ -1959,12 +2042,18 @@ $('#queueList')?.addEventListener('click', (e) => {
   });
 
   if (stemBtn) stemBtn.addEventListener('click', async () => {
+    if (stemBtn.disabled) return;
     const payload = {};
     if (lastResult?.jobId) payload.jobId = lastResult.jobId;
     else if (lastResult?.downloadUrl) payload.downloadUrl = toRelativePublic(lastResult.downloadUrl);
     else if ($('#url').value.trim()) payload.url = $('#url').value.trim();
     else { setToast('Belum ada audio untuk diproses'); return; }
     updateAiStatus('Memisahkan vokal dan instrumen…', 'info');
+    stemBtn.disabled = true;
+    stemBtn.setAttribute('aria-busy', 'true');
+    if (stemLoading) stemLoading.hidden = false;
+    if (stemResult) stemResult.hidden = false;
+    pauseStemPlayers();
     try {
       const resp = await fetch(api('/api/stems'), {
         method: 'POST',
@@ -1979,27 +2068,55 @@ $('#queueList')?.addEventListener('click', (e) => {
           const href = absoluteFromRelative(data.vocals.downloadUrl);
           stemVocalsLink.href = href;
           stemVocalsLink.setAttribute('download', data.vocals.fileName || 'vocals.mp3');
+          if (stemVocalsPlayer) {
+            stemVocalsPlayer.src = bustCache(href);
+            try { stemVocalsPlayer.load(); } catch {}
+          }
         }
         if (stemInstrumentalLink && data.instrumental?.downloadUrl) {
           const href = absoluteFromRelative(data.instrumental.downloadUrl);
           stemInstrumentalLink.href = href;
           stemInstrumentalLink.setAttribute('download', data.instrumental.fileName || 'instrumental.mp3');
+          if (stemInstrumentalPlayer) {
+            stemInstrumentalPlayer.src = bustCache(href);
+            try { stemInstrumentalPlayer.load(); } catch {}
+          }
         }
         if (stemZipLink && data.zip?.downloadUrl) {
           const href = absoluteFromRelative(data.zip.downloadUrl);
           stemZipLink.href = href;
           stemZipLink.setAttribute('download', data.zip.fileName || 'stems.zip');
         }
+        applyStemMeta(data.meta);
       }
       updateAiStatus('Stems siap diunduh', 'success');
       setToast('Stems berhasil dibuat');
     } catch (err) {
       updateAiStatus(err.message, 'danger');
       setToast('Gagal membuat stems: ' + err.message);
+    } finally {
+      if (stemLoading) stemLoading.hidden = true;
+      stemBtn.disabled = false;
+      stemBtn.removeAttribute('aria-busy');
     }
   });
 
   if (stemClearBtn) stemClearBtn.addEventListener('click', () => {
+    clearStemPlayers();
+    applyStemMeta(null);
+    if (stemVocalsLink) {
+      stemVocalsLink.removeAttribute('href');
+      stemVocalsLink.removeAttribute('download');
+    }
+    if (stemInstrumentalLink) {
+      stemInstrumentalLink.removeAttribute('href');
+      stemInstrumentalLink.removeAttribute('download');
+    }
+    if (stemZipLink) {
+      stemZipLink.removeAttribute('href');
+      stemZipLink.removeAttribute('download');
+    }
+    if (stemLoading) stemLoading.hidden = true;
     if (stemResult) stemResult.hidden = true;
   });
 

--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -292,9 +292,18 @@
                     <label class="form-check-label small" for="backgroundMode">Background mode</label>
                   </div>
                 </div>
-                <p class="text-secondary small mb-3">Gunakan Auto Music Tags untuk mengisi metadata secara instan sekaligus menyimpan job ke background queue bila diperlukan.</p>
+                <p class="text-secondary small mb-3">Gunakan Auto Music Tags untuk mengisi metadata secara instan atau minta AI membuat caption promosi siap pakai.</p>
                 <div class="d-grid d-sm-flex gap-2">
                   <button class="btn btn-outline-primary flex-grow-1" id="autoTagBtn" type="button"><i class="bi bi-stars"></i> Auto Music Tags</button>
+                  <button class="btn btn-outline-secondary flex-grow-1" id="aiCaptionBtn" type="button"><i class="bi bi-megaphone"></i> AI Caption Sosial</button>
+                </div>
+                <div class="mt-3" id="aiCaptionWrap" hidden>
+                  <label for="aiCaptionText" class="form-label small text-uppercase text-secondary">Caption &amp; Hashtag</label>
+                  <div class="input-group input-group-sm">
+                    <textarea id="aiCaptionText" class="form-control" rows="3" readonly spellcheck="false"></textarea>
+                    <button class="btn btn-outline-secondary" id="aiCaptionCopy" type="button" aria-label="Salin caption"><i class="bi bi-clipboard"></i></button>
+                  </div>
+                  <div class="small text-secondary mt-2" id="aiCaptionMeta"></div>
                 </div>
                 <div class="alert alert-info mt-3 small" id="aiStatus" hidden></div>
               </div>
@@ -647,6 +656,11 @@
   const backgroundMode = $('#backgroundMode');
   const aiStatus = $('#aiStatus');
   const autoTagBtn = $('#autoTagBtn');
+  const aiCaptionBtn = $('#aiCaptionBtn');
+  const aiCaptionWrap = $('#aiCaptionWrap');
+  const aiCaptionText = $('#aiCaptionText');
+  const aiCaptionCopy = $('#aiCaptionCopy');
+  const aiCaptionMeta = $('#aiCaptionMeta');
   const playlistResultWrap = $('#playlistResultWrap');
   const playlistDownloadLink = $('#playlistDownloadLink');
   const playlistInfo = $('#playlistInfo');
@@ -751,6 +765,12 @@
     aiStatus.hidden = false;
     aiStatus.className = `alert alert-${type} mt-3 small`;
     aiStatus.innerHTML = message;
+  };
+
+  const resetAiCaption = () => {
+    if (aiCaptionWrap) aiCaptionWrap.hidden = true;
+    if (aiCaptionText) aiCaptionText.value = '';
+    if (aiCaptionMeta) aiCaptionMeta.textContent = '';
   };
 
   const updateBackendBadge = () => {
@@ -864,6 +884,7 @@
     lastResult = null;
     lastPreviewMeta = {};
     updateAiStatus('');
+    resetAiCaption();
     if (equalizerWrap) equalizerWrap.hidden = true;
     if (eqBass) eqBass.value = 0;
     if (eqMid) eqMid.value = 0;
@@ -888,17 +909,23 @@
     shareUrl.searchParams.set('src', absoluteUrl);
     if (meta.fileName) shareUrl.searchParams.set('name', meta.fileName);
     if (meta.format) shareUrl.searchParams.set('fmt', meta.format);
+    if (meta.sampleRate) shareUrl.searchParams.set('sr', String(meta.sampleRate));
+    if (meta.channels) shareUrl.searchParams.set('ch', String(meta.channels));
     currentShareUrl = shareUrl.toString();
     lastResult = {
       downloadUrl: absoluteUrl,
       fileName: meta.fileName || '',
       format: meta.format || '',
       jobId: meta.jobId || null,
+      sampleRate: meta.sampleRate || null,
+      channels: meta.channels || null,
     };
     lastPreviewMeta = {
       format: meta.format || '',
       fileName: meta.fileName || '',
       baseName: meta.baseName || '',
+      sampleRate: meta.sampleRate || null,
+      channels: meta.channels || null,
     };
     if (shareWrap) shareWrap.hidden = false;
     if (shareLinkInput) shareLinkInput.value = currentShareUrl;
@@ -1348,6 +1375,8 @@ $('#queueList')?.addEventListener('click', (e) => {
           fileName: job.result.fileName || '',
           format: job.result.format || '',
           jobId: job.id,
+          sampleRate: job.result.sampleRate || null,
+          channels: job.result.channels || null,
         };
       }
     } else if (job.status === 'error' && previous?.status !== 'error') {
@@ -1458,6 +1487,15 @@ $('#queueList')?.addEventListener('click', (e) => {
     if (!miniSubtitle) return;
     const parts = [];
     if (lastPreviewMeta?.format) parts.push(String(lastPreviewMeta.format).toUpperCase());
+    const sr = Number(lastPreviewMeta?.sampleRate || 0);
+    if (Number.isFinite(sr) && sr > 0) {
+      const kHz = Math.round((sr / 1000) * 10) / 10;
+      parts.push(`${kHz % 1 === 0 ? kHz.toFixed(0) : kHz.toFixed(1)} kHz`);
+    }
+    const ch = Number(lastPreviewMeta?.channels || 0);
+    if (Number.isFinite(ch) && ch > 0) {
+      parts.push(ch === 1 ? 'Mono' : `${ch}-Ch`);
+    }
     const duration = previewPlayer?.duration;
     if (duration && Number.isFinite(duration) && duration > 0) parts.push(secondsToClock(duration));
     const name = lastPreviewMeta?.fileName || lastPreviewMeta?.baseName || currentDownloadName;
@@ -1593,6 +1631,60 @@ $('#queueList')?.addEventListener('click', (e) => {
     } catch (err) {
       updateAiStatus(err.message, 'danger');
       setToast('Gagal AI tags: ' + err.message);
+    }
+  });
+
+  if (aiCaptionBtn) aiCaptionBtn.addEventListener('click', async () => {
+    const title = $('#id3Title').value.trim() || lastVideoMeta.title || $('#videoTitle').textContent.trim();
+    if (!title) { setToast('Isi judul terlebih dahulu'); return; }
+    updateAiStatus('Menulis caption promosi…', 'info');
+    resetAiCaption();
+    try {
+      const payload = {
+        title,
+        channel: $('#id3Artist').value.trim() || lastVideoMeta.author || '',
+        duration: Number(previewPlayer?.duration || 0) || undefined,
+        speedMode: $('#speedMode').value,
+        denoise: denoiseInput?.checked || false,
+        volumeBoost: Number(volumeBoost?.value || 0) || 0,
+        enhancer: enhancerSelect?.value || 'none',
+        format: $('#format').value,
+      };
+      const resp = await fetch(api('/api/ai-caption'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const data = await resp.json();
+      if (!resp.ok) throw new Error(data.error || 'Gagal menulis caption');
+      const caption = (data.caption || '').trim();
+      const hashtags = Array.isArray(data.hashtags) ? data.hashtags.filter(Boolean) : [];
+      if (aiCaptionText) {
+        const combined = [caption, hashtags.join(' ')].filter(Boolean).join('\n');
+        aiCaptionText.value = combined;
+      }
+      if (aiCaptionMeta) {
+        aiCaptionMeta.textContent = hashtags.length
+          ? `Termasuk ${hashtags.length} hashtag: ${hashtags.join(' ')}`
+          : 'Tidak ada hashtag tambahan';
+      }
+      if (aiCaptionWrap) aiCaptionWrap.hidden = false;
+      updateAiStatus('Caption promosi siap digunakan ✨', 'success');
+      setToast('Caption siap disalin');
+    } catch (err) {
+      updateAiStatus(err.message, 'danger');
+      setToast('Gagal AI caption: ' + err.message);
+    }
+  });
+
+  if (aiCaptionCopy) aiCaptionCopy.addEventListener('click', async () => {
+    const text = aiCaptionText?.value?.trim();
+    if (!text) { setToast('Belum ada caption untuk disalin'); return; }
+    try {
+      await navigator.clipboard.writeText(text);
+      setToast('Caption disalin ke clipboard');
+    } catch {
+      setToast('Clipboard tidak tersedia');
     }
   });
 
@@ -1760,7 +1852,9 @@ $('#queueList')?.addEventListener('click', (e) => {
         fileName: data.fileName || '',
         baseName: data.baseName || '',
         format: data.format,
-        title: $('#id3Title').value.trim() || $('#videoTitle').textContent.trim() || data.fileName || ''
+        title: $('#id3Title').value.trim() || $('#videoTitle').textContent.trim() || data.fileName || '',
+        sampleRate: data.sampleRate || null,
+        channels: data.channels || null,
       };
       showAudioPreview(absoluteDownload, previewMeta);
       setToast('Berhasil diproses');

--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -38,6 +38,21 @@
     #playlistShareCard { margin-top: .75rem; }
     #urlDropOverlay { position: fixed; inset: 0; background: rgba(13,110,253,.1); display: flex; align-items: center; justify-content: center; font-size: 1.5rem; font-weight: 600; color: var(--bs-primary); z-index: 1090; backdrop-filter: blur(2px); padding: 1rem; text-align:center; }
     #urlDropOverlay[hidden] { display: none !important; }
+    #waveformWrap, #equalizerWrap, #shareWrap { background: var(--bs-secondary-bg); border: 1px solid var(--bs-border-color); border-radius: 1rem; padding: 1rem; }
+    #waveformCanvas { width: 100%; height: 140px; display: block; border-radius: .85rem; background: var(--bs-body-bg); cursor: crosshair; box-shadow: inset 0 0 0 1px rgba(0,0,0,.04); }
+    #waveformCanvas[data-loading="1"] { opacity: .55; }
+    #waveformMeta { font-size: .85rem; }
+    .eq-slider label { font-size: .75rem; text-transform: uppercase; letter-spacing: .08em; color: var(--bs-secondary); }
+    .eq-slider .form-range { height: 1.4rem; }
+    #shareWrap .input-group-text { border-radius: .75rem 0 0 .75rem; }
+    #subtitleResult pre { max-height: 160px; overflow:auto; background: var(--bs-body-bg); border-radius: .75rem; padding: .75rem; }
+    #subtitleResult .btn { border-radius: .75rem; }
+    #subtitleResult .badge { border-radius: .75rem; }
+    .mini-player { position: fixed; left: 0; right: 0; bottom: 1rem; display: flex; justify-content: center; pointer-events: none; z-index: 1090; }
+    .mini-player-card { pointer-events: auto; border-radius: 1rem; width: min(420px, calc(100% - 2.5rem)); }
+    .mini-player .btn { border-radius: 50%; }
+    .mini-player .form-range { height: 1rem; }
+    #miniPlayer[hidden] { display: none !important; }
     @media (max-width: 576px) {
       body { padding-bottom: 5rem; }
       .btn { padding: .75rem 1rem; font-size: 1.05rem; }
@@ -48,6 +63,9 @@
       .d-sm-flex > .btn { flex: 1 1 auto; }
       .form-check-input { transform: scale(1.2); margin-right: .5rem; }
       #qrWrap, #playlistQrWrap { min-width: 120px; }
+      .mini-player { bottom: .75rem; }
+      .mini-player-card { width: calc(100% - 1.5rem); }
+      #waveformCanvas { height: 110px; }
     }
   </style>
 </head>
@@ -229,6 +247,44 @@
               <button id="clearBtn" class="btn btn-outline-secondary"><i class="bi bi-x-circle"></i> Bersihkan</button>
             </div>
 
+            <div class="card border-0 bg-body-tertiary mt-4" id="subtitleCard">
+              <div class="card-body">
+                <div class="d-flex flex-column flex-lg-row align-items-lg-center gap-3">
+                  <div class="flex-grow-1">
+                    <strong>Podcast Mode · Subtitle</strong>
+                    <div class="small text-secondary">Ambil subtitle otomatis atau manual dan simpan sebagai teks.</div>
+                  </div>
+                  <div class="d-flex flex-wrap align-items-center gap-2">
+                    <select id="subtitleLang" class="form-select form-select-sm" aria-label="Pilih bahasa subtitle">
+                      <option value="id.*,en.*,en" selected>Indonesia / Inggris</option>
+                      <option value="id.*,id">Indonesia saja</option>
+                      <option value="en.*,en">Inggris saja</option>
+                      <option value="all">Semua bahasa</option>
+                    </select>
+                    <div class="form-check form-switch m-0">
+                      <input class="form-check-input" type="checkbox" id="subtitleAuto" checked>
+                      <label class="form-check-label small" for="subtitleAuto">Gunakan auto caption</label>
+                    </div>
+                    <button class="btn btn-outline-primary btn-sm" id="subtitleBtn" type="button"><i class="bi bi-text-left"></i> Ambil subtitle</button>
+                  </div>
+                </div>
+                <div class="alert alert-secondary mt-3" id="subtitleResult" hidden>
+                  <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
+                    <strong id="subtitleStatus">Subtitle siap</strong>
+                    <span class="badge text-bg-primary" id="subtitleLangBadge"></span>
+                    <span class="badge text-bg-warning text-dark" id="subtitleAutoBadge" hidden>Auto</span>
+                    <button class="btn btn-sm btn-outline-secondary ms-lg-auto" id="subtitleCopyBtn" type="button"><i class="bi bi-clipboard"></i> Salin teks</button>
+                  </div>
+                  <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
+                    <a id="subtitleSrtLink" class="btn btn-sm btn-primary" href="#" download><i class="bi bi-filetype-srt"></i> Download .srt</a>
+                    <a id="subtitleTxtLink" class="btn btn-sm btn-outline-primary" href="#" download><i class="bi bi-filetype-txt"></i> Download .txt</a>
+                    <button id="subtitleShareBtn" class="btn btn-sm btn-outline-secondary" type="button"><i class="bi bi-share"></i> Share</button>
+                  </div>
+                  <pre class="mb-0 small" id="subtitlePreview"></pre>
+                </div>
+              </div>
+            </div>
+
             <div class="mt-3" id="statusWrap" hidden>
               <div class="d-flex align-items-center gap-2">
                 <div class="spinner-border spinner-border-sm" role="status" id="loadingSpinner" aria-hidden="true"></div>
@@ -258,10 +314,65 @@
                       <strong>Preview Audio</strong>
                     </div>
                     <audio id="previewPlayer" class="w-100 mt-2" controls preload="none"></audio>
+
+                    <div id="shareWrap" class="mt-3" hidden>
+                      <div class="d-flex flex-wrap align-items-center gap-2">
+                        <strong class="me-auto">Bagikan</strong>
+                        <div class="btn-group btn-group-sm" role="group" aria-label="Bagikan hasil">
+                          <button class="btn btn-outline-primary" id="shareBtn" type="button"><i class="bi bi-share"></i> Share</button>
+                          <button class="btn btn-outline-secondary" id="copyShareBtn" type="button"><i class="bi bi-link-45deg"></i> Salin link</button>
+                        </div>
+                      </div>
+                      <div class="input-group input-group-sm mt-2">
+                        <span class="input-group-text"><i class="bi bi-box-arrow-up-right"></i></span>
+                        <input type="text" class="form-control" id="shareLinkInput" readonly>
+                        <button class="btn btn-outline-secondary" id="openShareBtn" type="button" aria-label="Buka link share"><i class="bi bi-arrow-up-right-square"></i></button>
+                      </div>
+                      <div class="small text-secondary mt-2" id="shareInfo"></div>
+                    </div>
+
+                    <div id="waveformWrap" class="mt-3" hidden>
+                      <div class="d-flex flex-wrap align-items-center gap-2">
+                        <strong class="me-auto">Editor Trim</strong>
+                        <span id="waveformMeta" class="text-secondary"></span>
+                        <div class="btn-group btn-group-sm" role="group">
+                          <button class="btn btn-outline-secondary" id="waveformClear" type="button"><i class="bi bi-eraser"></i> Reset</button>
+                          <button class="btn btn-outline-secondary" id="waveformUseSelection" type="button"><i class="bi bi-scissors"></i> Pakai seleksi</button>
+                        </div>
+                      </div>
+                      <canvas id="waveformCanvas" class="mt-2"></canvas>
+                      <div class="small text-secondary mt-2" id="waveformHint">Seret pada waveform untuk memilih bagian audio, kolom trim akan terisi otomatis.</div>
+                    </div>
+
+                    <div id="equalizerWrap" class="mt-3" hidden>
+                      <div class="d-flex flex-wrap align-items-center gap-2">
+                        <strong class="me-auto">Equalizer</strong>
+                        <div class="btn-group btn-group-sm" role="group">
+                          <button class="btn btn-outline-secondary" id="eqPresetFlat" type="button">Flat</button>
+                          <button class="btn btn-outline-secondary" id="eqPresetPodcast" type="button">Podcast</button>
+                          <button class="btn btn-outline-secondary" id="eqPresetBass" type="button">Bass+</button>
+                        </div>
+                      </div>
+                      <div class="row g-2 mt-2 eq-slider">
+                        <div class="col-sm-4">
+                          <label class="form-label">Bass</label>
+                          <input type="range" class="form-range" min="-12" max="12" step="1" value="0" id="eqBass">
+                        </div>
+                        <div class="col-sm-4">
+                          <label class="form-label">Mid</label>
+                          <input type="range" class="form-range" min="-12" max="12" step="1" value="0" id="eqMid">
+                        </div>
+                        <div class="col-sm-4">
+                          <label class="form-label">Treble</label>
+                          <input type="range" class="form-range" min="-12" max="12" step="1" value="0" id="eqTreble">
+                        </div>
+                      </div>
+                      <div class="small text-secondary mt-2" id="eqStatus">Flat</div>
+                    </div>
                   </div>
                   <div id="qrWrap" class="text-center" hidden>
                     <canvas id="downloadQr" width="156" height="156" class="border rounded bg-body"></canvas>
-                    <div class="small text-secondary mt-2"><i class="bi bi-qr-code"></i> Scan untuk unduh</div>
+                    <div class="small text-secondary mt-2"><i class="bi bi-qr-code"></i> Scan untuk mini player</div>
                   </div>
                 </div>
               </div>
@@ -337,6 +448,25 @@
       </div>
     </div>
   </main>
+
+  <div id="miniPlayer" class="mini-player" hidden>
+    <div class="mini-player-card card shadow-lg border-0">
+      <div class="card-body py-3 d-flex align-items-center gap-3">
+        <button class="btn btn-primary btn-sm" id="miniPlayBtn" type="button" aria-label="Putar / jeda">
+          <i class="bi bi-play-fill"></i>
+        </button>
+        <div class="flex-grow-1">
+          <div class="d-flex align-items-center justify-content-between gap-2">
+            <div class="fw-semibold small text-truncate" id="miniTitle">Audio Preview</div>
+            <div class="small text-secondary" id="miniTime">00:00</div>
+          </div>
+          <input type="range" class="form-range mt-1" id="miniSeek" min="0" max="1000" value="0" aria-label="Seek audio">
+        </div>
+        <button class="btn btn-outline-secondary btn-sm" id="miniShareBtn" type="button" aria-label="Bagikan mini player"><i class="bi bi-qr-code"></i></button>
+        <button class="btn btn-outline-secondary btn-sm" id="miniCloseBtn" type="button" aria-label="Tutup mini player"><i class="bi bi-x-lg"></i></button>
+      </div>
+    </div>
+  </div>
 
   <!-- Offcanvas Settings -->
   <div class="offcanvas offcanvas-end" tabindex="-1" id="offcanvasSettings">
@@ -432,6 +562,26 @@
   const previewPlayer = $('#previewPlayer');
   const qrCanvas = $('#downloadQr');
   const qrWrap = $('#qrWrap');
+  const shareWrap = $('#shareWrap');
+  const shareInfo = $('#shareInfo');
+  const shareLinkInput = $('#shareLinkInput');
+  const shareBtn = $('#shareBtn');
+  const copyShareBtn = $('#copyShareBtn');
+  const openShareBtn = $('#openShareBtn');
+  const waveformWrap = $('#waveformWrap');
+  const waveformCanvas = $('#waveformCanvas');
+  const waveformMeta = $('#waveformMeta');
+  const waveformHint = $('#waveformHint');
+  const waveformClearBtn = $('#waveformClear');
+  const waveformUseSelectionBtn = $('#waveformUseSelection');
+  const equalizerWrap = $('#equalizerWrap');
+  const eqBass = $('#eqBass');
+  const eqMid = $('#eqMid');
+  const eqTreble = $('#eqTreble');
+  const eqStatus = $('#eqStatus');
+  const eqPresetFlat = $('#eqPresetFlat');
+  const eqPresetPodcast = $('#eqPresetPodcast');
+  const eqPresetBass = $('#eqPresetBass');
   const playlistResultWrap = $('#playlistResultWrap');
   const playlistDownloadLink = $('#playlistDownloadLink');
   const playlistInfo = $('#playlistInfo');
@@ -439,6 +589,26 @@
   const playlistQrCanvas = $('#playlistQr');
   const playlistQrWrap = $('#playlistQrWrap');
   const urlDropOverlay = $('#urlDropOverlay');
+  const miniPlayerEl = $('#miniPlayer');
+  const miniPlayBtn = $('#miniPlayBtn');
+  const miniCloseBtn = $('#miniCloseBtn');
+  const miniShareBtn = $('#miniShareBtn');
+  const miniSeek = $('#miniSeek');
+  const miniTime = $('#miniTime');
+  const miniTitle = $('#miniTitle');
+  const subtitleBtn = $('#subtitleBtn');
+  const subtitleLang = $('#subtitleLang');
+  const subtitleAuto = $('#subtitleAuto');
+  const subtitleResult = $('#subtitleResult');
+  const subtitleLangBadge = $('#subtitleLangBadge');
+  const subtitleAutoBadge = $('#subtitleAutoBadge');
+  const subtitleSrtLink = $('#subtitleSrtLink');
+  const subtitleTxtLink = $('#subtitleTxtLink');
+  const subtitlePreview = $('#subtitlePreview');
+  const subtitleCopyBtn = $('#subtitleCopyBtn');
+  const subtitleShareBtn = $('#subtitleShareBtn');
+  const subtitleStatus = $('#subtitleStatus');
+  const subtitleBtnDefault = subtitleBtn ? subtitleBtn.innerHTML : '';
 
   const storage = {
     get k(){ return 'ytmp3.settings.v1'; },
@@ -451,7 +621,28 @@
     adminBearer: ''
   };
 
+  let audioCtx = null;
+  let eqFilters = [];
+  let eqSource = null;
+  let eqReady = false;
+  let currentDownloadUrl = '';
+  let currentDownloadName = '';
+  let currentShareUrl = '';
+  let waveformState = { url: '', duration: 0, peaks: [], selection: null };
+  let waveformAbort = null;
+  let miniSeeking = false;
+  let subtitleShareUrl = '';
+  let lastPreviewTitle = '';
+
   const getBackend = () => (state.backendUrl || '').trim();
+
+  const getAudioContext = () => {
+    if (audioCtx) return audioCtx;
+    const Ctx = window.AudioContext || window.webkitAudioContext;
+    if (!Ctx) return null;
+    audioCtx = new Ctx();
+    return audioCtx;
+  };
   const api = (path) => {
     const b = getBackend();
     return b ? b.replace(/\/$/, '') + path : path; // relative fallback
@@ -492,15 +683,46 @@
       previewPlayer.load();
     }
     if (previewCard) previewCard.hidden = true;
+    if (shareWrap) shareWrap.hidden = true;
+    if (shareLinkInput) shareLinkInput.value = '';
+    if (shareInfo) shareInfo.textContent = '';
+    currentDownloadUrl = '';
+    currentDownloadName = '';
+    currentShareUrl = '';
+    subtitleShareUrl = '';
+    resetWaveform();
+    if (equalizerWrap) equalizerWrap.hidden = true;
+    if (miniPlayerEl) miniPlayerEl.hidden = true;
     renderQr(qrCanvas, qrWrap, null);
   };
 
-  const showAudioPreview = (url) => {
+  const showAudioPreview = (url, meta = {}) => {
     if (!previewPlayer || !previewCard || !url) return;
     const cacheBuster = url.includes('?') ? '&' : '?';
-    previewPlayer.src = `${url}${cacheBuster}preview=${Date.now()}`;
+    const backendBase = getBackend() || window.location.origin;
+    const absoluteUrl = new URL(url, backendBase).href;
+    previewPlayer.src = `${absoluteUrl}${absoluteUrl.includes('?') ? '&' : '?'}preview=${Date.now()}`;
     previewCard.hidden = false;
-    renderQr(qrCanvas, qrWrap, url);
+    currentDownloadUrl = absoluteUrl;
+    currentDownloadName = meta.fileName || meta.baseName || '';
+    lastPreviewTitle = meta.title || meta.fileName || lastPreviewTitle || 'Audio Preview';
+    const shareUrl = new URL('share.html', window.location.href);
+    shareUrl.searchParams.set('src', absoluteUrl);
+    if (meta.fileName) shareUrl.searchParams.set('name', meta.fileName);
+    if (meta.format) shareUrl.searchParams.set('fmt', meta.format);
+    currentShareUrl = shareUrl.toString();
+    if (shareWrap) shareWrap.hidden = false;
+    if (shareLinkInput) shareLinkInput.value = currentShareUrl;
+    if (shareInfo) shareInfo.textContent = 'Bagikan link atau scan QR untuk membuka mini player.';
+    renderQr(qrCanvas, qrWrap, currentShareUrl);
+    loadWaveform(absoluteUrl);
+    if (equalizerWrap) equalizerWrap.hidden = false;
+    if (miniPlayerEl) {
+      miniPlayerEl.hidden = false;
+      if (miniSeek) miniSeek.value = 0;
+      if (miniTime) miniTime.textContent = '00:00';
+      if (miniTitle) miniTitle.textContent = lastPreviewTitle || 'Audio Preview';
+    }
   };
 
   const resetPlaylistPreview = () => {
@@ -511,16 +733,18 @@
 
   const showPlaylistResult = (data, count) => {
     if (!playlistResultWrap || !data) return;
+    const base = getBackend() || window.location.origin;
+    const absolute = new URL(data.downloadUrl, base).href;
     playlistResultWrap.hidden = false;
     if (playlistDownloadLink) {
-      playlistDownloadLink.href = data.downloadUrl;
+      playlistDownloadLink.href = absolute;
       playlistDownloadLink.setAttribute('download', data.fileName || 'playlist.zip');
     }
     if (playlistInfo) {
       playlistInfo.textContent = `${count} file siap diunduh`;
     }
     if (playlistShareCard) playlistShareCard.hidden = false;
-    renderQr(playlistQrCanvas, playlistQrWrap, data.downloadUrl);
+    renderQr(playlistQrCanvas, playlistQrWrap, absolute);
   };
 
   // ===== Queue =====
@@ -706,8 +930,460 @@ $('#queueList')?.addEventListener('click', (e) => {
     return Number.isNaN(n) ? null : n;
   }
 
+  function secondsToClock(sec){
+    if(!Number.isFinite(sec)) return '00:00';
+    const base = Math.max(0, sec);
+    const h = Math.floor(base / 3600);
+    const m = Math.floor((base % 3600) / 60);
+    const s = Math.floor(base % 60);
+    if(h){
+      return `${h.toString().padStart(2,'0')}:${m.toString().padStart(2,'0')}:${s.toString().padStart(2,'0')}`;
+    }
+    return `${m.toString().padStart(2,'0')}:${s.toString().padStart(2,'0')}`;
+  }
+
+  function secondsToInput(sec){
+    if(!Number.isFinite(sec)) return '';
+    const base = Math.max(0, sec);
+    const h = Math.floor(base / 3600);
+    const m = Math.floor((base % 3600) / 60);
+    const s = Math.floor(base % 60);
+    if(h){
+      return `${h}:${m.toString().padStart(2,'0')}:${s.toString().padStart(2,'0')}`;
+    }
+    return `${m}:${s.toString().padStart(2,'0')}`;
+  }
+
+  function clamp(val, min, max){
+    if(!Number.isFinite(val)) return min;
+    return Math.min(Math.max(val, min), max);
+  }
+
   function sanitizeFileName(str){
     return str.replace(/[\\/:*?"<>|\r\n]+/g,'').replace(/\s+/g,' ').trim();
+  }
+
+  // ===== Waveform helpers =====
+  function resetWaveform(clearSelection = true){
+    if (waveformAbort) {
+      waveformAbort.abort();
+      waveformAbort = null;
+    }
+    if (clearSelection) waveformState.selection = null;
+    waveformState.url = '';
+    waveformState.duration = 0;
+    waveformState.peaks = [];
+    if (waveformCanvas) {
+      const ctx = waveformCanvas.getContext('2d');
+      if (ctx) {
+        ctx.clearRect(0, 0, waveformCanvas.width || 0, waveformCanvas.height || 0);
+      }
+      waveformCanvas.removeAttribute('data-loading');
+    }
+    if (waveformWrap) waveformWrap.hidden = true;
+    if (waveformMeta) waveformMeta.textContent = '';
+    if (waveformHint) waveformHint.textContent = 'Waveform akan muncul setelah audio siap.';
+  }
+
+  function buildWaveformPeaks(channelData, target = 900){
+    const peaks = [];
+    if (!channelData || !channelData.length) return peaks;
+    const len = channelData.length;
+    const step = Math.max(1, Math.floor(len / target));
+    for (let i = 0; i < target; i += 1){
+      const start = i * step;
+      if (start >= len) break;
+      const end = Math.min(len, start + step);
+      let min = 1;
+      let max = -1;
+      for (let j = start; j < end; j += 1){
+        const value = channelData[j];
+        if (value > max) max = value;
+        if (value < min) min = value;
+      }
+      peaks.push({ min, max });
+    }
+    return peaks;
+  }
+
+  function updateWaveformMeta(){
+    if (!waveformMeta) return;
+    if (!waveformState.duration){
+      waveformMeta.textContent = '';
+      return;
+    }
+    if (waveformState.selection && waveformState.selection.end > waveformState.selection.start){
+      const { start, end } = waveformState.selection;
+      waveformMeta.textContent = `${secondsToClock(start)} → ${secondsToClock(end)} · ${secondsToClock(end - start)}`;
+    } else {
+      waveformMeta.textContent = `Durasi ${secondsToClock(waveformState.duration)}`;
+    }
+  }
+
+  function drawWaveform(){
+    if (!waveformCanvas) return;
+    const ctx = waveformCanvas.getContext('2d');
+    if (!ctx) return;
+    const width = waveformCanvas.clientWidth || waveformCanvas.offsetWidth || 480;
+    const height = waveformCanvas.clientHeight || 120;
+    const ratio = window.devicePixelRatio || 1;
+    waveformCanvas.width = Math.max(1, Math.floor(width * ratio));
+    waveformCanvas.height = Math.max(1, Math.floor(height * ratio));
+    ctx.save();
+    ctx.scale(ratio, ratio);
+    const styles = getComputedStyle(document.body);
+    const bg = (styles.getPropertyValue('--bs-body-bg') || '#ffffff').trim() || '#ffffff';
+    const accent = (styles.getPropertyValue('--bs-primary') || '#0d6efd').trim() || '#0d6efd';
+    const border = (styles.getPropertyValue('--bs-border-color') || '#ced4da').trim() || '#ced4da';
+    ctx.fillStyle = bg;
+    ctx.fillRect(0, 0, width, height);
+    ctx.strokeStyle = border;
+    ctx.lineWidth = 1;
+    const mid = height / 2;
+    ctx.beginPath();
+    ctx.moveTo(0, mid);
+    ctx.lineTo(width, mid);
+    ctx.stroke();
+    const peaks = waveformState.peaks || [];
+    if (peaks.length){
+      const columnWidth = width / peaks.length;
+      ctx.fillStyle = accent;
+      for (let i = 0; i < peaks.length; i += 1){
+        const { min, max } = peaks[i];
+        const x = i * columnWidth;
+        const top = mid + (min * mid);
+        const bottom = mid + (max * mid);
+        const h = bottom - top;
+        ctx.fillRect(x, top, Math.max(1, columnWidth * 0.9), h || 1);
+      }
+    }
+    if (waveformState.selection && waveformState.duration && waveformState.selection.end > waveformState.selection.start){
+      const { start, end } = waveformState.selection;
+      const startX = (start / waveformState.duration) * width;
+      const endX = (end / waveformState.duration) * width;
+      ctx.fillStyle = 'rgba(13,110,253,0.18)';
+      ctx.fillRect(startX, 0, Math.max(1, endX - startX), height);
+      ctx.strokeStyle = accent;
+      ctx.beginPath();
+      ctx.moveTo(startX, 0);
+      ctx.lineTo(startX, height);
+      ctx.moveTo(endX, 0);
+      ctx.lineTo(endX, height);
+      ctx.stroke();
+    }
+    ctx.restore();
+  }
+
+  function getWaveformTime(evt){
+    if (!waveformCanvas || !waveformState.duration) return 0;
+    const rect = waveformCanvas.getBoundingClientRect();
+    const x = clamp(evt.clientX - rect.left, 0, rect.width || 1);
+    const ratio = rect.width ? x / rect.width : 0;
+    return ratio * waveformState.duration;
+  }
+
+  function syncWaveformFromInputs(){
+    if (!waveformState.duration) return;
+    const sVal = parseTime($('#trimStart').value.trim());
+    const eVal = parseTime($('#trimEnd').value.trim());
+    if (sVal === null && eVal === null){
+      waveformState.selection = null;
+      drawWaveform();
+      updateWaveformMeta();
+      return;
+    }
+    const start = sVal === null ? 0 : clamp(sVal, 0, waveformState.duration);
+    const end = eVal === null ? waveformState.duration : clamp(eVal, 0, waveformState.duration);
+    if (end <= start){
+      waveformState.selection = null;
+    } else {
+      waveformState.selection = { start, end };
+    }
+    drawWaveform();
+    updateWaveformMeta();
+  }
+
+  async function loadWaveform(url){
+    if (!waveformCanvas || !url) return;
+    const ctx = getAudioContext();
+    if (!ctx){
+      if (waveformWrap) waveformWrap.hidden = true;
+      if (waveformHint) waveformHint.textContent = 'Browser tidak mendukung Web Audio API.';
+      return;
+    }
+    if (waveformAbort) waveformAbort.abort();
+    waveformAbort = new AbortController();
+    waveformCanvas.dataset.loading = '1';
+    if (waveformHint) waveformHint.textContent = 'Memuat waveform…';
+    try {
+      const resp = await fetch(`${url}${url.includes('?') ? '&' : '?'}waveform=${Date.now()}`, { signal: waveformAbort.signal, cache: 'no-store' });
+      if (!resp.ok) throw new Error('Gagal memuat audio');
+      const arr = await resp.arrayBuffer();
+      const audioBuffer = await ctx.decodeAudioData(arr);
+      const peaks = buildWaveformPeaks(audioBuffer.getChannelData(0), Math.min(1400, Math.ceil(audioBuffer.duration * 80)));
+      waveformState.url = url;
+      waveformState.duration = audioBuffer.duration;
+      waveformState.peaks = peaks;
+      waveformWrap.hidden = false;
+      drawWaveform();
+      updateWaveformMeta();
+      if (waveformHint) waveformHint.textContent = 'Seret area untuk memilih bagian audio.';
+      syncWaveformFromInputs();
+    } catch (err){
+      if (err.name === 'AbortError') return;
+      console.error(err);
+      if (waveformHint) waveformHint.textContent = 'Waveform tidak bisa dimuat';
+      waveformWrap.hidden = true;
+    } finally {
+      waveformCanvas.removeAttribute('data-loading');
+    }
+  }
+
+  if (waveformCanvas){
+    let dragging = false;
+    let dragStart = 0;
+    waveformCanvas.addEventListener('pointerdown', (e) => {
+      if (!waveformState.duration) return;
+      dragging = true;
+      waveformCanvas.setPointerCapture(e.pointerId);
+      const time = getWaveformTime(e);
+      dragStart = time;
+      waveformState.selection = { start: time, end: time };
+      drawWaveform();
+      updateWaveformMeta();
+    });
+    waveformCanvas.addEventListener('pointermove', (e) => {
+      if (!dragging) return;
+      const time = getWaveformTime(e);
+      const start = Math.min(dragStart, time);
+      const end = Math.max(dragStart, time);
+      waveformState.selection = end > start ? { start, end } : null;
+      drawWaveform();
+      updateWaveformMeta();
+      if (waveformState.selection){
+        $('#trimStart').value = secondsToInput(start);
+        $('#trimEnd').value = secondsToInput(end);
+      }
+    });
+    const stopDrag = (e) => {
+      if (!dragging) return;
+      if (e && e.pointerId != null) waveformCanvas.releasePointerCapture(e.pointerId);
+      dragging = false;
+      updateWaveformMeta();
+    };
+    waveformCanvas.addEventListener('pointerup', stopDrag);
+    waveformCanvas.addEventListener('pointercancel', stopDrag);
+    waveformCanvas.addEventListener('pointerleave', stopDrag);
+    waveformCanvas.addEventListener('dblclick', () => {
+      waveformState.selection = null;
+      drawWaveform();
+      updateWaveformMeta();
+      $('#trimStart').value = '';
+      $('#trimEnd').value = '';
+    });
+  }
+
+  if (waveformClearBtn){
+    waveformClearBtn.addEventListener('click', () => {
+      waveformState.selection = null;
+      drawWaveform();
+      updateWaveformMeta();
+      $('#trimStart').value = '';
+      $('#trimEnd').value = '';
+    });
+  }
+
+  if (waveformUseSelectionBtn){
+    waveformUseSelectionBtn.addEventListener('click', () => {
+      if (!waveformState.selection){
+        setToast('Pilih bagian audio di waveform terlebih dahulu');
+        return;
+      }
+      $('#trimStart').value = secondsToInput(waveformState.selection.start);
+      $('#trimEnd').value = secondsToInput(waveformState.selection.end);
+      setToast('Trim diperbarui dari waveform');
+    });
+  }
+
+  // ===== Equalizer helpers =====
+  const formatGain = (value) => `${Number(value) >= 0 ? '+' : ''}${Number(value)} dB`;
+
+  const updateEqStatus = () => {
+    if (!eqStatus) return;
+    const bassVal = Number(eqBass?.value || 0);
+    const midVal = Number(eqMid?.value || 0);
+    const trebleVal = Number(eqTreble?.value || 0);
+    eqStatus.textContent = `Bass ${formatGain(bassVal)} · Mid ${formatGain(midVal)} · Treble ${formatGain(trebleVal)}`;
+  };
+
+  const ensureEqualizer = () => {
+    if (!previewPlayer) return false;
+    const ctx = getAudioContext();
+    if (!ctx) return false;
+    if (eqReady) return true;
+    if (!eqSource) {
+      eqSource = ctx.createMediaElementSource(previewPlayer);
+      const bass = ctx.createBiquadFilter();
+      bass.type = 'lowshelf';
+      bass.frequency.value = 200;
+      const mid = ctx.createBiquadFilter();
+      mid.type = 'peaking';
+      mid.frequency.value = 1000;
+      mid.Q.value = 1;
+      const treble = ctx.createBiquadFilter();
+      treble.type = 'highshelf';
+      treble.frequency.value = 4000;
+      eqFilters = [bass, mid, treble];
+      eqSource.connect(bass);
+      bass.connect(mid);
+      mid.connect(treble);
+      treble.connect(ctx.destination);
+    }
+    eqReady = true;
+    return true;
+  };
+
+  const applyEqFromInputs = () => {
+    const ctx = getAudioContext();
+    if (ctx && ctx.state === 'suspended') ctx.resume().catch(()=>{});
+    if (!ensureEqualizer()) return;
+    const bassVal = Number(eqBass?.value || 0);
+    const midVal = Number(eqMid?.value || 0);
+    const trebleVal = Number(eqTreble?.value || 0);
+    if (eqFilters[0]) eqFilters[0].gain.value = bassVal;
+    if (eqFilters[1]) eqFilters[1].gain.value = midVal;
+    if (eqFilters[2]) eqFilters[2].gain.value = trebleVal;
+    updateEqStatus();
+  };
+
+  if (eqBass) eqBass.addEventListener('input', applyEqFromInputs);
+  if (eqMid) eqMid.addEventListener('input', applyEqFromInputs);
+  if (eqTreble) eqTreble.addEventListener('input', applyEqFromInputs);
+  if (eqPresetFlat) eqPresetFlat.addEventListener('click', () => {
+    if (eqBass) eqBass.value = 0;
+    if (eqMid) eqMid.value = 0;
+    if (eqTreble) eqTreble.value = 0;
+    applyEqFromInputs();
+    setToast('Equalizer direset ke mode Flat');
+  });
+  if (eqPresetPodcast) eqPresetPodcast.addEventListener('click', () => {
+    if (eqBass) eqBass.value = 2;
+    if (eqMid) eqMid.value = 3;
+    if (eqTreble) eqTreble.value = -1;
+    applyEqFromInputs();
+    setToast('Preset Podcast diterapkan');
+  });
+  if (eqPresetBass) eqPresetBass.addEventListener('click', () => {
+    if (eqBass) eqBass.value = 5;
+    if (eqMid) eqMid.value = 0;
+    if (eqTreble) eqTreble.value = 2;
+    applyEqFromInputs();
+    setToast('Bass+ diterapkan');
+  });
+  updateEqStatus();
+
+  const shareLink = async (link) => {
+    if (!link) { setToast('Belum ada link untuk dibagikan'); return; }
+    if (navigator.share){
+      try {
+        await navigator.share({ title: lastPreviewTitle || document.title, url: link });
+        return;
+      } catch (err){
+        if (err && err.name === 'AbortError') return;
+      }
+    }
+    try {
+      await navigator.clipboard.writeText(link);
+      setToast('Link share disalin');
+    } catch {
+      setToast(link);
+    }
+  };
+
+  if (shareBtn) shareBtn.addEventListener('click', () => shareLink(currentShareUrl));
+  if (miniShareBtn) miniShareBtn.addEventListener('click', () => shareLink(currentShareUrl));
+  if (copyShareBtn) copyShareBtn.addEventListener('click', async () => {
+    if (!currentShareUrl){ setToast('Belum ada link share'); return; }
+    try {
+      await navigator.clipboard.writeText(currentShareUrl);
+      setToast('Link share disalin');
+    } catch {
+      setToast(currentShareUrl);
+    }
+  });
+  if (openShareBtn) openShareBtn.addEventListener('click', () => {
+    if (!currentShareUrl){ setToast('Belum ada link share'); return; }
+    window.open(currentShareUrl, '_blank', 'noopener');
+  });
+
+  const updateMiniPlayState = () => {
+    if (!miniPlayBtn || !previewPlayer) return;
+    if (previewPlayer.paused){
+      miniPlayBtn.innerHTML = '<i class="bi bi-play-fill"></i>';
+      miniPlayBtn.setAttribute('aria-label', 'Putar');
+    } else {
+      miniPlayBtn.innerHTML = '<i class="bi bi-pause-fill"></i>';
+      miniPlayBtn.setAttribute('aria-label', 'Jeda');
+    }
+  };
+
+  if (miniPlayBtn) miniPlayBtn.addEventListener('click', () => {
+    if (!previewPlayer) return;
+    if (previewPlayer.paused) previewPlayer.play().catch(()=>{});
+    else previewPlayer.pause();
+  });
+
+  if (miniCloseBtn) miniCloseBtn.addEventListener('click', () => {
+    if (miniPlayerEl) miniPlayerEl.hidden = true;
+  });
+
+  if (miniSeek){
+    miniSeek.addEventListener('input', (e) => {
+      if (!previewPlayer || !previewPlayer.duration) return;
+      miniSeeking = true;
+      const ratio = Number(e.target.value) / 1000;
+      if (miniTime) miniTime.textContent = `${secondsToClock(ratio * previewPlayer.duration)} / ${secondsToClock(previewPlayer.duration)}`;
+    });
+    const commitSeek = (e) => {
+      if (!previewPlayer || !previewPlayer.duration) { miniSeeking = false; return; }
+      const ratio = Number(e.target.value) / 1000;
+      previewPlayer.currentTime = clamp(ratio, 0, 1) * previewPlayer.duration;
+      miniSeeking = false;
+    };
+    miniSeek.addEventListener('change', commitSeek);
+    miniSeek.addEventListener('pointerup', (e) => commitSeek(e));
+  }
+
+  if (previewPlayer){
+    previewPlayer.addEventListener('loadedmetadata', () => {
+      updateMiniPlayState();
+      if (miniSeek) {
+        miniSeek.disabled = !previewPlayer.duration;
+        miniSeek.value = 0;
+      }
+      if (miniTime) miniTime.textContent = previewPlayer.duration ? `00:00 / ${secondsToClock(previewPlayer.duration)}` : '00:00';
+    });
+    previewPlayer.addEventListener('play', async () => {
+      const ctx = getAudioContext();
+      if (ctx && ctx.state === 'suspended') {
+        try { await ctx.resume(); } catch {}
+      }
+      ensureEqualizer();
+      applyEqFromInputs();
+      updateMiniPlayState();
+      if (miniPlayerEl) miniPlayerEl.hidden = false;
+    });
+    previewPlayer.addEventListener('pause', updateMiniPlayState);
+    previewPlayer.addEventListener('ended', updateMiniPlayState);
+    previewPlayer.addEventListener('timeupdate', () => {
+      if (!miniTime) return;
+      const dur = previewPlayer.duration || 0;
+      const cur = previewPlayer.currentTime || 0;
+      miniTime.textContent = dur ? `${secondsToClock(cur)} / ${secondsToClock(dur)}` : secondsToClock(cur);
+      if (miniSeek && !miniSeeking && dur){
+        miniSeek.value = Math.round((cur / dur) * 1000);
+      }
+    });
   }
 
   async function updatePreview(){
@@ -734,6 +1410,8 @@ $('#queueList')?.addEventListener('click', (e) => {
     updatePreview();
   });
   $('#url').addEventListener('change', updatePreview);
+  $('#trimStart').addEventListener('change', syncWaveformFromInputs);
+  $('#trimEnd').addEventListener('change', syncWaveformFromInputs);
 
   // ===== Drag & drop cookies.txt =====
   const dz = $('#dropzone');
@@ -784,6 +1462,7 @@ $('#queueList')?.addEventListener('click', (e) => {
   $('#convertBtn').addEventListener('click', () => doConvert(null, $('#autoDownload').checked));
   $('#downloadAllBtn').addEventListener('click', doConvertQueue);
   $('#downloadZipBtn').addEventListener('click', downloadPlaylistZip);
+  if (subtitleBtn) subtitleBtn.addEventListener('click', handleSubtitle);
   $('#clearBtn').addEventListener('click', () => {
     $('#url').value='';
     $('#playlist').value='';
@@ -799,10 +1478,26 @@ $('#queueList')?.addEventListener('click', (e) => {
     $('#previewWrap').hidden=true; $('#thumb').src=''; $('#videoTitle').textContent='';
     resetAudioPreview();
     resetPlaylistPreview();
+    if (subtitleResult) subtitleResult.hidden = true;
+    if (subtitlePreview) subtitlePreview.textContent = '';
+    if (subtitleAutoBadge) subtitleAutoBadge.hidden = true;
+    subtitleShareUrl = '';
     $('#resultWrap').hidden=true; $('#statusWrap').hidden=true; $('#logWrap').hidden=true; $('#logs').textContent='';
     $('#convertProgWrap').hidden=true;
   });
   $('#url').addEventListener('keydown', (e)=>{ if(e.key==='Enter') doConvert(null, $('#autoDownload').checked); });
+
+  if (subtitleCopyBtn) subtitleCopyBtn.addEventListener('click', async () => {
+    const text = (subtitlePreview?.textContent || '').trim();
+    if (!text){ setToast('Belum ada teks subtitle'); return; }
+    try {
+      await navigator.clipboard.writeText(text);
+      setToast('Teks subtitle tersalin');
+    } catch {
+      setToast('Tidak dapat menyalin teks subtitle');
+    }
+  });
+  if (subtitleShareBtn) subtitleShareBtn.addEventListener('click', () => shareLink(subtitleShareUrl));
 
   async function doConvert(urlOverride, autoDownload = false){
     const url = (urlOverride || $('#url').value).trim();
@@ -854,15 +1549,23 @@ $('#queueList')?.addEventListener('click', (e) => {
       const data = await resp.json();
       if(!resp.ok) throw new Error(data.error || 'Gagal memproses');
 
-      $('#downloadLink').href = data.downloadUrl; $('#downloadLink').setAttribute('download', data.fileName || 'audio');
+      const backendBase = getBackend() || window.location.origin;
+      const absoluteDownload = new URL(data.downloadUrl, backendBase).href;
+      $('#downloadLink').href = absoluteDownload; $('#downloadLink').setAttribute('download', data.fileName || 'audio');
       $('#resultWrap').hidden = false;
       $('#status').textContent = 'Selesai';
       $('#loadingSpinner').style.display = 'none';
       fake = 100; progBar.style.width='100%'; progBar.textContent='100%';
       if(data.logs && $('#showLog').checked){ $('#logs').textContent = data.logs; }
       if(autoDownload) $('#downloadLink').click();
-      pushHistory({ downloadUrl: data.downloadUrl, format: data.format, abr: body.abr, fileName: data.fileName });
-      showAudioPreview(data.downloadUrl);
+      pushHistory({ downloadUrl: absoluteDownload, format: data.format, abr: body.abr, fileName: data.fileName });
+      const previewMeta = {
+        fileName: data.fileName || '',
+        baseName: data.baseName || '',
+        format: data.format,
+        title: $('#id3Title').value.trim() || $('#videoTitle').textContent.trim() || data.fileName || ''
+      };
+      showAudioPreview(absoluteDownload, previewMeta);
       setToast('Berhasil diproses');
       if($('#autoClear').checked && !urlOverride){ $('#clearBtn').click(); }
     }catch(err){
@@ -948,7 +1651,9 @@ $('#queueList')?.addEventListener('click', (e) => {
       $('#status').textContent = 'ZIP selesai';
       showPlaylistResult(data, items.length);
       setToast(`Playlist ZIP siap (${items.length} file)`);
-      pushHistory({ downloadUrl: data.downloadUrl, format: 'zip', abr: body.abr, fileName: data.fileName });
+      const base = getBackend() || window.location.origin;
+      const absoluteZip = new URL(data.downloadUrl, base).href;
+      pushHistory({ downloadUrl: absoluteZip, format: 'zip', abr: body.abr, fileName: data.fileName });
       if($('#autoDownload').checked && playlistDownloadLink){ playlistDownloadLink.click(); }
       if($('#autoClear').checked){ queue.length = 0; renderQueue(); $('#playlist').value=''; }
     } catch(err){
@@ -957,6 +1662,61 @@ $('#queueList')?.addEventListener('click', (e) => {
       $('#logWrap').hidden = false;
       $('#logs').textContent = (err && err.stack) ? err.stack : String(err);
       setToast('Terjadi error: '+err.message);
+    }
+  }
+
+  async function handleSubtitle(){
+    const url = $('#url').value.trim();
+    if(!/^https?:\/\//i.test(url)){
+      setToast('Masukkan URL YouTube yang valid terlebih dahulu');
+      $('#url').focus();
+      return;
+    }
+    if (subtitleResult) subtitleResult.hidden = true;
+    if (subtitlePreview) subtitlePreview.textContent = '';
+    if (subtitleAutoBadge) subtitleAutoBadge.hidden = true;
+    subtitleShareUrl = '';
+    if (subtitleBtn){
+      subtitleBtn.disabled = true;
+      subtitleBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>Memuat';
+    }
+    try {
+      const langVal = subtitleLang?.value || 'id.*,en.*,en';
+      const body = {
+        url,
+        lang: langVal === 'all' ? 'all' : langVal,
+        preferAuto: subtitleAuto ? subtitleAuto.checked : true,
+        fileName: sanitizeFileName($('#fileName').value.trim()) || undefined,
+        title: $('#id3Title').value.trim() || $('#videoTitle').textContent.trim() || undefined,
+      };
+      const resp = await fetch(api('/api/subtitle'), { method:'POST', headers:{ 'Content-Type':'application/json' }, body: JSON.stringify(body) });
+      const data = await resp.json();
+      if(!resp.ok) throw new Error(data.error || 'Gagal mengambil subtitle');
+      if (subtitleLangBadge) subtitleLangBadge.textContent = (data.lang || '').toUpperCase() || 'TXT';
+      if (subtitleAutoBadge) subtitleAutoBadge.hidden = !data.auto;
+      if (subtitleSrtLink){
+        subtitleSrtLink.href = data.srtUrl || '#';
+        if (data.srtFileName) subtitleSrtLink.setAttribute('download', data.srtFileName);
+      }
+      if (subtitleTxtLink){
+        subtitleTxtLink.href = data.txtUrl || '#';
+        if (data.txtFileName) subtitleTxtLink.setAttribute('download', data.txtFileName);
+      }
+      if (subtitlePreview) subtitlePreview.textContent = data.preview || '(Tidak ada preview tersedia)';
+      if (subtitleStatus) subtitleStatus.textContent = 'Subtitle siap diunduh';
+      subtitleShareUrl = data.txtUrl ? new URL(data.txtUrl, window.location.origin).href : (data.srtUrl ? new URL(data.srtUrl, window.location.origin).href : '');
+      if (subtitleResult) subtitleResult.hidden = false;
+      setToast('Subtitle siap diunduh');
+    } catch(err){
+      if (subtitleStatus) subtitleStatus.textContent = 'Gagal mengambil subtitle';
+      if (subtitlePreview) subtitlePreview.textContent = err.message || 'Terjadi kesalahan';
+      if (subtitleResult) subtitleResult.hidden = false;
+      setToast('Subtitle gagal: '+ err.message);
+    } finally {
+      if (subtitleBtn){
+        subtitleBtn.disabled = false;
+        subtitleBtn.innerHTML = subtitleBtnDefault || '<i class="bi bi-text-left"></i> Ambil subtitle';
+      }
     }
   }
 

--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -50,9 +50,52 @@
     .eq-slider .eq-value { font-size: .7rem; font-weight: 600; background: var(--bs-primary-bg-subtle); color: var(--bs-primary-text); border-radius: .65rem; padding: .2rem .45rem; min-width: 3.4rem; text-align: center; }
     html[data-bs-theme='dark'] .eq-slider .eq-value { background: color-mix(in srgb, var(--bs-primary) 22%, transparent); color: var(--bs-body-color); }
     #shareWrap .input-group-text { border-radius: .75rem 0 0 .75rem; }
-    #subtitleResult pre { max-height: 160px; overflow:auto; background: var(--bs-body-bg); border-radius: .75rem; padding: .75rem; }
+    #subtitleResult pre {
+      max-height: 160px;
+      overflow: auto;
+      background: var(--bs-body-bg);
+      border-radius: .75rem;
+      padding: .75rem;
+      white-space: pre-wrap;
+      line-height: 1.45;
+    }
     #subtitleResult .btn { border-radius: .75rem; }
     #subtitleResult .badge { border-radius: .75rem; }
+    .faq-item {
+      background: var(--bs-body-bg);
+      border-radius: .9rem;
+      padding: .75rem 1rem;
+      border: 1px solid color-mix(in srgb, var(--bs-border-color) 80%, transparent);
+    }
+    .faq-item + .faq-item { margin-top: .5rem; }
+    .faq-item summary {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+      cursor: pointer;
+      font-weight: 600;
+      list-style: none;
+    }
+    .faq-item summary::marker,
+    .faq-item summary::-webkit-details-marker { display: none; }
+    .faq-item summary::after {
+      font-family: "bootstrap-icons";
+      content: "\f282";
+      font-size: .9rem;
+      color: var(--bs-secondary);
+      transition: transform .2s ease, color .2s ease;
+    }
+    .faq-item[open] summary { color: var(--bs-primary); }
+    .faq-item[open] summary::after {
+      transform: rotate(180deg);
+      color: var(--bs-primary);
+    }
+    .faq-item p {
+      margin: .75rem 0 0;
+      font-size: .9rem;
+      color: var(--bs-secondary);
+    }
     .mini-player { position: fixed; left: 0; right: 0; bottom: 1rem; display: flex; justify-content: center; pointer-events: none; z-index: 1090; }
     .mini-player-card { pointer-events: auto; border-radius: 1rem; width: min(420px, calc(100% - 2.5rem)); }
     .mini-player-body { display: flex; align-items: center; gap: 1.5rem; flex-wrap: wrap; }
@@ -322,6 +365,7 @@
                   <button class="btn btn-outline-primary flex-grow-1" id="autoTagBtn" type="button"><i class="bi bi-stars"></i> Auto Music Tags</button>
                   <button class="btn btn-outline-secondary flex-grow-1" id="aiCaptionBtn" type="button"><i class="bi bi-megaphone"></i> AI Caption Sosial</button>
                   <button class="btn btn-outline-success flex-grow-1" id="aiPitchBtn" type="button"><i class="bi bi-broadcast"></i> AI Playlist Pitch</button>
+                  <button class="btn btn-outline-warning flex-grow-1" id="aiAudiophileBtn" type="button"><i class="bi bi-soundwave"></i> AI Audiophile Guide</button>
                 </div>
                 <div class="mt-3" id="aiCaptionWrap" hidden>
                   <label for="aiCaptionText" class="form-label small text-uppercase text-secondary">Caption &amp; Hashtag</label>
@@ -339,6 +383,14 @@
                   </div>
                   <div class="small text-secondary mt-2" id="aiPitchHook"></div>
                   <div class="small text-secondary" id="aiPitchPlaylists"></div>
+                </div>
+                <div class="mt-3" id="aiAudiophileWrap" hidden>
+                  <label for="aiAudiophileText" class="form-label small text-uppercase text-secondary">Panduan Audiophile</label>
+                  <div class="input-group input-group-sm">
+                    <textarea id="aiAudiophileText" class="form-control" rows="5" readonly spellcheck="false"></textarea>
+                    <button class="btn btn-outline-secondary" id="aiAudiophileCopy" type="button" aria-label="Salin panduan audiophile"><i class="bi bi-clipboard"></i></button>
+                  </div>
+                  <div class="small text-secondary mt-2" id="aiAudiophileMeta"></div>
                 </div>
                 <div class="alert alert-info mt-3 small" id="aiStatus" hidden></div>
               </div>
@@ -549,6 +601,29 @@
             </ul>
           </div>
         </div>
+
+        <div class="card shadow-sm mt-4">
+          <div class="card-body p-4">
+            <div class="d-flex align-items-center mb-2">
+              <i class="bi bi-question-circle me-2"></i>
+              <h5 class="mb-0">FAQ</h5>
+            </div>
+            <div class="d-grid gap-2">
+              <details class="faq-item" open>
+                <summary>Apakah subtitle yang diunduh lengkap?</summary>
+                <p>Ya. Tombol <strong>Ambil subtitle</strong> sekarang menarik transkrip penuh dari YouTube, menyimpan berkas <code>.srt</code>, <code>.txt</code>, serta menampilkan teks lengkap yang bisa Anda salin langsung.</p>
+              </details>
+              <details class="faq-item">
+                <summary>Bagaimana AI Studio membantu audiophile?</summary>
+                <p>Gunakan <strong>AI Audiophile Guide</strong> untuk mendapatkan rekomendasi EQ, saran sample rate, dan tips monitoring yang disesuaikan dengan genre, mood, dan pengaturan convert Anda.</p>
+              </details>
+              <details class="faq-item">
+                <summary>Bagaimana cara berbagi hasil ke perangkat lain?</summary>
+                <p>Setelah convert, buka kartu preview dan pilih tombol QR. Kode tersebut dapat dipindai dari ponsel sehingga file bisa diunduh tanpa perlu menyalin tautan secara manual.</p>
+              </details>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </main>
@@ -717,6 +792,11 @@
   const aiPitchCopy = $('#aiPitchCopy');
   const aiPitchHook = $('#aiPitchHook');
   const aiPitchPlaylists = $('#aiPitchPlaylists');
+  const aiAudiophileBtn = $('#aiAudiophileBtn');
+  const aiAudiophileWrap = $('#aiAudiophileWrap');
+  const aiAudiophileText = $('#aiAudiophileText');
+  const aiAudiophileCopy = $('#aiAudiophileCopy');
+  const aiAudiophileMeta = $('#aiAudiophileMeta');
   const playlistResultWrap = $('#playlistResultWrap');
   const playlistDownloadLink = $('#playlistDownloadLink');
   const playlistInfo = $('#playlistInfo');
@@ -880,6 +960,7 @@
   let currentShareUrl = '';
   let miniSeeking = false;
   let subtitleShareUrl = '';
+  let subtitleFullText = '';
   let lastPreviewTitle = '';
   let lastPreviewMeta = {};
   let lastResult = null;
@@ -946,6 +1027,12 @@
     if (aiPitchText) aiPitchText.value = '';
     if (aiPitchHook) aiPitchHook.textContent = '';
     if (aiPitchPlaylists) aiPitchPlaylists.textContent = '';
+  };
+
+  const resetAiAudiophile = () => {
+    if (aiAudiophileWrap) aiAudiophileWrap.hidden = true;
+    if (aiAudiophileText) aiAudiophileText.value = '';
+    if (aiAudiophileMeta) aiAudiophileMeta.textContent = '';
   };
 
   const updateBackendBadge = () => {
@@ -1056,11 +1143,13 @@
     currentDownloadName = '';
     currentShareUrl = '';
     subtitleShareUrl = '';
+    subtitleFullText = '';
     lastResult = null;
     lastPreviewMeta = {};
     updateAiStatus('');
     resetAiCaption();
     resetAiPitch();
+    resetAiAudiophile();
     if (equalizerWrap) equalizerWrap.hidden = true;
     if (eqBass) eqBass.value = 0;
     if (eqMid) eqMid.value = 0;
@@ -1902,12 +1991,91 @@ $('#queueList')?.addEventListener('click', (e) => {
     }
   });
 
+  if (aiAudiophileBtn) aiAudiophileBtn.addEventListener('click', async () => {
+    const title = $('#id3Title').value.trim() || lastVideoMeta.title || $('#videoTitle').textContent.trim();
+    if (!title) { setToast('Isi judul terlebih dahulu'); return; }
+    updateAiStatus('Menganalisis karakter audio…', 'info');
+    resetAiAudiophile();
+    try {
+      const payload = {
+        title,
+        channel: $('#id3Artist').value.trim() || lastVideoMeta.author || '',
+        duration: Number(previewPlayer?.duration || 0) || undefined,
+        genre: id3Genre ? (id3Genre.value.trim() || undefined) : undefined,
+        format: $('#format').value,
+        sampleRate: Number(sampleRateSelect?.value || 0) || undefined,
+        speedMode: $('#speedMode').value,
+        denoise: denoiseInput?.checked || false,
+        volumeBoost: Number(volumeBoost?.value || 0) || 0,
+        enhancer: enhancerSelect?.value || 'none',
+        normalize: $('#normalize').checked,
+      };
+      const resp = await fetch(api('/api/ai-audiophile'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const data = await resp.json();
+      if (!resp.ok) throw new Error(data.error || 'Gagal membuat panduan');
+      const guide = data.guide || {};
+      const lines = [];
+      const summary = (guide.summary || '').trim();
+      const sampleAdvice = (guide.sampleRate || '').trim();
+      if (summary) lines.push(summary);
+      if (sampleAdvice) lines.push('', `Sample rate: ${sampleAdvice}`);
+      if (Array.isArray(guide.eq) && guide.eq.length) {
+        lines.push('', 'Rekomendasi EQ:');
+        guide.eq.filter(Boolean).forEach((item) => lines.push(`- ${item}`));
+      }
+      if (Array.isArray(guide.playback) && guide.playback.length) {
+        lines.push('', 'Monitoring & playback:');
+        guide.playback.filter(Boolean).forEach((item) => lines.push(`- ${item}`));
+      }
+      if (Array.isArray(guide.enhancements) && guide.enhancements.length) {
+        lines.push('', 'Catatan tambahan:');
+        guide.enhancements.filter(Boolean).forEach((item) => lines.push(`- ${item}`));
+      }
+      const text = lines.join('\n').replace(/\n{3,}/g, '\n\n').trim();
+      if (aiAudiophileText) {
+        aiAudiophileText.value = text;
+        const lineCount = text ? text.split(/\n/).length : 5;
+        aiAudiophileText.rows = Math.min(12, Math.max(5, lineCount));
+      }
+      if (aiAudiophileMeta) {
+        const metaParts = [];
+        if (guide.focus) metaParts.push(`Fokus: ${guide.focus}`);
+        if (guide.tags?.genre) metaParts.push(`Genre: ${guide.tags.genre}`);
+        if (guide.tags?.mood) metaParts.push(`Mood: ${guide.tags.mood}`);
+        if (guide.tags?.energy) metaParts.push(`Energi: ${guide.tags.energy}`);
+        aiAudiophileMeta.textContent = metaParts.join(' · ');
+      }
+      if (aiAudiophileWrap) aiAudiophileWrap.hidden = false;
+      updateAiStatus('Panduan audiophile siap digunakan 🎧', 'success');
+      setToast('Panduan audiophile siap disalin');
+    } catch (err) {
+      resetAiAudiophile();
+      updateAiStatus(err.message, 'danger');
+      setToast('Gagal AI audiophile: ' + err.message);
+    }
+  });
+
   if (aiPitchCopy) aiPitchCopy.addEventListener('click', async () => {
     const text = aiPitchText?.value?.trim();
     if (!text) { setToast('Belum ada pitch untuk disalin'); return; }
     try {
       await navigator.clipboard.writeText(text);
       setToast('Pitch disalin ke clipboard');
+    } catch {
+      setToast('Clipboard tidak tersedia');
+    }
+  });
+
+  if (aiAudiophileCopy) aiAudiophileCopy.addEventListener('click', async () => {
+    const text = aiAudiophileText?.value?.trim();
+    if (!text) { setToast('Belum ada panduan audiophile untuk disalin'); return; }
+    try {
+      await navigator.clipboard.writeText(text);
+      setToast('Panduan audiophile disalin');
     } catch {
       setToast('Clipboard tidak tersedia');
     }
@@ -1989,13 +2157,14 @@ $('#queueList')?.addEventListener('click', (e) => {
     if (subtitlePreview) subtitlePreview.textContent = '';
     if (subtitleAutoBadge) subtitleAutoBadge.hidden = true;
     subtitleShareUrl = '';
+    subtitleFullText = '';
     $('#resultWrap').hidden=true; $('#statusWrap').hidden=true; $('#logWrap').hidden=true; $('#logs').textContent='';
     $('#convertProgWrap').hidden=true;
   });
   $('#url').addEventListener('keydown', (e)=>{ if(e.key==='Enter') doConvert(null, $('#autoDownload').checked); });
 
   if (subtitleCopyBtn) subtitleCopyBtn.addEventListener('click', async () => {
-    const text = (subtitlePreview?.textContent || '').trim();
+    const text = (subtitleFullText || subtitlePreview?.textContent || '').trim();
     if (!text){ setToast('Belum ada teks subtitle'); return; }
     try {
       await navigator.clipboard.writeText(text);
@@ -2246,12 +2415,25 @@ $('#queueList')?.addEventListener('click', (e) => {
         subtitleTxtLink.href = data.txtUrl || '#';
         if (data.txtFileName) subtitleTxtLink.setAttribute('download', data.txtFileName);
       }
-      if (subtitlePreview) subtitlePreview.textContent = data.preview || '(Tidak ada preview tersedia)';
-      if (subtitleStatus) subtitleStatus.textContent = 'Subtitle siap diunduh';
+      const rawText = (data.text || data.preview || '').trim();
+      subtitleFullText = rawText;
+      if (subtitlePreview) {
+        subtitlePreview.textContent = rawText || '(Tidak ada teks tersedia)';
+        subtitlePreview.scrollTop = 0;
+      }
+      if (subtitleStatus) {
+        const lineCount = Number(data.lineCount);
+        const wordCount = Number(data.wordCount);
+        const metaParts = [];
+        if (Number.isFinite(lineCount) && lineCount > 0) metaParts.push(`${lineCount} baris`);
+        if (Number.isFinite(wordCount) && wordCount > 0) metaParts.push(`${wordCount} kata`);
+        subtitleStatus.textContent = metaParts.length ? `Subtitle lengkap (${metaParts.join(' · ')})` : 'Subtitle siap diunduh';
+      }
       subtitleShareUrl = data.txtUrl ? new URL(data.txtUrl, window.location.origin).href : (data.srtUrl ? new URL(data.srtUrl, window.location.origin).href : '');
       if (subtitleResult) subtitleResult.hidden = false;
-      setToast('Subtitle siap diunduh');
+      setToast('Subtitle lengkap siap diunduh');
     } catch(err){
+      subtitleFullText = '';
       if (subtitleStatus) subtitleStatus.textContent = 'Gagal mengambil subtitle';
       if (subtitlePreview) subtitlePreview.textContent = err.message || 'Terjadi kesalahan';
       if (subtitleResult) subtitleResult.hidden = false;

--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -32,6 +32,23 @@
     .history-link { word-break: break-all; }
     .dropzone { border: 2px dashed var(--bs-border-color); border-radius: 1rem; padding: 1rem; text-align:center; transition: .2s; }
     .dropzone.dragover { background: rgba(0,0,0,.03); border-color: var(--bs-primary); }
+    .preview-card audio { border-radius: .8rem; background: var(--bs-body-bg); }
+    #qrWrap, #playlistQrWrap { min-width: 150px; }
+    #qrWrap canvas, #playlistQrWrap canvas { width: 100%; height: auto; max-width: 160px; }
+    #playlistShareCard { margin-top: .75rem; }
+    #urlDropOverlay { position: fixed; inset: 0; background: rgba(13,110,253,.1); display: flex; align-items: center; justify-content: center; font-size: 1.5rem; font-weight: 600; color: var(--bs-primary); z-index: 1090; backdrop-filter: blur(2px); padding: 1rem; text-align:center; }
+    #urlDropOverlay[hidden] { display: none !important; }
+    @media (max-width: 576px) {
+      body { padding-bottom: 5rem; }
+      .btn { padding: .75rem 1rem; font-size: 1.05rem; }
+      .input-group { flex-wrap: wrap; gap: .5rem; }
+      .input-group .form-control, .input-group .form-select { flex: 1 1 100%; }
+      .input-group .input-group-text { width: 100%; justify-content: center; border-radius: .9rem; }
+      .input-group > .btn { width: 100%; }
+      .d-sm-flex > .btn { flex: 1 1 auto; }
+      .form-check-input { transform: scale(1.2); margin-right: .5rem; }
+      #qrWrap, #playlistQrWrap { min-width: 120px; }
+    }
   </style>
 </head>
 <body>
@@ -97,15 +114,17 @@
             </div>
 
             <div class="row g-3 mb-3">
-              <div class="col-md-4">
+              <div class="col-md-3">
                 <label for="format" class="form-label">Format</label>
                 <select id="format" class="form-select">
                   <option value="mp3">MP3 (re-encode, fleksibel)</option>
                   <option value="m4a" selected>M4A (super cepat)</option>
                   <option value="flac">FLAC (Hi-Res lossless)</option>
+                  <option value="wav">WAV (PCM lossless)</option>
+                  <option value="ogg">OGG Vorbis</option>
                 </select>
               </div>
-              <div class="col-md-4">
+              <div class="col-md-3">
                 <label for="abr" class="form-label">Kualitas (MP3)</label>
                 <select id="abr" class="form-select">
                   <option value="320">320 kbps</option>
@@ -115,12 +134,20 @@
                   <option value="64">64 kbps</option>
                 </select>
               </div>
-              <div class="col-md-4">
+              <div class="col-md-3">
                 <label for="sampleRate" class="form-label">Sample Rate</label>
                 <select id="sampleRate" class="form-select">
                   <option value="44100" selected>44.1 kHz</option>
                   <option value="48000">48 kHz</option>
                   <option value="96000">96 kHz (Hi-Res)</option>
+                </select>
+              </div>
+              <div class="col-md-3">
+                <label for="speedMode" class="form-label">Mode Kecepatan</label>
+                <select id="speedMode" class="form-select">
+                  <option value="normal" selected>Normal</option>
+                  <option value="nightcore">Nightcore ⚡</option>
+                  <option value="slow_reverb">Slowed + Reverb</option>
                 </select>
               </div>
             </div>
@@ -198,6 +225,7 @@
             <div class="d-grid d-sm-flex gap-2 align-items-center">
               <button id="convertBtn" class="btn btn-primary btn-lg"><i class="bi bi-magic"></i> Convert</button>
               <button id="downloadAllBtn" class="btn btn-outline-primary"><i class="bi bi-download"></i> Download Semua</button>
+              <button id="downloadZipBtn" class="btn btn-success"><i class="bi bi-collection"></i> Download ZIP</button>
               <button id="clearBtn" class="btn btn-outline-secondary"><i class="bi bi-x-circle"></i> Bersihkan</button>
             </div>
 
@@ -220,6 +248,43 @@
                 <i class="bi bi-check-circle me-2"></i>
                 <div>
                   Selesai! <a id="downloadLink" class="alert-link" href="#" download>Download hasil</a>
+                </div>
+              </div>
+              <div class="card border-0 bg-body-tertiary preview-card" id="previewCard" hidden>
+                <div class="card-body d-flex flex-column flex-md-row align-items-start gap-3">
+                  <div class="flex-grow-1 w-100">
+                    <div class="d-flex align-items-center gap-2">
+                      <i class="bi bi-play-circle-fill text-primary"></i>
+                      <strong>Preview Audio</strong>
+                    </div>
+                    <audio id="previewPlayer" class="w-100 mt-2" controls preload="none"></audio>
+                  </div>
+                  <div id="qrWrap" class="text-center" hidden>
+                    <canvas id="downloadQr" width="156" height="156" class="border rounded bg-body"></canvas>
+                    <div class="small text-secondary mt-2"><i class="bi bi-qr-code"></i> Scan untuk unduh</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-3" id="playlistResultWrap" hidden>
+              <div class="alert alert-info d-flex align-items-center" role="alert">
+                <i class="bi bi-collection-play me-2"></i>
+                <div>
+                  Playlist ZIP siap! <a id="playlistDownloadLink" class="alert-link" href="#" download>Download ZIP</a>
+                  <div class="small text-secondary" id="playlistInfo"></div>
+                </div>
+              </div>
+              <div class="card border-0 bg-body-tertiary" id="playlistShareCard" hidden>
+                <div class="card-body d-flex flex-column flex-md-row align-items-start gap-3">
+                  <div class="flex-grow-1">
+                    <strong>Bagikan playlist</strong>
+                    <p class="small text-secondary mb-0">Scan kode QR untuk unduh ZIP di perangkat lain.</p>
+                  </div>
+                  <div id="playlistQrWrap" class="text-center" hidden>
+                    <canvas id="playlistQr" width="156" height="156" class="border rounded bg-body"></canvas>
+                    <div class="small text-secondary mt-2">Scan untuk unduh ZIP</div>
+                  </div>
                 </div>
               </div>
             </div>
@@ -347,7 +412,14 @@
     </div>
   </div>
 
+  <div id="urlDropOverlay" hidden>
+    <div class="text-center">
+      <i class="bi bi-link-45deg me-2"></i>Lepas URL YouTube untuk diisi otomatis
+    </div>
+  </div>
+
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.min.js" defer></script>
   <script>
   document.addEventListener('DOMContentLoaded', () => {
   // ===== Utilities =====
@@ -355,6 +427,18 @@
   const $$ = (sel) => document.querySelectorAll(sel);
   const toast = new bootstrap.Toast($('#toast'));
   const setToast = (msg) => { $('#toastText').textContent = msg; toast.show(); };
+
+  const previewCard = $('#previewCard');
+  const previewPlayer = $('#previewPlayer');
+  const qrCanvas = $('#downloadQr');
+  const qrWrap = $('#qrWrap');
+  const playlistResultWrap = $('#playlistResultWrap');
+  const playlistDownloadLink = $('#playlistDownloadLink');
+  const playlistInfo = $('#playlistInfo');
+  const playlistShareCard = $('#playlistShareCard');
+  const playlistQrCanvas = $('#playlistQr');
+  const playlistQrWrap = $('#playlistQrWrap');
+  const urlDropOverlay = $('#urlDropOverlay');
 
   const storage = {
     get k(){ return 'ytmp3.settings.v1'; },
@@ -377,6 +461,66 @@
     const badge = $('#backendBadge');
     const b = getBackend();
     badge.textContent = b ? new URL(b).host : location.host;
+  };
+
+  const renderQr = (canvas, wrap, url) => {
+    if (!canvas || !wrap) return;
+    const ctx = canvas.getContext('2d');
+    if (!url) {
+      wrap.hidden = true;
+      if (ctx) ctx.clearRect(0, 0, canvas.width, canvas.height);
+      return;
+    }
+    wrap.hidden = false;
+    if (window.QRCode && typeof window.QRCode.toCanvas === 'function') {
+      window.QRCode.toCanvas(canvas, url, { width: canvas.width || 156, margin: 1 }, (err) => {
+        if (err) console.error(err);
+      });
+    } else if (ctx) {
+      ctx.fillStyle = '#fff';
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.fillStyle = '#000';
+      ctx.font = '16px sans-serif';
+      ctx.fillText('QR', 10, 24);
+    }
+  };
+
+  const resetAudioPreview = () => {
+    if (previewPlayer) {
+      try { previewPlayer.pause(); } catch {}
+      previewPlayer.removeAttribute('src');
+      previewPlayer.load();
+    }
+    if (previewCard) previewCard.hidden = true;
+    renderQr(qrCanvas, qrWrap, null);
+  };
+
+  const showAudioPreview = (url) => {
+    if (!previewPlayer || !previewCard || !url) return;
+    const cacheBuster = url.includes('?') ? '&' : '?';
+    previewPlayer.src = `${url}${cacheBuster}preview=${Date.now()}`;
+    previewCard.hidden = false;
+    renderQr(qrCanvas, qrWrap, url);
+  };
+
+  const resetPlaylistPreview = () => {
+    if (playlistResultWrap) playlistResultWrap.hidden = true;
+    if (playlistShareCard) playlistShareCard.hidden = true;
+    renderQr(playlistQrCanvas, playlistQrWrap, null);
+  };
+
+  const showPlaylistResult = (data, count) => {
+    if (!playlistResultWrap || !data) return;
+    playlistResultWrap.hidden = false;
+    if (playlistDownloadLink) {
+      playlistDownloadLink.href = data.downloadUrl;
+      playlistDownloadLink.setAttribute('download', data.fileName || 'playlist.zip');
+    }
+    if (playlistInfo) {
+      playlistInfo.textContent = `${count} file siap diunduh`;
+    }
+    if (playlistShareCard) playlistShareCard.hidden = false;
+    renderQr(playlistQrCanvas, playlistQrWrap, data.downloadUrl);
   };
 
   // ===== Queue =====
@@ -639,6 +783,7 @@ $('#queueList')?.addEventListener('click', (e) => {
   // ===== Convert handler =====
   $('#convertBtn').addEventListener('click', () => doConvert(null, $('#autoDownload').checked));
   $('#downloadAllBtn').addEventListener('click', doConvertQueue);
+  $('#downloadZipBtn').addEventListener('click', downloadPlaylistZip);
   $('#clearBtn').addEventListener('click', () => {
     $('#url').value='';
     $('#playlist').value='';
@@ -652,6 +797,8 @@ $('#queueList')?.addEventListener('click', (e) => {
     $('#normalize').checked=false;
     $('#atmos').checked=false;
     $('#previewWrap').hidden=true; $('#thumb').src=''; $('#videoTitle').textContent='';
+    resetAudioPreview();
+    resetPlaylistPreview();
     $('#resultWrap').hidden=true; $('#statusWrap').hidden=true; $('#logWrap').hidden=true; $('#logs').textContent='';
     $('#convertProgWrap').hidden=true;
   });
@@ -660,6 +807,8 @@ $('#queueList')?.addEventListener('click', (e) => {
   async function doConvert(urlOverride, autoDownload = false){
     const url = (urlOverride || $('#url').value).trim();
     if(!/^https?:\/\//i.test(url)){ setToast('Masukkan URL YouTube yang valid'); $('#url').focus(); return; }
+    resetAudioPreview();
+    if(!urlOverride) resetPlaylistPreview();
     const body = {
       url,
       format: $('#format').value,
@@ -667,7 +816,8 @@ $('#queueList')?.addEventListener('click', (e) => {
       sampleRate: Number($('#sampleRate').value),
       fileName: sanitizeFileName($('#fileName').value.trim()),
       noPlaylist: $('#noPlaylist').checked,
-      atmos: $('#atmos').checked
+      atmos: $('#atmos').checked,
+      speedMode: $('#speedMode').value
     };
 
     const id3 = {
@@ -712,6 +862,7 @@ $('#queueList')?.addEventListener('click', (e) => {
       if(data.logs && $('#showLog').checked){ $('#logs').textContent = data.logs; }
       if(autoDownload) $('#downloadLink').click();
       pushHistory({ downloadUrl: data.downloadUrl, format: data.format, abr: body.abr, fileName: data.fileName });
+      showAudioPreview(data.downloadUrl);
       setToast('Berhasil diproses');
       if($('#autoClear').checked && !urlOverride){ $('#clearBtn').click(); }
     }catch(err){
@@ -720,6 +871,7 @@ $('#queueList')?.addEventListener('click', (e) => {
       $('#resultWrap').hidden = true;
       $('#logWrap').hidden = false;
       $('#logs').textContent = (err && err.stack) ? err.stack : String(err);
+      resetAudioPreview();
       setToast('Terjadi error: '+err.message);
     } finally {
       clearInterval(timer);
@@ -747,6 +899,101 @@ $('#queueList')?.addEventListener('click', (e) => {
     progress.hidden = true;
     setToast('Semua antrian selesai');
   }
+
+  async function downloadPlaylistZip(){
+    const itemsSrc = queue.length ? [...queue] : $('#playlist').value.split(/\n+/).map(s=>s.trim()).filter(u=>/^https?:\/\//i.test(u)).map(url => ({ url, title: '' }));
+    if(!itemsSrc.length){ setToast('Antrian kosong'); return; }
+    resetPlaylistPreview();
+    $('#statusWrap').hidden = false; $('#resultWrap').hidden = true; $('#logWrap').hidden = true; $('#logs').textContent = '';
+    $('#loadingSpinner').style.display = '';
+    $('#status').textContent = 'Menyiapkan ZIP…';
+
+    const trim = {};
+    const s = parseTime($('#trimStart').value.trim());
+    const e = parseTime($('#trimEnd').value.trim());
+    if(s !== null) trim.start = s;
+    if(e !== null) trim.end = e;
+
+    const id3 = {
+      title: $('#id3Title').value.trim(),
+      artist: $('#id3Artist').value.trim(),
+      album: $('#id3Album').value.trim()
+    };
+    Object.keys(id3).forEach(k => { if(!id3[k]) delete id3[k]; });
+
+    const items = itemsSrc.map(item => ({
+      url: item.url || item,
+      fileName: sanitizeFileName(item.title || item.url || ''),
+    }));
+
+    const body = {
+      items,
+      format: $('#format').value,
+      abr: Number($('#abr').value),
+      sampleRate: Number($('#sampleRate').value),
+      normalize: $('#normalize').checked,
+      coverUrl: $('#thumb').src || undefined,
+      atmos: $('#atmos').checked,
+      speedMode: $('#speedMode').value,
+      zipName: sanitizeFileName($('#fileName').value.trim()) || undefined,
+    };
+    if(Object.keys(trim).length) body.trim = trim;
+    if(Object.keys(id3).length) body.id3 = id3;
+
+    try {
+      const resp = await fetch(api('/api/convert-playlist'), { method:'POST', headers:{ 'Content-Type':'application/json' }, body: JSON.stringify(body) });
+      const data = await resp.json();
+      if(!resp.ok) throw new Error(data.error || 'Gagal membuat ZIP');
+      $('#loadingSpinner').style.display = 'none';
+      $('#status').textContent = 'ZIP selesai';
+      showPlaylistResult(data, items.length);
+      setToast(`Playlist ZIP siap (${items.length} file)`);
+      pushHistory({ downloadUrl: data.downloadUrl, format: 'zip', abr: body.abr, fileName: data.fileName });
+      if($('#autoDownload').checked && playlistDownloadLink){ playlistDownloadLink.click(); }
+      if($('#autoClear').checked){ queue.length = 0; renderQueue(); $('#playlist').value=''; }
+    } catch(err){
+      $('#status').textContent = 'Error: ' + err.message;
+      $('#loadingSpinner').style.display = 'none';
+      $('#logWrap').hidden = false;
+      $('#logs').textContent = (err && err.stack) ? err.stack : String(err);
+      setToast('Terjadi error: '+err.message);
+    }
+  }
+
+  let urlDragDepth = 0;
+  const isUrlDrag = (e) => {
+    const dt = e.dataTransfer;
+    if(!dt) return false;
+    if(dt.types && Array.from(dt.types).includes('Files')) return false;
+    return true;
+  };
+
+  ['dragenter', 'dragleave'].forEach(ev => {
+    document.addEventListener(ev, (e) => {
+      if(!isUrlDrag(e)) return;
+      if(ev === 'dragenter'){ urlDragDepth += 1; if(urlDropOverlay) urlDropOverlay.hidden = false; }
+      else { urlDragDepth = Math.max(0, urlDragDepth - 1); if(urlDragDepth === 0 && urlDropOverlay) urlDropOverlay.hidden = true; }
+      e.preventDefault();
+    });
+  });
+
+  document.addEventListener('dragover', (e) => {
+    if(!isUrlDrag(e)) return;
+    e.preventDefault();
+  });
+
+  document.addEventListener('drop', (e) => {
+    if(!isUrlDrag(e)) return;
+    e.preventDefault();
+    urlDragDepth = 0;
+    if(urlDropOverlay) urlDropOverlay.hidden = true;
+    const data = e.dataTransfer.getData('text/uri-list') || e.dataTransfer.getData('text/plain');
+    if(data){
+      $('#url').value = data.trim();
+      updatePreview();
+      setToast('URL ditempel dari drag & drop');
+    }
+  });
 
   // ===== Copy log =====
   $('#copyLog').addEventListener('click', async ()=>{

--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -38,37 +38,28 @@
     #playlistShareCard { margin-top: .75rem; }
     #urlDropOverlay { position: fixed; inset: 0; background: rgba(13,110,253,.1); display: flex; align-items: center; justify-content: center; font-size: 1.5rem; font-weight: 600; color: var(--bs-primary); z-index: 1090; backdrop-filter: blur(2px); padding: 1rem; text-align:center; }
     #urlDropOverlay[hidden] { display: none !important; }
-    #waveformWrap, #equalizerWrap, #shareWrap { background: var(--bs-secondary-bg); border: 1px solid var(--bs-border-color); border-radius: 1rem; padding: 1rem; }
-    #waveformCanvas { width: 100%; height: 140px; display: block; border-radius: .85rem; background: var(--bs-body-bg); cursor: crosshair; box-shadow: inset 0 0 0 1px rgba(0,0,0,.04); }
-    #waveformCanvas::selection { background: transparent; }
-    #waveformCanvas[data-loading="1"] { opacity: .55; }
-    #waveformMeta { font-size: .85rem; }
+    #equalizerWrap, #shareWrap { background: var(--bs-secondary-bg); border: 1px solid var(--bs-border-color); border-radius: 1rem; padding: 1rem; box-shadow: 0 12px 32px rgba(13,110,253,.08); }
     .eq-slider label { font-size: .75rem; text-transform: uppercase; letter-spacing: .08em; color: var(--bs-secondary); }
-    .eq-slider .form-range { height: 1.6rem; appearance: none; background: linear-gradient(90deg, rgba(220,53,69,.2) 0%, rgba(13,110,253,.25) 100%); border-radius: 999px; transition: background .2s ease; }
-    .eq-slider .form-range:focus { outline: none; box-shadow: none; }
+    .eq-slider .form-range { height: 1.6rem; appearance: none; background: linear-gradient(90deg, rgba(13,110,253,.28) 0%, rgba(111,66,193,.38) 55%, rgba(220,53,69,.32) 100%); border-radius: 999px; box-shadow: inset 0 0 0 1px rgba(255,255,255,.12), 0 6px 18px rgba(13,110,253,.15); transition: box-shadow .2s ease, background .2s ease; }
+    .eq-slider .form-range:focus-visible { outline: none; box-shadow: inset 0 0 0 1px rgba(255,255,255,.18), 0 0 0 .35rem rgba(13,110,253,.25); }
     .eq-slider .form-range::-webkit-slider-runnable-track { height: .55rem; border-radius: 999px; background: transparent; }
     .eq-slider .form-range::-moz-range-track { height: .55rem; border-radius: 999px; background: transparent; }
-    .eq-slider .form-range::-webkit-slider-thumb { -webkit-appearance: none; width: 18px; height: 18px; border-radius: 50%; background: var(--bs-primary); border: 2px solid var(--bs-body-bg); box-shadow: 0 2px 6px rgba(0,0,0,.25); transition: transform .15s ease, background .2s ease; margin-top: -6.5px; }
-    .eq-slider .form-range::-moz-range-thumb { width: 18px; height: 18px; border-radius: 50%; background: var(--bs-primary); border: 2px solid var(--bs-body-bg); box-shadow: 0 2px 6px rgba(0,0,0,.25); transition: transform .15s ease, background .2s ease; }
-    .eq-slider .form-range:active::-webkit-slider-thumb, .eq-slider .form-range:active::-moz-range-thumb { transform: scale(1.1); }
+    .eq-slider .form-range::-webkit-slider-thumb { -webkit-appearance: none; width: 20px; height: 20px; border-radius: 50%; background: radial-gradient(circle at 30% 30%, #ffffff 0%, rgba(255,255,255,.65) 40%, rgba(13,110,253,1) 100%); border: 2px solid rgba(255,255,255,.85); box-shadow: 0 0 12px rgba(13,110,253,.55), 0 4px 10px rgba(0,0,0,.25); transition: transform .15s ease, box-shadow .2s ease; margin-top: -7px; }
+    .eq-slider .form-range::-moz-range-thumb { width: 20px; height: 20px; border-radius: 50%; background: radial-gradient(circle at 30% 30%, #ffffff 0%, rgba(255,255,255,.65) 40%, rgba(13,110,253,1) 100%); border: 2px solid rgba(255,255,255,.85); box-shadow: 0 0 12px rgba(13,110,253,.55), 0 4px 10px rgba(0,0,0,.25); transition: transform .15s ease, box-shadow .2s ease; }
+    .eq-slider .form-range:active::-webkit-slider-thumb, .eq-slider .form-range:active::-moz-range-thumb { transform: scale(1.08); box-shadow: 0 0 18px rgba(111,66,193,.55), 0 6px 14px rgba(0,0,0,.3); }
     .eq-slider .eq-value { font-size: .7rem; font-weight: 600; background: var(--bs-primary-bg-subtle); color: var(--bs-primary-text); border-radius: .65rem; padding: .2rem .45rem; min-width: 3.4rem; text-align: center; }
     html[data-bs-theme='dark'] .eq-slider .eq-value { background: color-mix(in srgb, var(--bs-primary) 22%, transparent); color: var(--bs-body-color); }
     #shareWrap .input-group-text { border-radius: .75rem 0 0 .75rem; }
     #subtitleResult pre { max-height: 160px; overflow:auto; background: var(--bs-body-bg); border-radius: .75rem; padding: .75rem; }
     #subtitleResult .btn { border-radius: .75rem; }
     #subtitleResult .badge { border-radius: .75rem; }
-    #stemResultCard { background: color-mix(in srgb, var(--bs-body-bg) 90%, rgba(13,110,253,.05)); border: 1px solid color-mix(in srgb, var(--bs-primary) 12%, transparent); border-radius: 1.15rem; padding: 1.25rem; box-shadow: 0 12px 32px rgba(13,110,253,.06); }
-    .stem-preview { background: var(--bs-secondary-bg); border-radius: 1rem; border: 1px solid color-mix(in srgb, var(--bs-border-color) 70%, transparent); padding: 1rem; display: flex; flex-direction: column; gap: .75rem; height: 100%; }
-    .stem-preview audio { width: 100%; border-radius: .85rem; background: var(--bs-body-bg); }
-    .stem-preview .btn { border-radius: .75rem; }
-    #stemMeta { font-size: .75rem; color: var(--bs-secondary); }
-    #stemLoading { font-size: .8rem; color: var(--bs-secondary); }
-    html[data-bs-theme='dark'] #stemResultCard { background: color-mix(in srgb, var(--bs-body-bg) 75%, rgba(13,110,253,.08)); border-color: color-mix(in srgb, var(--bs-primary) 20%, transparent); box-shadow: 0 12px 32px rgba(13,110,253,.12); }
-    html[data-bs-theme='dark'] .stem-preview { background: color-mix(in srgb, var(--bs-secondary-bg) 80%, rgba(255,255,255,.04)); border-color: color-mix(in srgb, rgba(255,255,255,.08) 40%, transparent); }
     .mini-player { position: fixed; left: 0; right: 0; bottom: 1rem; display: flex; justify-content: center; pointer-events: none; z-index: 1090; }
     .mini-player-card { pointer-events: auto; border-radius: 1rem; width: min(420px, calc(100% - 2.5rem)); }
     .mini-player .btn { border-radius: 50%; }
-    .mini-player .form-range { height: 1rem; }
+    .mini-player .form-range { height: 1rem; appearance: none; background: linear-gradient(90deg, rgba(13,110,253,.35) 0%, rgba(32,201,151,.35) 50%, rgba(220,53,69,.35) 100%); border-radius: 999px; box-shadow: inset 0 0 0 1px rgba(255,255,255,.18), 0 4px 14px rgba(13,110,253,.18); }
+    .mini-player .form-range::-webkit-slider-runnable-track, .mini-player .form-range::-moz-range-track { height: .45rem; border-radius: 999px; background: transparent; }
+    .mini-player .form-range::-webkit-slider-thumb { -webkit-appearance: none; width: 16px; height: 16px; border-radius: 50%; background: radial-gradient(circle at 30% 30%, #fff 0%, rgba(255,255,255,.6) 45%, rgba(32,201,151,1) 100%); border: 2px solid rgba(255,255,255,.9); box-shadow: 0 0 10px rgba(32,201,151,.6), 0 2px 6px rgba(0,0,0,.25); margin-top: -6px; }
+    .mini-player .form-range::-moz-range-thumb { width: 16px; height: 16px; border-radius: 50%; background: radial-gradient(circle at 30% 30%, #fff 0%, rgba(255,255,255,.6) 45%, rgba(32,201,151,1) 100%); border: 2px solid rgba(255,255,255,.9); box-shadow: 0 0 10px rgba(32,201,151,.6), 0 2px 6px rgba(0,0,0,.25); }
     .mini-player-card { background: radial-gradient(circle at top left, rgba(13,110,253,.12), transparent 60%), radial-gradient(circle at bottom right, rgba(220,53,69,.12), transparent 55%), var(--bs-body-bg); backdrop-filter: blur(6px); }
     .mini-player-title { font-size: .85rem; letter-spacing: .01em; }
     .mini-player-subtitle { font-size: .7rem; color: var(--bs-secondary); margin-top: .1rem; }
@@ -86,7 +77,6 @@
       #qrWrap, #playlistQrWrap { min-width: 120px; }
       .mini-player { bottom: .75rem; }
       .mini-player-card { width: calc(100% - 1.5rem); }
-      #waveformCanvas { height: 110px; }
     }
   </style>
 </head>
@@ -296,70 +286,17 @@
             <div class="card border-0 bg-body-tertiary mt-4" id="aiStudioCard">
               <div class="card-body">
                 <div class="d-flex flex-wrap align-items-center gap-2 mb-3">
-                  <strong class="me-auto">AI Studio & Cloud</strong>
+                  <strong class="me-auto">AI Studio</strong>
                   <div class="form-check form-switch m-0">
                     <input class="form-check-input" type="checkbox" id="backgroundMode">
                     <label class="form-check-label small" for="backgroundMode">Background mode</label>
                   </div>
                 </div>
-                <div class="row g-3">
-                  <div class="col-md-6">
-                    <div class="d-grid gap-2">
-                      <button class="btn btn-outline-primary" id="autoTagBtn" type="button"><i class="bi bi-stars"></i> Auto Music Tags</button>
-                      <button class="btn btn-outline-secondary" id="thumbnailBtn" type="button"><i class="bi bi-image"></i> AI Thumbnail</button>
-                      <button class="btn btn-outline-success" id="stemBtn" type="button"><i class="bi bi-mic-fill"></i> Voice ↔ Instrumental</button>
-                    </div>
-                  </div>
-                  <div class="col-md-6">
-                    <div class="d-grid gap-2">
-                      <button class="btn btn-outline-primary" id="cloudDriveBtn" type="button"><i class="bi bi-cloud-arrow-up"></i> Save to Drive</button>
-                      <button class="btn btn-outline-primary" id="cloudDropboxBtn" type="button"><i class="bi bi-cloud-upload"></i> Save to Dropbox</button>
-                      <button class="btn btn-outline-primary" id="cloudOnedriveBtn" type="button"><i class="bi bi-cloud"></i> Save to OneDrive</button>
-                    </div>
-                  </div>
+                <p class="text-secondary small mb-3">Gunakan Auto Music Tags untuk mengisi metadata secara instan sekaligus menyimpan job ke background queue bila diperlukan.</p>
+                <div class="d-grid d-sm-flex gap-2">
+                  <button class="btn btn-outline-primary flex-grow-1" id="autoTagBtn" type="button"><i class="bi bi-stars"></i> Auto Music Tags</button>
                 </div>
                 <div class="alert alert-info mt-3 small" id="aiStatus" hidden></div>
-                <div class="mt-3" id="stemResult" hidden>
-                  <div id="stemResultCard">
-                    <div class="d-flex flex-wrap align-items-center gap-2 mb-3">
-                      <div class="d-flex align-items-center gap-2">
-                        <span class="badge rounded-pill text-bg-primary"><i class="bi bi-sliders"></i></span>
-                        <strong>Stems siap</strong>
-                      </div>
-                      <span class="badge rounded-pill bg-body-tertiary text-secondary" id="stemMeta" hidden></span>
-                      <button class="btn btn-sm btn-outline-secondary ms-auto" id="stemClearBtn" type="button"><i class="bi bi-x"></i> Tutup</button>
-                    </div>
-                    <div class="row g-3 align-items-stretch" id="stemPreviewWrap">
-                      <div class="col-12 col-lg-6">
-                        <div class="stem-preview">
-                          <div class="d-flex align-items-center gap-2">
-                            <span class="badge rounded-pill text-bg-primary"><i class="bi bi-mic-fill"></i> Vocals</span>
-                            <a id="stemVocalsLink" class="btn btn-sm btn-primary ms-auto" href="#" download><i class="bi bi-download"></i> Download</a>
-                          </div>
-                          <audio id="stemVocalsPlayer" controls preload="none"></audio>
-                        </div>
-                      </div>
-                      <div class="col-12 col-lg-6">
-                        <div class="stem-preview">
-                          <div class="d-flex align-items-center gap-2">
-                            <span class="badge rounded-pill text-bg-info text-dark"><i class="bi bi-music-note-beamed"></i> Instrumental</span>
-                            <a id="stemInstrumentalLink" class="btn btn-sm btn-outline-primary ms-auto" href="#" download><i class="bi bi-download"></i> Download</a>
-                          </div>
-                          <audio id="stemInstrumentalPlayer" controls preload="none"></audio>
-                        </div>
-                      </div>
-                    </div>
-                    <div class="d-flex flex-wrap align-items-center gap-2 mt-3">
-                      <a id="stemZipLink" class="btn btn-outline-secondary" href="#" download><i class="bi bi-file-earmark-zip"></i> Unduh ZIP</a>
-                      <div class="ms-auto" id="stemLoading" hidden>
-                        <div class="d-inline-flex align-items-center gap-2 small text-secondary">
-                          <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
-                          <span>Sedang memproses…</span>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
               </div>
             </div>
 
@@ -445,19 +382,6 @@
                         <button class="btn btn-outline-secondary" id="openShareBtn" type="button" aria-label="Buka link share"><i class="bi bi-arrow-up-right-square"></i></button>
                       </div>
                       <div class="small text-secondary mt-2" id="shareInfo"></div>
-                    </div>
-
-                    <div id="waveformWrap" class="mt-3" hidden>
-                      <div class="d-flex flex-wrap align-items-center gap-2">
-                        <strong class="me-auto">Editor Trim</strong>
-                        <span id="waveformMeta" class="text-secondary"></span>
-                        <div class="btn-group btn-group-sm" role="group">
-                          <button class="btn btn-outline-secondary" id="waveformClear" type="button"><i class="bi bi-eraser"></i> Reset</button>
-                          <button class="btn btn-outline-secondary" id="waveformUseSelection" type="button"><i class="bi bi-scissors"></i> Pakai seleksi</button>
-                        </div>
-                      </div>
-                      <canvas id="waveformCanvas" class="mt-2"></canvas>
-                      <div class="small text-secondary mt-2" id="waveformHint">Seret pada waveform untuk memilih bagian audio, kolom trim akan terisi otomatis.</div>
                     </div>
 
                     <div id="equalizerWrap" class="mt-3" hidden>
@@ -705,12 +629,6 @@
   const shareBtn = $('#shareBtn');
   const copyShareBtn = $('#copyShareBtn');
   const openShareBtn = $('#openShareBtn');
-  const waveformWrap = $('#waveformWrap');
-  const waveformCanvas = $('#waveformCanvas');
-  const waveformMeta = $('#waveformMeta');
-  const waveformHint = $('#waveformHint');
-  const waveformClearBtn = $('#waveformClear');
-  const waveformUseSelectionBtn = $('#waveformUseSelection');
   const equalizerWrap = $('#equalizerWrap');
   const eqBass = $('#eqBass');
   const eqMid = $('#eqMid');
@@ -729,61 +647,6 @@
   const backgroundMode = $('#backgroundMode');
   const aiStatus = $('#aiStatus');
   const autoTagBtn = $('#autoTagBtn');
-  const thumbnailBtn = $('#thumbnailBtn');
-  const stemBtn = $('#stemBtn');
-  const stemResult = $('#stemResult');
-  const stemVocalsLink = $('#stemVocalsLink');
-  const stemInstrumentalLink = $('#stemInstrumentalLink');
-  const stemZipLink = $('#stemZipLink');
-  const stemClearBtn = $('#stemClearBtn');
-  const stemVocalsPlayer = $('#stemVocalsPlayer');
-  const stemInstrumentalPlayer = $('#stemInstrumentalPlayer');
-  const stemMeta = $('#stemMeta');
-  const stemLoading = $('#stemLoading');
-
-  const bustCache = (href) => {
-    if (!href || typeof href !== 'string') return href;
-    const [base, hash] = href.split('#');
-    const timed = `${base}${base.includes('?') ? '&' : '?'}t=${Date.now()}`;
-    return hash ? `${timed}#${hash}` : timed;
-  };
-
-  const applyStemMeta = (meta) => {
-    if (!stemMeta) return;
-    if (!meta) { stemMeta.textContent = ''; stemMeta.hidden = true; return; }
-    const bits = [];
-    if (meta.strategy === 'stereo_mid_side') bits.push('Stereo split');
-    else if (meta.strategy === 'mono_adaptive') bits.push('Mono adaptif');
-    else if (typeof meta.strategy === 'string' && meta.strategy.trim()) bits.push(meta.strategy);
-    const channelCount = Number(meta.channels);
-    if (Number.isFinite(channelCount) && channelCount > 0) {
-      const layout = typeof meta.channelLayout === 'string' && meta.channelLayout.trim() ? ` (${meta.channelLayout})` : '';
-      bits.push(`${channelCount} ch${layout}`);
-    } else if (typeof meta.channelLayout === 'string' && meta.channelLayout.trim()) {
-      bits.push(meta.channelLayout);
-    }
-    stemMeta.textContent = bits.join(' · ');
-    stemMeta.hidden = !stemMeta.textContent.trim();
-  };
-
-  const pauseStemPlayers = () => {
-    [stemVocalsPlayer, stemInstrumentalPlayer].forEach((player) => {
-      if (!player) return;
-      try { player.pause(); } catch {}
-    });
-  };
-
-  const clearStemPlayers = () => {
-    [stemVocalsPlayer, stemInstrumentalPlayer].forEach((player) => {
-      if (!player) return;
-      try { player.pause(); } catch {}
-      player.removeAttribute('src');
-      try { player.load(); } catch {}
-    });
-  };
-  const cloudDriveBtn = $('#cloudDriveBtn');
-  const cloudDropboxBtn = $('#cloudDropboxBtn');
-  const cloudOnedriveBtn = $('#cloudOnedriveBtn');
   const playlistResultWrap = $('#playlistResultWrap');
   const playlistDownloadLink = $('#playlistDownloadLink');
   const playlistInfo = $('#playlistInfo');
@@ -833,8 +696,6 @@
   let currentDownloadUrl = '';
   let currentDownloadName = '';
   let currentShareUrl = '';
-  let waveformState = { url: '', duration: 0, peaks: [], selection: null };
-  let waveformAbort = null;
   let miniSeeking = false;
   let subtitleShareUrl = '';
   let lastPreviewTitle = '';
@@ -1003,7 +864,6 @@
     lastResult = null;
     lastPreviewMeta = {};
     updateAiStatus('');
-    resetWaveform();
     if (equalizerWrap) equalizerWrap.hidden = true;
     if (eqBass) eqBass.value = 0;
     if (eqMid) eqMid.value = 0;
@@ -1044,7 +904,6 @@
     if (shareLinkInput) shareLinkInput.value = currentShareUrl;
     if (shareInfo) shareInfo.textContent = 'Bagikan link atau scan QR untuk membuka mini player.';
     renderQr(qrCanvas, qrWrap, currentShareUrl);
-    loadWaveform(absoluteUrl);
     if (equalizerWrap) equalizerWrap.hidden = false;
     refreshEqUi();
     if (miniPlayerEl) {
@@ -1296,273 +1155,6 @@ $('#queueList')?.addEventListener('click', (e) => {
     return str.replace(/[\\/:*?"<>|\r\n]+/g,'').replace(/\s+/g,' ').trim();
   }
 
-  // ===== Waveform helpers =====
-  function resetWaveform(clearSelection = true){
-    if (waveformAbort) {
-      waveformAbort.abort();
-      waveformAbort = null;
-    }
-    if (clearSelection) waveformState.selection = null;
-    waveformState.url = '';
-    waveformState.duration = 0;
-    waveformState.peaks = [];
-    if (waveformCanvas) {
-      const ctx = waveformCanvas.getContext('2d');
-      if (ctx) {
-        ctx.clearRect(0, 0, waveformCanvas.width || 0, waveformCanvas.height || 0);
-      }
-      waveformCanvas.removeAttribute('data-loading');
-    }
-    if (waveformWrap) waveformWrap.hidden = true;
-    if (waveformMeta) waveformMeta.textContent = '';
-    if (waveformHint) waveformHint.textContent = 'Waveform akan muncul setelah audio siap.';
-  }
-
-  function buildWaveformPeaks(channelData, target = 900){
-    const peaks = [];
-    if (!channelData || !channelData.length) return peaks;
-    const len = channelData.length;
-    const step = Math.max(1, Math.floor(len / target));
-    for (let i = 0; i < target; i += 1){
-      const start = i * step;
-      if (start >= len) break;
-      const end = Math.min(len, start + step);
-      let min = 1;
-      let max = -1;
-      for (let j = start; j < end; j += 1){
-        const value = channelData[j];
-        if (value > max) max = value;
-        if (value < min) min = value;
-      }
-      peaks.push({ min, max });
-    }
-    return peaks;
-  }
-
-  function updateWaveformMeta(){
-    if (!waveformMeta) return;
-    if (!waveformState.duration){
-      waveformMeta.textContent = '';
-      return;
-    }
-    if (waveformState.selection && waveformState.selection.end > waveformState.selection.start){
-      const { start, end } = waveformState.selection;
-      waveformMeta.textContent = `${secondsToClock(start)} → ${secondsToClock(end)} · ${secondsToClock(end - start)}`;
-    } else {
-      waveformMeta.textContent = `Durasi ${secondsToClock(waveformState.duration)}`;
-    }
-  }
-
-  function drawWaveform(){
-    if (!waveformCanvas) return;
-    const ctx = waveformCanvas.getContext('2d');
-    if (!ctx) return;
-    const width = waveformCanvas.clientWidth || waveformCanvas.offsetWidth || 480;
-    const height = waveformCanvas.clientHeight || 120;
-    const ratio = window.devicePixelRatio || 1;
-    waveformCanvas.width = Math.max(1, Math.floor(width * ratio));
-    waveformCanvas.height = Math.max(1, Math.floor(height * ratio));
-    ctx.save();
-    ctx.scale(ratio, ratio);
-    const bg = getThemeColor('--bs-body-bg', '#ffffff');
-    const accent = getThemeColor('--bs-primary', '#0d6efd');
-    const border = getThemeColor('--bs-border-color', '#ced4da');
-    const danger = getThemeColor('--bs-danger', '#dc3545');
-    ctx.fillStyle = bg;
-    ctx.fillRect(0, 0, width, height);
-    ctx.strokeStyle = border;
-    ctx.lineWidth = 1;
-    const mid = height / 2;
-    ctx.beginPath();
-    ctx.moveTo(0, mid);
-    ctx.lineTo(width, mid);
-    ctx.stroke();
-    const peaks = waveformState.peaks || [];
-    if (peaks.length){
-      const columnWidth = width / peaks.length;
-      const gradient = ctx.createLinearGradient(0, 0, width, 0);
-      gradient.addColorStop(0, accent);
-      gradient.addColorStop(1, danger);
-      ctx.fillStyle = gradient;
-      for (let i = 0; i < peaks.length; i += 1){
-        const { min, max } = peaks[i];
-        const x = i * columnWidth;
-        const top = mid + (min * mid);
-        const bottom = mid + (max * mid);
-        const h = bottom - top;
-        ctx.fillRect(x, top, Math.max(1, columnWidth * 0.9), h || 1);
-      }
-    }
-    if (waveformState.selection && waveformState.duration && waveformState.selection.end > waveformState.selection.start){
-      const { start, end } = waveformState.selection;
-      const startX = (start / waveformState.duration) * width;
-      const endX = (end / waveformState.duration) * width;
-      const selGradient = ctx.createLinearGradient(startX, 0, endX, 0);
-      selGradient.addColorStop(0, accent);
-      selGradient.addColorStop(1, danger);
-      ctx.save();
-      ctx.globalAlpha = 0.3;
-      ctx.fillStyle = selGradient;
-      ctx.fillRect(startX, 0, Math.max(1, endX - startX), height);
-      ctx.restore();
-      ctx.strokeStyle = accent;
-      ctx.beginPath();
-      ctx.moveTo(startX, 0);
-      ctx.lineTo(startX, height);
-      ctx.stroke();
-      ctx.strokeStyle = danger;
-      ctx.beginPath();
-      ctx.moveTo(endX, 0);
-      ctx.lineTo(endX, height);
-      ctx.stroke();
-      const radius = 5;
-      ctx.fillStyle = accent;
-      ctx.beginPath();
-      ctx.arc(Math.max(radius, startX), mid, radius, 0, Math.PI * 2);
-      ctx.fill();
-      ctx.fillStyle = danger;
-      ctx.beginPath();
-      ctx.arc(Math.min(width - radius, endX), mid, radius, 0, Math.PI * 2);
-      ctx.fill();
-    }
-    ctx.restore();
-  }
-
-  function getWaveformTime(evt){
-    if (!waveformCanvas || !waveformState.duration) return 0;
-    const rect = waveformCanvas.getBoundingClientRect();
-    const x = clamp(evt.clientX - rect.left, 0, rect.width || 1);
-    const ratio = rect.width ? x / rect.width : 0;
-    return ratio * waveformState.duration;
-  }
-
-  function syncWaveformFromInputs(){
-    if (!waveformState.duration) return;
-    const sVal = parseTime($('#trimStart').value.trim());
-    const eVal = parseTime($('#trimEnd').value.trim());
-    if (sVal === null && eVal === null){
-      waveformState.selection = null;
-      drawWaveform();
-      updateWaveformMeta();
-      return;
-    }
-    const start = sVal === null ? 0 : clamp(sVal, 0, waveformState.duration);
-    const end = eVal === null ? waveformState.duration : clamp(eVal, 0, waveformState.duration);
-    if (end <= start){
-      waveformState.selection = null;
-    } else {
-      waveformState.selection = { start, end };
-    }
-    drawWaveform();
-    updateWaveformMeta();
-  }
-
-  async function loadWaveform(url){
-    if (!waveformCanvas || !url) return;
-    const ctx = getAudioContext();
-    if (!ctx){
-      if (waveformWrap) waveformWrap.hidden = true;
-      if (waveformHint) waveformHint.textContent = 'Browser tidak mendukung Web Audio API.';
-      return;
-    }
-    if (waveformAbort) waveformAbort.abort();
-    waveformAbort = new AbortController();
-    waveformCanvas.dataset.loading = '1';
-    if (waveformHint) waveformHint.textContent = 'Memuat waveform…';
-    try {
-      const resp = await fetch(`${url}${url.includes('?') ? '&' : '?'}waveform=${Date.now()}`, { signal: waveformAbort.signal, cache: 'no-store' });
-      if (!resp.ok) throw new Error('Gagal memuat audio');
-      const arr = await resp.arrayBuffer();
-      const audioBuffer = await ctx.decodeAudioData(arr);
-      const peaks = buildWaveformPeaks(audioBuffer.getChannelData(0), Math.min(1400, Math.ceil(audioBuffer.duration * 80)));
-      waveformState.url = url;
-      waveformState.duration = audioBuffer.duration;
-      waveformState.peaks = peaks;
-      waveformWrap.hidden = false;
-      drawWaveform();
-      updateWaveformMeta();
-      if (waveformHint) waveformHint.textContent = 'Seret area untuk memilih bagian audio.';
-      syncWaveformFromInputs();
-    } catch (err){
-      if (err.name === 'AbortError') return;
-      console.error(err);
-      if (waveformHint) waveformHint.textContent = 'Waveform tidak bisa dimuat';
-      waveformWrap.hidden = true;
-    } finally {
-      waveformCanvas.removeAttribute('data-loading');
-    }
-  }
-
-  if (waveformCanvas){
-    let dragging = false;
-    let dragStart = 0;
-    waveformCanvas.addEventListener('pointerdown', (e) => {
-      if (!waveformState.duration) return;
-      dragging = true;
-      waveformCanvas.setPointerCapture(e.pointerId);
-      const time = getWaveformTime(e);
-      dragStart = time;
-      waveformState.selection = { start: time, end: time };
-      drawWaveform();
-      updateWaveformMeta();
-    });
-    waveformCanvas.addEventListener('pointermove', (e) => {
-      if (!dragging) return;
-      const time = getWaveformTime(e);
-      const start = Math.min(dragStart, time);
-      const end = Math.max(dragStart, time);
-      waveformState.selection = end > start ? { start, end } : null;
-      drawWaveform();
-      updateWaveformMeta();
-      if (waveformState.selection){
-        $('#trimStart').value = secondsToInput(start);
-        $('#trimEnd').value = secondsToInput(end);
-      }
-    });
-    const stopDrag = (e) => {
-      if (!dragging) return;
-      if (e && e.pointerId != null) waveformCanvas.releasePointerCapture(e.pointerId);
-      dragging = false;
-      updateWaveformMeta();
-      if (waveformState.selection){
-        $('#trimStart').value = secondsToInput(waveformState.selection.start);
-        $('#trimEnd').value = secondsToInput(waveformState.selection.end);
-      }
-    };
-    waveformCanvas.addEventListener('pointerup', stopDrag);
-    waveformCanvas.addEventListener('pointercancel', stopDrag);
-    waveformCanvas.addEventListener('pointerleave', stopDrag);
-    waveformCanvas.addEventListener('dblclick', () => {
-      waveformState.selection = null;
-      drawWaveform();
-      updateWaveformMeta();
-      $('#trimStart').value = '';
-      $('#trimEnd').value = '';
-    });
-  }
-
-  if (waveformClearBtn){
-    waveformClearBtn.addEventListener('click', () => {
-      waveformState.selection = null;
-      drawWaveform();
-      updateWaveformMeta();
-      $('#trimStart').value = '';
-      $('#trimEnd').value = '';
-    });
-  }
-
-  if (waveformUseSelectionBtn){
-    waveformUseSelectionBtn.addEventListener('click', () => {
-      if (!waveformState.selection){
-        setToast('Pilih bagian audio di waveform terlebih dahulu');
-        return;
-      }
-      $('#trimStart').value = secondsToInput(waveformState.selection.start);
-      $('#trimEnd').value = secondsToInput(waveformState.selection.end);
-      setToast('Trim diperbarui dari waveform');
-    });
-  }
-
   // ===== Equalizer helpers =====
   const formatGain = (value) => `${Number(value) >= 0 ? '+' : ''}${Number(value)} dB`;
 
@@ -1721,9 +1313,6 @@ $('#queueList')?.addEventListener('click', (e) => {
       if (job.result?.downloadUrl) {
         const href = absoluteFromRelative(job.result.downloadUrl);
         actions.push(`<a class="btn btn-sm btn-outline-primary" href="${href}" download="${job.result.fileName || ''}"><i class="bi bi-download"></i> Unduh</a>`);
-      }
-      if (status === 'done') {
-        actions.push(`<button class="btn btn-sm btn-outline-secondary" data-cloud="drive" data-job="${job.id}" title="Simpan ke cloud"><i class="bi bi-cloud-arrow-up"></i></button>`);
       }
       if (status !== 'done' && status !== 'error') {
         actions.push('<span class="text-secondary">Diproses…</span>');
@@ -1979,9 +1568,6 @@ $('#queueList')?.addEventListener('click', (e) => {
     updatePreview();
   });
   $('#url').addEventListener('change', updatePreview);
-  $('#trimStart').addEventListener('change', syncWaveformFromInputs);
-  $('#trimEnd').addEventListener('change', syncWaveformFromInputs);
-
   if (autoTagBtn) autoTagBtn.addEventListener('click', async () => {
     const title = $('#id3Title').value.trim() || lastVideoMeta.title || $('#videoTitle').textContent.trim();
     if (!title) { setToast('Isi judul terlebih dahulu'); return; }
@@ -2008,128 +1594,6 @@ $('#queueList')?.addEventListener('click', (e) => {
       updateAiStatus(err.message, 'danger');
       setToast('Gagal AI tags: ' + err.message);
     }
-  });
-
-  if (thumbnailBtn) thumbnailBtn.addEventListener('click', async () => {
-    const baseImage = lastVideoMeta.thumbnail || $('#thumb').src;
-    if (!baseImage) { setToast('Thumbnail belum tersedia'); return; }
-    const baseTitle = $('#id3Title').value.trim() || lastVideoMeta.title || 'AI Cover';
-    const title = prompt('Judul cover', baseTitle);
-    if (title === null) return;
-    const subtitle = prompt('Subjudul (opsional)', lastVideoMeta.author || '');
-    const accent = prompt('Warna aksen (#RRGGBB)', '#0d6efd') || '#0d6efd';
-    const style = prompt('Style (modern/vibrant/mono)', 'modern') || 'modern';
-    updateAiStatus('Membuat thumbnail…', 'info');
-    try {
-      const resp = await fetch(api('/api/thumbnail'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ imageUrl: baseImage, title, subtitle, accent, style }),
-      });
-      const data = await resp.json();
-      if (!resp.ok) throw new Error(data.error || 'Gagal membuat thumbnail');
-      if (data.url) {
-        const absolute = absoluteFromRelative(data.url);
-        $('#thumb').src = `${absolute}${absolute.includes('?') ? '&' : '?'}t=${Date.now()}`;
-        updateAiStatus(`Thumbnail baru siap. <a href="${absolute}" target="_blank" rel="noopener">Lihat</a>`, 'success');
-        setToast('Thumbnail diperbarui');
-        lastVideoMeta.thumbnail = absolute;
-      }
-    } catch (err) {
-      updateAiStatus(err.message, 'danger');
-      setToast('Gagal membuat thumbnail: ' + err.message);
-    }
-  });
-
-  if (stemBtn) stemBtn.addEventListener('click', async () => {
-    if (stemBtn.disabled) return;
-    const payload = {};
-    if (lastResult?.jobId) payload.jobId = lastResult.jobId;
-    else if (lastResult?.downloadUrl) payload.downloadUrl = toRelativePublic(lastResult.downloadUrl);
-    else if ($('#url').value.trim()) payload.url = $('#url').value.trim();
-    else { setToast('Belum ada audio untuk diproses'); return; }
-    updateAiStatus('Memisahkan vokal dan instrumen…', 'info');
-    stemBtn.disabled = true;
-    stemBtn.setAttribute('aria-busy', 'true');
-    if (stemLoading) stemLoading.hidden = false;
-    if (stemResult) stemResult.hidden = false;
-    pauseStemPlayers();
-    try {
-      const resp = await fetch(api('/api/stems'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
-      });
-      const data = await resp.json();
-      if (!resp.ok) throw new Error(data.error || 'Gagal memisahkan');
-      if (stemResult) {
-        stemResult.hidden = false;
-        if (stemVocalsLink && data.vocals?.downloadUrl) {
-          const href = absoluteFromRelative(data.vocals.downloadUrl);
-          stemVocalsLink.href = href;
-          stemVocalsLink.setAttribute('download', data.vocals.fileName || 'vocals.mp3');
-          if (stemVocalsPlayer) {
-            stemVocalsPlayer.src = bustCache(href);
-            try { stemVocalsPlayer.load(); } catch {}
-          }
-        }
-        if (stemInstrumentalLink && data.instrumental?.downloadUrl) {
-          const href = absoluteFromRelative(data.instrumental.downloadUrl);
-          stemInstrumentalLink.href = href;
-          stemInstrumentalLink.setAttribute('download', data.instrumental.fileName || 'instrumental.mp3');
-          if (stemInstrumentalPlayer) {
-            stemInstrumentalPlayer.src = bustCache(href);
-            try { stemInstrumentalPlayer.load(); } catch {}
-          }
-        }
-        if (stemZipLink && data.zip?.downloadUrl) {
-          const href = absoluteFromRelative(data.zip.downloadUrl);
-          stemZipLink.href = href;
-          stemZipLink.setAttribute('download', data.zip.fileName || 'stems.zip');
-        }
-        applyStemMeta(data.meta);
-      }
-      updateAiStatus('Stems siap diunduh', 'success');
-      setToast('Stems berhasil dibuat');
-    } catch (err) {
-      updateAiStatus(err.message, 'danger');
-      setToast('Gagal membuat stems: ' + err.message);
-    } finally {
-      if (stemLoading) stemLoading.hidden = true;
-      stemBtn.disabled = false;
-      stemBtn.removeAttribute('aria-busy');
-    }
-  });
-
-  if (stemClearBtn) stemClearBtn.addEventListener('click', () => {
-    clearStemPlayers();
-    applyStemMeta(null);
-    if (stemVocalsLink) {
-      stemVocalsLink.removeAttribute('href');
-      stemVocalsLink.removeAttribute('download');
-    }
-    if (stemInstrumentalLink) {
-      stemInstrumentalLink.removeAttribute('href');
-      stemInstrumentalLink.removeAttribute('download');
-    }
-    if (stemZipLink) {
-      stemZipLink.removeAttribute('href');
-      stemZipLink.removeAttribute('download');
-    }
-    if (stemLoading) stemLoading.hidden = true;
-    if (stemResult) stemResult.hidden = true;
-  });
-
-  if (cloudDriveBtn) cloudDriveBtn.addEventListener('click', () => saveToCloud('drive'));
-  if (cloudDropboxBtn) cloudDropboxBtn.addEventListener('click', () => saveToCloud('dropbox'));
-  if (cloudOnedriveBtn) cloudOnedriveBtn.addEventListener('click', () => saveToCloud('onedrive'));
-
-  if (backgroundList) backgroundList.addEventListener('click', (e) => {
-    const btn = e.target.closest('button[data-cloud][data-job]');
-    if (!btn) return;
-    const target = btn.getAttribute('data-cloud');
-    const jobId = btn.getAttribute('data-job');
-    if (target && jobId) saveToCloud(target, jobId);
   });
 
   if (backgroundMode) backgroundMode.addEventListener('change', async () => {
@@ -2336,35 +1800,6 @@ $('#queueList')?.addEventListener('click', (e) => {
     } catch (err) {
       updateAiStatus(err.message || 'Gagal membuat job', 'danger');
       setToast('Gagal membuat job: ' + err.message);
-    }
-  }
-
-  async function saveToCloud(target, jobIdOverride){
-    const payload = { target };
-    const jobId = jobIdOverride || lastResult?.jobId;
-    if (jobId) {
-      payload.jobId = jobId;
-    } else {
-      const rel = toRelativePublic(lastResult?.downloadUrl);
-      if (!rel) { setToast('Belum ada hasil untuk disimpan'); return; }
-      payload.downloadUrl = rel;
-      if (lastResult?.fileName) payload.fileName = lastResult.fileName;
-    }
-    try {
-      updateAiStatus(`Menyimpan ke ${target}…`, 'info');
-      const resp = await fetch(api('/api/cloud/save'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
-      });
-      const data = await resp.json();
-      if (!resp.ok) throw new Error(data.error || 'Gagal menyimpan');
-      const href = absoluteFromRelative(data.downloadUrl);
-      updateAiStatus(`Tersimpan di ${data.label}. <a href="${href}" target="_blank" rel="noopener">Buka file</a>`, 'success');
-      setToast(`Tersimpan di ${data.label}`);
-    } catch (err) {
-      updateAiStatus(err.message || 'Gagal menyimpan', 'danger');
-      setToast('Gagal menyimpan: ' + err.message);
     }
   }
 

--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -40,10 +40,19 @@
     #urlDropOverlay[hidden] { display: none !important; }
     #waveformWrap, #equalizerWrap, #shareWrap { background: var(--bs-secondary-bg); border: 1px solid var(--bs-border-color); border-radius: 1rem; padding: 1rem; }
     #waveformCanvas { width: 100%; height: 140px; display: block; border-radius: .85rem; background: var(--bs-body-bg); cursor: crosshair; box-shadow: inset 0 0 0 1px rgba(0,0,0,.04); }
+    #waveformCanvas::selection { background: transparent; }
     #waveformCanvas[data-loading="1"] { opacity: .55; }
     #waveformMeta { font-size: .85rem; }
     .eq-slider label { font-size: .75rem; text-transform: uppercase; letter-spacing: .08em; color: var(--bs-secondary); }
-    .eq-slider .form-range { height: 1.4rem; }
+    .eq-slider .form-range { height: 1.6rem; appearance: none; background: linear-gradient(90deg, rgba(220,53,69,.2) 0%, rgba(13,110,253,.25) 100%); border-radius: 999px; transition: background .2s ease; }
+    .eq-slider .form-range:focus { outline: none; box-shadow: none; }
+    .eq-slider .form-range::-webkit-slider-runnable-track { height: .55rem; border-radius: 999px; background: transparent; }
+    .eq-slider .form-range::-moz-range-track { height: .55rem; border-radius: 999px; background: transparent; }
+    .eq-slider .form-range::-webkit-slider-thumb { -webkit-appearance: none; width: 18px; height: 18px; border-radius: 50%; background: var(--bs-primary); border: 2px solid var(--bs-body-bg); box-shadow: 0 2px 6px rgba(0,0,0,.25); transition: transform .15s ease, background .2s ease; margin-top: -6.5px; }
+    .eq-slider .form-range::-moz-range-thumb { width: 18px; height: 18px; border-radius: 50%; background: var(--bs-primary); border: 2px solid var(--bs-body-bg); box-shadow: 0 2px 6px rgba(0,0,0,.25); transition: transform .15s ease, background .2s ease; }
+    .eq-slider .form-range:active::-webkit-slider-thumb, .eq-slider .form-range:active::-moz-range-thumb { transform: scale(1.1); }
+    .eq-slider .eq-value { font-size: .7rem; font-weight: 600; background: var(--bs-primary-bg-subtle); color: var(--bs-primary-text); border-radius: .65rem; padding: .2rem .45rem; min-width: 3.4rem; text-align: center; }
+    html[data-bs-theme='dark'] .eq-slider .eq-value { background: color-mix(in srgb, var(--bs-primary) 22%, transparent); color: var(--bs-body-color); }
     #shareWrap .input-group-text { border-radius: .75rem 0 0 .75rem; }
     #subtitleResult pre { max-height: 160px; overflow:auto; background: var(--bs-body-bg); border-radius: .75rem; padding: .75rem; }
     #subtitleResult .btn { border-radius: .75rem; }
@@ -52,6 +61,10 @@
     .mini-player-card { pointer-events: auto; border-radius: 1rem; width: min(420px, calc(100% - 2.5rem)); }
     .mini-player .btn { border-radius: 50%; }
     .mini-player .form-range { height: 1rem; }
+    .mini-player-card { background: radial-gradient(circle at top left, rgba(13,110,253,.12), transparent 60%), radial-gradient(circle at bottom right, rgba(220,53,69,.12), transparent 55%), var(--bs-body-bg); backdrop-filter: blur(6px); }
+    .mini-player-title { font-size: .85rem; letter-spacing: .01em; }
+    .mini-player-subtitle { font-size: .7rem; color: var(--bs-secondary); margin-top: .1rem; }
+    html[data-bs-theme='dark'] .mini-player-subtitle { color: rgba(255,255,255,.6); }
     #miniPlayer[hidden] { display: none !important; }
     @media (max-width: 576px) {
       body { padding-bottom: 5rem; }
@@ -418,18 +431,27 @@
                           <button class="btn btn-outline-secondary" id="eqPresetBass" type="button">Bass+</button>
                         </div>
                       </div>
-                      <div class="row g-2 mt-2 eq-slider">
+                      <div class="row g-3 mt-2 eq-slider">
                         <div class="col-sm-4">
-                          <label class="form-label">Bass</label>
-                          <input type="range" class="form-range" min="-12" max="12" step="1" value="0" id="eqBass">
+                          <div class="d-flex justify-content-between align-items-center">
+                            <label class="form-label mb-0" for="eqBass">Bass</label>
+                            <span class="eq-value" id="eqBassValue">0 dB</span>
+                          </div>
+                          <input type="range" class="form-range" min="-12" max="12" step="1" value="0" id="eqBass" aria-label="Atur gain bass">
                         </div>
                         <div class="col-sm-4">
-                          <label class="form-label">Mid</label>
-                          <input type="range" class="form-range" min="-12" max="12" step="1" value="0" id="eqMid">
+                          <div class="d-flex justify-content-between align-items-center">
+                            <label class="form-label mb-0" for="eqMid">Mid</label>
+                            <span class="eq-value" id="eqMidValue">0 dB</span>
+                          </div>
+                          <input type="range" class="form-range" min="-12" max="12" step="1" value="0" id="eqMid" aria-label="Atur gain mid">
                         </div>
                         <div class="col-sm-4">
-                          <label class="form-label">Treble</label>
-                          <input type="range" class="form-range" min="-12" max="12" step="1" value="0" id="eqTreble">
+                          <div class="d-flex justify-content-between align-items-center">
+                            <label class="form-label mb-0" for="eqTreble">Treble</label>
+                            <span class="eq-value" id="eqTrebleValue">0 dB</span>
+                          </div>
+                          <input type="range" class="form-range" min="-12" max="12" step="1" value="0" id="eqTreble" aria-label="Atur gain treble">
                         </div>
                       </div>
                       <div class="small text-secondary mt-2" id="eqStatus">Flat</div>
@@ -533,10 +555,11 @@
         </button>
         <div class="flex-grow-1">
           <div class="d-flex align-items-center justify-content-between gap-2">
-            <div class="fw-semibold small text-truncate" id="miniTitle">Audio Preview</div>
+            <div class="fw-semibold mini-player-title text-truncate" id="miniTitle">Audio Preview</div>
             <div class="small text-secondary" id="miniTime">00:00</div>
           </div>
-          <input type="range" class="form-range mt-1" id="miniSeek" min="0" max="1000" value="0" aria-label="Seek audio">
+          <div class="mini-player-subtitle text-truncate" id="miniSubtitle"></div>
+          <input type="range" class="form-range mt-2" id="miniSeek" min="0" max="1000" value="0" aria-label="Seek audio">
         </div>
         <button class="btn btn-outline-secondary btn-sm" id="miniShareBtn" type="button" aria-label="Bagikan mini player"><i class="bi bi-qr-code"></i></button>
         <button class="btn btn-outline-secondary btn-sm" id="miniCloseBtn" type="button" aria-label="Tutup mini player"><i class="bi bi-x-lg"></i></button>
@@ -654,6 +677,9 @@
   const eqBass = $('#eqBass');
   const eqMid = $('#eqMid');
   const eqTreble = $('#eqTreble');
+  const eqBassValue = $('#eqBassValue');
+  const eqMidValue = $('#eqMidValue');
+  const eqTrebleValue = $('#eqTrebleValue');
   const eqStatus = $('#eqStatus');
   const eqPresetFlat = $('#eqPresetFlat');
   const eqPresetPodcast = $('#eqPresetPodcast');
@@ -691,6 +717,7 @@
   const miniSeek = $('#miniSeek');
   const miniTime = $('#miniTime');
   const miniTitle = $('#miniTitle');
+  const miniSubtitle = $('#miniSubtitle');
   const subtitleBtn = $('#subtitleBtn');
   const subtitleLang = $('#subtitleLang');
   const subtitleAuto = $('#subtitleAuto');
@@ -728,11 +755,13 @@
   let miniSeeking = false;
   let subtitleShareUrl = '';
   let lastPreviewTitle = '';
+  let lastPreviewMeta = {};
   let lastResult = null;
   let lastVideoMeta = {};
   const backgroundJobsState = new Map();
   const backgroundTimers = new Map();
   const BACKGROUND_STORE_KEY = 'ytmp3.background.jobs.v1';
+  let qrLibPromise = null;
 
   const getBackend = () => (state.backendUrl || '').trim();
 
@@ -792,6 +821,47 @@
     volumeBoostLabel.textContent = `${val >= 0 ? '+' : ''}${val} dB`;
   };
 
+  const getThemeColor = (token, fallback) => {
+    const styles = getComputedStyle(document.body);
+    const raw = (styles.getPropertyValue(token) || '').trim();
+    return raw || fallback;
+  };
+
+  const ensureQrLib = () => {
+    if (window.QRCode && typeof window.QRCode.toCanvas === 'function') {
+      return Promise.resolve(window.QRCode);
+    }
+    if (qrLibPromise) return qrLibPromise;
+    qrLibPromise = new Promise((resolve, reject) => {
+      const onReady = () => {
+        if (window.QRCode && typeof window.QRCode.toCanvas === 'function') resolve(window.QRCode);
+        else reject(new Error('QR library belum siap'));
+      };
+      const onError = () => reject(new Error('Gagal memuat library QR'));
+      const existing = document.querySelector('script[src*="qrcode.min.js"]');
+      if (existing) {
+        existing.addEventListener('load', onReady, { once: true });
+        existing.addEventListener('error', onError, { once: true });
+      } else {
+        const script = document.createElement('script');
+        script.src = 'https://cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.min.js';
+        script.defer = true;
+        script.addEventListener('load', onReady, { once: true });
+        script.addEventListener('error', onError, { once: true });
+        document.head.appendChild(script);
+      }
+      setTimeout(() => {
+        if (window.QRCode && typeof window.QRCode.toCanvas === 'function') {
+          resolve(window.QRCode);
+        }
+      }, 0);
+    }).catch((err) => {
+      qrLibPromise = null;
+      throw err;
+    });
+    return qrLibPromise;
+  };
+
   const renderQr = (canvas, wrap, url) => {
     if (!canvas || !wrap) return;
     const ctx = canvas.getContext('2d');
@@ -801,17 +871,36 @@
       return;
     }
     wrap.hidden = false;
-    if (window.QRCode && typeof window.QRCode.toCanvas === 'function') {
-      window.QRCode.toCanvas(canvas, url, { width: canvas.width || 156, margin: 1 }, (err) => {
-        if (err) console.error(err);
-      });
-    } else if (ctx) {
-      ctx.fillStyle = '#fff';
+    if (ctx) {
+      const bg = getThemeColor('--bs-body-bg', '#ffffff');
+      const border = getThemeColor('--bs-border-color', '#ced4da');
+      ctx.fillStyle = bg;
       ctx.fillRect(0, 0, canvas.width, canvas.height);
-      ctx.fillStyle = '#000';
-      ctx.font = '16px sans-serif';
-      ctx.fillText('QR', 10, 24);
+      ctx.strokeStyle = border;
+      ctx.lineWidth = 2;
+      ctx.strokeRect(1, 1, canvas.width - 2, canvas.height - 2);
     }
+    ensureQrLib().then((lib) => {
+      const theme = document.documentElement.getAttribute('data-bs-theme') || 'light';
+      const light = theme === 'dark' ? '#0d1117' : '#ffffff';
+      const dark = theme === 'dark' ? '#ffffff' : '#0d0d0d';
+      lib.toCanvas(canvas, url, { width: canvas.width || 156, margin: 1, color: { dark, light } }, (err) => {
+        if (err && ctx) {
+          ctx.fillStyle = '#dc3545';
+          ctx.font = '12px sans-serif';
+          ctx.textAlign = 'center';
+          ctx.textBaseline = 'middle';
+          ctx.fillText('QR gagal', canvas.width / 2, canvas.height / 2);
+        }
+      });
+    }).catch(() => {
+      if (!ctx) return;
+      ctx.fillStyle = '#dc3545';
+      ctx.font = '12px sans-serif';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText('QR gagal dimuat', canvas.width / 2, canvas.height / 2);
+    });
   };
 
   const resetAudioPreview = () => {
@@ -829,10 +918,16 @@
     currentShareUrl = '';
     subtitleShareUrl = '';
     lastResult = null;
+    lastPreviewMeta = {};
     updateAiStatus('');
     resetWaveform();
     if (equalizerWrap) equalizerWrap.hidden = true;
+    if (eqBass) eqBass.value = 0;
+    if (eqMid) eqMid.value = 0;
+    if (eqTreble) eqTreble.value = 0;
+    refreshEqUi();
     if (miniPlayerEl) miniPlayerEl.hidden = true;
+    updateMiniSubtitle();
     renderQr(qrCanvas, qrWrap, null);
   };
 
@@ -857,17 +952,24 @@
       format: meta.format || '',
       jobId: meta.jobId || null,
     };
+    lastPreviewMeta = {
+      format: meta.format || '',
+      fileName: meta.fileName || '',
+      baseName: meta.baseName || '',
+    };
     if (shareWrap) shareWrap.hidden = false;
     if (shareLinkInput) shareLinkInput.value = currentShareUrl;
     if (shareInfo) shareInfo.textContent = 'Bagikan link atau scan QR untuk membuka mini player.';
     renderQr(qrCanvas, qrWrap, currentShareUrl);
     loadWaveform(absoluteUrl);
     if (equalizerWrap) equalizerWrap.hidden = false;
+    refreshEqUi();
     if (miniPlayerEl) {
       miniPlayerEl.hidden = false;
       if (miniSeek) miniSeek.value = 0;
       if (miniTime) miniTime.textContent = '00:00';
       if (miniTitle) miniTitle.textContent = lastPreviewTitle || 'Audio Preview';
+      updateMiniSubtitle();
     }
   };
 
@@ -974,12 +1076,14 @@ $('#queueList')?.addEventListener('click', (e) => {
     const t = stored || prefers;
     applyTheme(t);
     themeToggle.innerHTML = t === 'light' ? '<i class="bi bi-moon-stars"></i>' : '<i class="bi bi-sun"></i>';
+    refreshEqUi();
   };
   themeToggle.addEventListener('click', () => {
     const cur = document.documentElement.getAttribute('data-bs-theme') || 'light';
     const nxt = cur === 'light' ? 'dark' : 'light';
     applyTheme(nxt); localStorage.setItem(themeKey, nxt);
     themeToggle.innerHTML = nxt === 'light' ? '<i class="bi bi-moon-stars"></i>' : '<i class="bi bi-sun"></i>';
+    requestAnimationFrame(refreshEqUi);
   });
 
   function initWelcome(){
@@ -1177,10 +1281,10 @@ $('#queueList')?.addEventListener('click', (e) => {
     waveformCanvas.height = Math.max(1, Math.floor(height * ratio));
     ctx.save();
     ctx.scale(ratio, ratio);
-    const styles = getComputedStyle(document.body);
-    const bg = (styles.getPropertyValue('--bs-body-bg') || '#ffffff').trim() || '#ffffff';
-    const accent = (styles.getPropertyValue('--bs-primary') || '#0d6efd').trim() || '#0d6efd';
-    const border = (styles.getPropertyValue('--bs-border-color') || '#ced4da').trim() || '#ced4da';
+    const bg = getThemeColor('--bs-body-bg', '#ffffff');
+    const accent = getThemeColor('--bs-primary', '#0d6efd');
+    const border = getThemeColor('--bs-border-color', '#ced4da');
+    const danger = getThemeColor('--bs-danger', '#dc3545');
     ctx.fillStyle = bg;
     ctx.fillRect(0, 0, width, height);
     ctx.strokeStyle = border;
@@ -1193,7 +1297,10 @@ $('#queueList')?.addEventListener('click', (e) => {
     const peaks = waveformState.peaks || [];
     if (peaks.length){
       const columnWidth = width / peaks.length;
-      ctx.fillStyle = accent;
+      const gradient = ctx.createLinearGradient(0, 0, width, 0);
+      gradient.addColorStop(0, accent);
+      gradient.addColorStop(1, danger);
+      ctx.fillStyle = gradient;
       for (let i = 0; i < peaks.length; i += 1){
         const { min, max } = peaks[i];
         const x = i * columnWidth;
@@ -1207,15 +1314,33 @@ $('#queueList')?.addEventListener('click', (e) => {
       const { start, end } = waveformState.selection;
       const startX = (start / waveformState.duration) * width;
       const endX = (end / waveformState.duration) * width;
-      ctx.fillStyle = 'rgba(13,110,253,0.18)';
+      const selGradient = ctx.createLinearGradient(startX, 0, endX, 0);
+      selGradient.addColorStop(0, accent);
+      selGradient.addColorStop(1, danger);
+      ctx.save();
+      ctx.globalAlpha = 0.3;
+      ctx.fillStyle = selGradient;
       ctx.fillRect(startX, 0, Math.max(1, endX - startX), height);
+      ctx.restore();
       ctx.strokeStyle = accent;
       ctx.beginPath();
       ctx.moveTo(startX, 0);
       ctx.lineTo(startX, height);
+      ctx.stroke();
+      ctx.strokeStyle = danger;
+      ctx.beginPath();
       ctx.moveTo(endX, 0);
       ctx.lineTo(endX, height);
       ctx.stroke();
+      const radius = 5;
+      ctx.fillStyle = accent;
+      ctx.beginPath();
+      ctx.arc(Math.max(radius, startX), mid, radius, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.fillStyle = danger;
+      ctx.beginPath();
+      ctx.arc(Math.min(width - radius, endX), mid, radius, 0, Math.PI * 2);
+      ctx.fill();
     }
     ctx.restore();
   }
@@ -1316,6 +1441,10 @@ $('#queueList')?.addEventListener('click', (e) => {
       if (e && e.pointerId != null) waveformCanvas.releasePointerCapture(e.pointerId);
       dragging = false;
       updateWaveformMeta();
+      if (waveformState.selection){
+        $('#trimStart').value = secondsToInput(waveformState.selection.start);
+        $('#trimEnd').value = secondsToInput(waveformState.selection.end);
+      }
     };
     waveformCanvas.addEventListener('pointerup', stopDrag);
     waveformCanvas.addEventListener('pointercancel', stopDrag);
@@ -1354,12 +1483,54 @@ $('#queueList')?.addEventListener('click', (e) => {
   // ===== Equalizer helpers =====
   const formatGain = (value) => `${Number(value) >= 0 ? '+' : ''}${Number(value)} dB`;
 
+  const getEqValues = () => ({
+    bass: Number(eqBass?.value || 0),
+    mid: Number(eqMid?.value || 0),
+    treble: Number(eqTreble?.value || 0),
+  });
+
   const updateEqStatus = () => {
     if (!eqStatus) return;
-    const bassVal = Number(eqBass?.value || 0);
-    const midVal = Number(eqMid?.value || 0);
-    const trebleVal = Number(eqTreble?.value || 0);
-    eqStatus.textContent = `Bass ${formatGain(bassVal)} · Mid ${formatGain(midVal)} · Treble ${formatGain(trebleVal)}`;
+    const { bass, mid, treble } = getEqValues();
+    eqStatus.textContent = `Bass ${formatGain(bass)} · Mid ${formatGain(mid)} · Treble ${formatGain(treble)}`;
+  };
+
+  const setEqBadge = (input, badge) => {
+    if (!input || !badge) return;
+    badge.textContent = formatGain(input.value || 0);
+  };
+
+  const updateEqTrack = (input) => {
+    if (!input) return;
+    const min = Number(input.min || -12);
+    const max = Number(input.max || 12);
+    const val = Number(input.value || 0);
+    const range = max - min || 1;
+    const rawValuePercent = ((val - min) / range) * 100;
+    const rawZeroPercent = ((0 - min) / range) * 100;
+    const clampPct = (pct) => Math.min(100, Math.max(0, pct));
+    const valuePercent = clampPct(rawValuePercent);
+    const zeroPercent = clampPct(rawZeroPercent);
+    const accent = getThemeColor('--bs-primary', '#0d6efd');
+    const danger = getThemeColor('--bs-danger', '#dc3545');
+    const neutral = getThemeColor('--bs-border-color', '#ced4da');
+    let gradient;
+    if (valuePercent >= zeroPercent) {
+      gradient = `linear-gradient(90deg, ${danger} 0%, ${danger} ${zeroPercent}%, ${accent} ${zeroPercent}%, ${accent} ${valuePercent}%, ${neutral} ${valuePercent}%, ${neutral} 100%)`;
+    } else {
+      gradient = `linear-gradient(90deg, ${danger} 0%, ${danger} ${valuePercent}%, ${neutral} ${valuePercent}%, ${neutral} ${zeroPercent}%, ${accent} ${zeroPercent}%, ${accent} 100%)`;
+    }
+    input.style.background = gradient;
+  };
+
+  const refreshEqUi = () => {
+    updateEqTrack(eqBass);
+    updateEqTrack(eqMid);
+    updateEqTrack(eqTreble);
+    setEqBadge(eqBass, eqBassValue);
+    setEqBadge(eqMid, eqMidValue);
+    setEqBadge(eqTreble, eqTrebleValue);
+    updateEqStatus();
   };
 
   const ensureEqualizer = () => {
@@ -1399,7 +1570,7 @@ $('#queueList')?.addEventListener('click', (e) => {
     if (eqFilters[0]) eqFilters[0].gain.value = bassVal;
     if (eqFilters[1]) eqFilters[1].gain.value = midVal;
     if (eqFilters[2]) eqFilters[2].gain.value = trebleVal;
-    updateEqStatus();
+    refreshEqUi();
   };
 
   if (eqBass) eqBass.addEventListener('input', applyEqFromInputs);
@@ -1611,6 +1782,17 @@ $('#queueList')?.addEventListener('click', (e) => {
     window.open(currentShareUrl, '_blank', 'noopener');
   });
 
+  const updateMiniSubtitle = () => {
+    if (!miniSubtitle) return;
+    const parts = [];
+    if (lastPreviewMeta?.format) parts.push(String(lastPreviewMeta.format).toUpperCase());
+    const duration = previewPlayer?.duration;
+    if (duration && Number.isFinite(duration) && duration > 0) parts.push(secondsToClock(duration));
+    const name = lastPreviewMeta?.fileName || lastPreviewMeta?.baseName || currentDownloadName;
+    if (name) parts.push(name);
+    miniSubtitle.textContent = parts.join(' • ');
+  };
+
   const updateMiniPlayState = () => {
     if (!miniPlayBtn || !previewPlayer) return;
     if (previewPlayer.paused){
@@ -1657,6 +1839,7 @@ $('#queueList')?.addEventListener('click', (e) => {
         miniSeek.value = 0;
       }
       if (miniTime) miniTime.textContent = previewPlayer.duration ? `00:00 / ${secondsToClock(previewPlayer.duration)}` : '00:00';
+      updateMiniSubtitle();
     });
     previewPlayer.addEventListener('play', async () => {
       const ctx = getAudioContext();

--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -55,7 +55,19 @@
     #subtitleResult .badge { border-radius: .75rem; }
     .mini-player { position: fixed; left: 0; right: 0; bottom: 1rem; display: flex; justify-content: center; pointer-events: none; z-index: 1090; }
     .mini-player-card { pointer-events: auto; border-radius: 1rem; width: min(420px, calc(100% - 2.5rem)); }
-    .mini-player .btn { border-radius: 50%; }
+    .mini-player-body { display: flex; align-items: center; gap: 1.5rem; flex-wrap: wrap; }
+    .mini-player-main { flex: 1 1 220px; min-width: 0; }
+    .mini-player .mini-btn { width: 52px; height: 52px; border-radius: 50%; display: grid; place-items: center; border: none; font-size: 1.35rem; transition: transform .15s ease, box-shadow .2s ease, background .2s ease; box-shadow: 0 12px 30px rgba(13,110,253,.18), 0 2px 10px rgba(0,0,0,.25); }
+    .mini-player .mini-btn i { font-size: 1.2rem; }
+    .mini-player .mini-btn:focus-visible { outline: 3px solid rgba(13,110,253,.4); outline-offset: 3px; }
+    .mini-player .mini-btn:hover { transform: translateY(-1px); box-shadow: 0 16px 36px rgba(13,110,253,.22), 0 6px 14px rgba(0,0,0,.25); }
+    .mini-player .mini-btn:active { transform: translateY(0); box-shadow: 0 10px 22px rgba(13,110,253,.18), 0 3px 10px rgba(0,0,0,.24); }
+    .mini-player .mini-btn-play { background: var(--bs-primary); background: linear-gradient(135deg, rgba(13,110,253,1) 0%, rgba(111,66,193,1) 100%); color: #fff; }
+    .mini-player .mini-btn-ghost { background: var(--bs-secondary-bg); background: color-mix(in srgb, var(--bs-secondary-bg) 82%, transparent); color: var(--bs-body-color); border: 1px solid color-mix(in srgb, var(--bs-border-color) 70%, transparent); box-shadow: 0 8px 20px rgba(13,110,253,.08), 0 2px 6px rgba(0,0,0,.15); }
+    .mini-player .mini-btn-ghost:hover { background: var(--bs-secondary-bg); background: color-mix(in srgb, var(--bs-secondary-bg) 92%, var(--bs-primary) 12%); }
+    .mini-player .mini-actions { display: flex; flex-direction: column; gap: .55rem; align-items: center; justify-content: center; min-width: 62px; }
+    .mini-player .mini-action { display: flex; flex-direction: column; align-items: center; gap: .2rem; }
+    .mini-player .mini-action-label { font-size: .65rem; font-weight: 600; letter-spacing: .08em; text-transform: uppercase; color: var(--bs-secondary); }
     .mini-player .form-range { height: 1rem; appearance: none; background: linear-gradient(90deg, rgba(13,110,253,.35) 0%, rgba(32,201,151,.35) 50%, rgba(220,53,69,.35) 100%); border-radius: 999px; box-shadow: inset 0 0 0 1px rgba(255,255,255,.18), 0 4px 14px rgba(13,110,253,.18); }
     .mini-player .form-range::-webkit-slider-runnable-track, .mini-player .form-range::-moz-range-track { height: .45rem; border-radius: 999px; background: transparent; }
     .mini-player .form-range::-webkit-slider-thumb { -webkit-appearance: none; width: 16px; height: 16px; border-radius: 50%; background: radial-gradient(circle at 30% 30%, #fff 0%, rgba(255,255,255,.6) 45%, rgba(32,201,151,1) 100%); border: 2px solid rgba(255,255,255,.9); box-shadow: 0 0 10px rgba(32,201,151,.6), 0 2px 6px rgba(0,0,0,.25); margin-top: -6px; }
@@ -63,8 +75,14 @@
     .mini-player-card { background: radial-gradient(circle at top left, rgba(13,110,253,.12), transparent 60%), radial-gradient(circle at bottom right, rgba(220,53,69,.12), transparent 55%), var(--bs-body-bg); backdrop-filter: blur(6px); }
     .mini-player-title { font-size: .85rem; letter-spacing: .01em; }
     .mini-player-subtitle { font-size: .7rem; color: var(--bs-secondary); margin-top: .1rem; }
+    html[data-bs-theme='dark'] .mini-player .mini-btn-play { box-shadow: 0 16px 32px rgba(13,110,253,.28), 0 6px 18px rgba(0,0,0,.45); }
+    html[data-bs-theme='dark'] .mini-player .mini-btn-ghost { background: rgba(255,255,255,.08); background: color-mix(in srgb, rgba(255,255,255,.12) 80%, transparent); border-color: rgba(255,255,255,.18); color: rgba(255,255,255,.85); box-shadow: 0 10px 24px rgba(13,110,253,.16), 0 4px 10px rgba(0,0,0,.45); }
+    html[data-bs-theme='dark'] .mini-player .mini-action-label { color: rgba(255,255,255,.6); }
     html[data-bs-theme='dark'] .mini-player-subtitle { color: rgba(255,255,255,.6); }
     #miniPlayer[hidden] { display: none !important; }
+    @media (min-width: 577px) {
+      .mini-player-body { flex-wrap: nowrap; }
+    }
     @media (max-width: 576px) {
       body { padding-bottom: 5rem; }
       .btn { padding: .75rem 1rem; font-size: 1.05rem; }
@@ -77,6 +95,9 @@
       #qrWrap, #playlistQrWrap { min-width: 120px; }
       .mini-player { bottom: .75rem; }
       .mini-player-card { width: calc(100% - 1.5rem); }
+      .mini-player-body { gap: 1rem; }
+      .mini-player .mini-actions { flex-direction: row; min-width: 100%; justify-content: space-evenly; }
+      .mini-player .mini-action-label { font-size: .6rem; }
     }
   </style>
 </head>
@@ -534,11 +555,12 @@
 
   <div id="miniPlayer" class="mini-player" hidden>
     <div class="mini-player-card card shadow-lg border-0">
-      <div class="card-body py-3 d-flex align-items-center gap-3">
-        <button class="btn btn-primary btn-sm" id="miniPlayBtn" type="button" aria-label="Putar / jeda">
-          <i class="bi bi-play-fill"></i>
+      <div class="card-body mini-player-body py-3">
+        <button class="mini-btn mini-btn-play" id="miniPlayBtn" type="button" aria-label="Putar / jeda" title="Putar / jeda">
+          <i class="bi bi-play-fill" aria-hidden="true"></i>
+          <span class="visually-hidden mini-btn-label">Putar</span>
         </button>
-        <div class="flex-grow-1">
+        <div class="mini-player-main">
           <div class="d-flex align-items-center justify-content-between gap-2">
             <div class="fw-semibold mini-player-title text-truncate" id="miniTitle">Audio Preview</div>
             <div class="small text-secondary" id="miniTime">00:00</div>
@@ -546,8 +568,22 @@
           <div class="mini-player-subtitle text-truncate" id="miniSubtitle"></div>
           <input type="range" class="form-range mt-2" id="miniSeek" min="0" max="1000" value="0" aria-label="Seek audio">
         </div>
-        <button class="btn btn-outline-secondary btn-sm" id="miniShareBtn" type="button" aria-label="Bagikan mini player"><i class="bi bi-qr-code"></i></button>
-        <button class="btn btn-outline-secondary btn-sm" id="miniCloseBtn" type="button" aria-label="Tutup mini player"><i class="bi bi-x-lg"></i></button>
+        <div class="mini-actions">
+          <div class="mini-action">
+            <button class="mini-btn mini-btn-ghost" id="miniShareBtn" type="button" aria-label="Bagikan mini player" title="Bagikan mini player">
+              <i class="bi bi-qr-code" aria-hidden="true"></i>
+              <span class="visually-hidden">Bagikan mini player</span>
+            </button>
+            <span class="mini-action-label">QR</span>
+          </div>
+          <div class="mini-action">
+            <button class="mini-btn mini-btn-ghost" id="miniCloseBtn" type="button" aria-label="Tutup mini player" title="Tutup mini player">
+              <i class="bi bi-x-lg" aria-hidden="true"></i>
+              <span class="visually-hidden">Tutup mini player</span>
+            </button>
+            <span class="mini-action-label">Tutup</span>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -692,6 +728,8 @@
   const urlDropOverlay = $('#urlDropOverlay');
   const miniPlayerEl = $('#miniPlayer');
   const miniPlayBtn = $('#miniPlayBtn');
+  const miniPlayIcon = miniPlayBtn ? miniPlayBtn.querySelector('i') : null;
+  const miniPlayLabel = miniPlayBtn ? miniPlayBtn.querySelector('.mini-btn-label') : null;
   const miniCloseBtn = $('#miniCloseBtn');
   const miniShareBtn = $('#miniShareBtn');
   const miniSeek = $('#miniSeek');
@@ -1643,13 +1681,10 @@ $('#queueList')?.addEventListener('click', (e) => {
 
   const updateMiniPlayState = () => {
     if (!miniPlayBtn || !previewPlayer) return;
-    if (previewPlayer.paused){
-      miniPlayBtn.innerHTML = '<i class="bi bi-play-fill"></i>';
-      miniPlayBtn.setAttribute('aria-label', 'Putar');
-    } else {
-      miniPlayBtn.innerHTML = '<i class="bi bi-pause-fill"></i>';
-      miniPlayBtn.setAttribute('aria-label', 'Jeda');
-    }
+    const paused = previewPlayer.paused;
+    if (miniPlayIcon) miniPlayIcon.className = paused ? 'bi bi-play-fill' : 'bi bi-pause-fill';
+    if (miniPlayLabel) miniPlayLabel.textContent = paused ? 'Putar' : 'Jeda';
+    miniPlayBtn.setAttribute('aria-label', paused ? 'Putar' : 'Jeda');
   };
 
   if (miniPlayBtn) miniPlayBtn.addEventListener('click', () => {

--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -233,6 +233,31 @@
               <label class="form-check-label" for="atmos">Dolby Atmos (multi-channel)</label>
             </div>
 
+            <div class="row g-3 mb-3 align-items-end">
+              <div class="col-md-4">
+                <div class="form-check form-switch">
+                  <input class="form-check-input" type="checkbox" id="denoise">
+                  <label class="form-check-label" for="denoise">AI Noise Cleaner</label>
+                </div>
+              </div>
+              <div class="col-md-4">
+                <label class="form-label d-flex justify-content-between align-items-center" for="volumeBoost">
+                  <span>Volume Booster</span>
+                  <span class="badge text-bg-secondary" id="volumeBoostLabel">0 dB</span>
+                </label>
+                <input type="range" class="form-range" id="volumeBoost" min="0" max="12" step="1" value="0">
+              </div>
+              <div class="col-md-4">
+                <label class="form-label" for="enhancer">AI Enhancer</label>
+                <select id="enhancer" class="form-select">
+                  <option value="none" selected>Off</option>
+                  <option value="clarity">Vocal Clarity</option>
+                  <option value="warm">Warm Glow</option>
+                  <option value="club">Club Lift</option>
+                </select>
+              </div>
+            </div>
+
             <div class="dropzone mb-3" id="dropzone">
               <i class="bi bi-cloud-arrow-up fs-4 d-block mb-1"></i>
               <div class="small text-secondary">Seret & lepas file <code>cookies.txt</code> ke sini (opsional) untuk bypass age‑gate</div>
@@ -245,6 +270,46 @@
               <button id="downloadAllBtn" class="btn btn-outline-primary"><i class="bi bi-download"></i> Download Semua</button>
               <button id="downloadZipBtn" class="btn btn-success"><i class="bi bi-collection"></i> Download ZIP</button>
               <button id="clearBtn" class="btn btn-outline-secondary"><i class="bi bi-x-circle"></i> Bersihkan</button>
+            </div>
+
+            <div class="card border-0 bg-body-tertiary mt-4" id="aiStudioCard">
+              <div class="card-body">
+                <div class="d-flex flex-wrap align-items-center gap-2 mb-3">
+                  <strong class="me-auto">AI Studio & Cloud</strong>
+                  <div class="form-check form-switch m-0">
+                    <input class="form-check-input" type="checkbox" id="backgroundMode">
+                    <label class="form-check-label small" for="backgroundMode">Background mode</label>
+                  </div>
+                </div>
+                <div class="row g-3">
+                  <div class="col-md-6">
+                    <div class="d-grid gap-2">
+                      <button class="btn btn-outline-primary" id="autoTagBtn" type="button"><i class="bi bi-stars"></i> Auto Music Tags</button>
+                      <button class="btn btn-outline-secondary" id="thumbnailBtn" type="button"><i class="bi bi-image"></i> AI Thumbnail</button>
+                      <button class="btn btn-outline-success" id="stemBtn" type="button"><i class="bi bi-mic-fill"></i> Voice ↔ Instrumental</button>
+                    </div>
+                  </div>
+                  <div class="col-md-6">
+                    <div class="d-grid gap-2">
+                      <button class="btn btn-outline-primary" id="cloudDriveBtn" type="button"><i class="bi bi-cloud-arrow-up"></i> Save to Drive</button>
+                      <button class="btn btn-outline-primary" id="cloudDropboxBtn" type="button"><i class="bi bi-cloud-upload"></i> Save to Dropbox</button>
+                      <button class="btn btn-outline-primary" id="cloudOnedriveBtn" type="button"><i class="bi bi-cloud"></i> Save to OneDrive</button>
+                    </div>
+                  </div>
+                </div>
+                <div class="alert alert-info mt-3 small" id="aiStatus" hidden></div>
+                <div class="mt-3" id="stemResult" hidden>
+                  <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
+                    <strong>Stems siap</strong>
+                    <button class="btn btn-sm btn-outline-secondary" id="stemClearBtn" type="button"><i class="bi bi-x"></i> Tutup</button>
+                  </div>
+                  <div class="d-flex flex-wrap gap-2">
+                    <a id="stemVocalsLink" class="btn btn-sm btn-primary" href="#" download>Vocals</a>
+                    <a id="stemInstrumentalLink" class="btn btn-sm btn-outline-primary" href="#" download>Instrumental</a>
+                    <a id="stemZipLink" class="btn btn-sm btn-outline-secondary" href="#" download>ZIP</a>
+                  </div>
+                </div>
+              </div>
             </div>
 
             <div class="card border-0 bg-body-tertiary mt-4" id="subtitleCard">
@@ -417,6 +482,17 @@
       </div>
 
       <div class="col-lg-5">
+        <div class="card shadow-sm mb-4" id="backgroundCard">
+          <div class="card-body p-4">
+            <div class="d-flex align-items-center mb-2">
+              <i class="bi bi-cloud-check me-2"></i>
+              <h5 class="mb-0">Background Jobs</h5>
+            </div>
+            <div class="small text-secondary" id="backgroundEmpty">Belum ada job latar.</div>
+            <ul class="list-group list-group-flush" id="backgroundList"></ul>
+          </div>
+        </div>
+
         <div class="card shadow-sm mb-4">
           <div class="card-body p-4">
             <div class="d-flex align-items-center mb-2">
@@ -582,12 +658,31 @@
   const eqPresetFlat = $('#eqPresetFlat');
   const eqPresetPodcast = $('#eqPresetPodcast');
   const eqPresetBass = $('#eqPresetBass');
+  const denoiseInput = $('#denoise');
+  const volumeBoost = $('#volumeBoost');
+  const volumeBoostLabel = $('#volumeBoostLabel');
+  const enhancerSelect = $('#enhancer');
+  const backgroundMode = $('#backgroundMode');
+  const aiStatus = $('#aiStatus');
+  const autoTagBtn = $('#autoTagBtn');
+  const thumbnailBtn = $('#thumbnailBtn');
+  const stemBtn = $('#stemBtn');
+  const stemResult = $('#stemResult');
+  const stemVocalsLink = $('#stemVocalsLink');
+  const stemInstrumentalLink = $('#stemInstrumentalLink');
+  const stemZipLink = $('#stemZipLink');
+  const stemClearBtn = $('#stemClearBtn');
+  const cloudDriveBtn = $('#cloudDriveBtn');
+  const cloudDropboxBtn = $('#cloudDropboxBtn');
+  const cloudOnedriveBtn = $('#cloudOnedriveBtn');
   const playlistResultWrap = $('#playlistResultWrap');
   const playlistDownloadLink = $('#playlistDownloadLink');
   const playlistInfo = $('#playlistInfo');
   const playlistShareCard = $('#playlistShareCard');
   const playlistQrCanvas = $('#playlistQr');
   const playlistQrWrap = $('#playlistQrWrap');
+  const backgroundList = $('#backgroundList');
+  const backgroundEmpty = $('#backgroundEmpty');
   const urlDropOverlay = $('#urlDropOverlay');
   const miniPlayerEl = $('#miniPlayer');
   const miniPlayBtn = $('#miniPlayBtn');
@@ -633,6 +728,11 @@
   let miniSeeking = false;
   let subtitleShareUrl = '';
   let lastPreviewTitle = '';
+  let lastResult = null;
+  let lastVideoMeta = {};
+  const backgroundJobsState = new Map();
+  const backgroundTimers = new Map();
+  const BACKGROUND_STORE_KEY = 'ytmp3.background.jobs.v1';
 
   const getBackend = () => (state.backendUrl || '').trim();
 
@@ -648,10 +748,48 @@
     return b ? b.replace(/\/$/, '') + path : path; // relative fallback
   };
 
+  const toRelativePublic = (link) => {
+    if (!link) return '';
+    try {
+      const parsed = new URL(link);
+      return parsed.pathname;
+    } catch {
+      return link.startsWith('/public/') ? link : '';
+    }
+  };
+
+  const absoluteFromRelative = (path) => {
+    if (!path) return '';
+    const base = getBackend() || window.location.origin;
+    try {
+      return new URL(path, base).href;
+    } catch {
+      return path;
+    }
+  };
+
+  const updateAiStatus = (message, type = 'info') => {
+    if (!aiStatus) return;
+    if (!message) {
+      aiStatus.hidden = true;
+      aiStatus.textContent = '';
+      return;
+    }
+    aiStatus.hidden = false;
+    aiStatus.className = `alert alert-${type} mt-3 small`;
+    aiStatus.innerHTML = message;
+  };
+
   const updateBackendBadge = () => {
     const badge = $('#backendBadge');
     const b = getBackend();
     badge.textContent = b ? new URL(b).host : location.host;
+  };
+
+  const updateBoostLabel = () => {
+    if (!volumeBoost || !volumeBoostLabel) return;
+    const val = Number(volumeBoost.value || 0);
+    volumeBoostLabel.textContent = `${val >= 0 ? '+' : ''}${val} dB`;
   };
 
   const renderQr = (canvas, wrap, url) => {
@@ -690,6 +828,8 @@
     currentDownloadName = '';
     currentShareUrl = '';
     subtitleShareUrl = '';
+    lastResult = null;
+    updateAiStatus('');
     resetWaveform();
     if (equalizerWrap) equalizerWrap.hidden = true;
     if (miniPlayerEl) miniPlayerEl.hidden = true;
@@ -711,6 +851,12 @@
     if (meta.fileName) shareUrl.searchParams.set('name', meta.fileName);
     if (meta.format) shareUrl.searchParams.set('fmt', meta.format);
     currentShareUrl = shareUrl.toString();
+    lastResult = {
+      downloadUrl: absoluteUrl,
+      fileName: meta.fileName || '',
+      format: meta.format || '',
+      jobId: meta.jobId || null,
+    };
     if (shareWrap) shareWrap.hidden = false;
     if (shareLinkInput) shareLinkInput.value = currentShareUrl;
     if (shareInfo) shareInfo.textContent = 'Bagikan link atau scan QR untuk membuka mini player.';
@@ -1280,7 +1426,156 @@ $('#queueList')?.addEventListener('click', (e) => {
     applyEqFromInputs();
     setToast('Bass+ diterapkan');
   });
+  if (volumeBoost) {
+    volumeBoost.addEventListener('input', updateBoostLabel);
+    updateBoostLabel();
+  }
   updateEqStatus();
+
+  const persistBackgroundJobs = () => {
+    try {
+      const ids = Array.from(backgroundJobsState.keys()).slice(0, 20);
+      localStorage.setItem(BACKGROUND_STORE_KEY, JSON.stringify(ids));
+    } catch {}
+  };
+
+  const notifyJob = (job, isError = false) => {
+    if (!('Notification' in window)) return;
+    if (Notification.permission !== 'granted') return;
+    const title = isError ? 'Konversi gagal' : 'Konversi selesai';
+    const body = job?.result?.fileName || job?.error || job?.id || 'Job selesai';
+    try { new Notification(title, { body }); } catch {}
+  };
+
+  const renderBackgroundJobs = () => {
+    if (!backgroundList || !backgroundEmpty) return;
+    backgroundList.innerHTML = '';
+    const jobs = Array.from(backgroundJobsState.values())
+      .sort((a, b) => (b.createdAt || 0) - (a.createdAt || 0));
+    if (!jobs.length) {
+      backgroundEmpty.hidden = false;
+      return;
+    }
+    backgroundEmpty.hidden = true;
+    jobs.slice(0, 12).forEach((job) => {
+      const li = document.createElement('li');
+      li.className = 'list-group-item small';
+      const status = job.status || 'queued';
+      const badge = status === 'done' ? 'success' : status === 'error' ? 'danger' : 'secondary';
+      const label = job?.result?.fileName || job?.payload?.fileName || job?.payload?.title || job?.payload?.url || `Job ${job.id}`;
+      const actions = [];
+      if (job.result?.downloadUrl) {
+        const href = absoluteFromRelative(job.result.downloadUrl);
+        actions.push(`<a class="btn btn-sm btn-outline-primary" href="${href}" download="${job.result.fileName || ''}"><i class="bi bi-download"></i> Unduh</a>`);
+      }
+      if (status === 'done') {
+        actions.push(`<button class="btn btn-sm btn-outline-secondary" data-cloud="drive" data-job="${job.id}" title="Simpan ke cloud"><i class="bi bi-cloud-arrow-up"></i></button>`);
+      }
+      if (status !== 'done' && status !== 'error') {
+        actions.push('<span class="text-secondary">Diproses…</span>');
+      }
+      li.innerHTML = `
+        <div class="d-flex flex-column gap-1">
+          <div class="d-flex justify-content-between align-items-center">
+            <span class="fw-semibold text-truncate" title="${label}">${label}</span>
+            <span class="badge text-bg-${badge} text-uppercase">${status}</span>
+          </div>
+          <div class="d-flex flex-wrap align-items-center gap-2">
+            <span class="text-secondary">#${job.id.slice(-6)}</span>
+            ${actions.join(' ')}
+          </div>
+        </div>`;
+      backgroundList.appendChild(li);
+    });
+  };
+
+  const updateBackgroundJob = (job) => {
+    if (!job || !job.id) return;
+    const previous = backgroundJobsState.get(job.id);
+    backgroundJobsState.set(job.id, job);
+    renderBackgroundJobs();
+    persistBackgroundJobs();
+    if (job.status === 'done' && previous?.status !== 'done') {
+      setToast(`Job selesai: ${job.result?.fileName || job.id}`);
+      notifyJob(job, false);
+      updateAiStatus(`Job selesai: ${job.result?.fileName || job.id}`, 'success');
+      if (job.result?.downloadUrl) {
+        lastResult = {
+          downloadUrl: absoluteFromRelative(job.result.downloadUrl),
+          fileName: job.result.fileName || '',
+          format: job.result.format || '',
+          jobId: job.id,
+        };
+      }
+    } else if (job.status === 'error' && previous?.status !== 'error') {
+      setToast(`Job gagal: ${job.error || job.id}`);
+      notifyJob(job, true);
+      updateAiStatus(`Job gagal: ${job.error || job.id}`, 'danger');
+    }
+  };
+
+  const scheduleJobPoll = (id, delay = 3500) => {
+    if (!id) return;
+    if (backgroundTimers.has(id)) {
+      clearTimeout(backgroundTimers.get(id));
+    }
+    const timer = setTimeout(() => pollBackgroundJob(id), delay);
+    backgroundTimers.set(id, timer);
+  };
+
+  const pollBackgroundJob = async (id) => {
+    backgroundTimers.delete(id);
+    try {
+      const resp = await fetch(api(`/api/background/${id}`));
+      if (!resp.ok) {
+        if (resp.status === 404) {
+          backgroundJobsState.delete(id);
+          renderBackgroundJobs();
+          persistBackgroundJobs();
+        }
+        return;
+      }
+      const data = await resp.json();
+      if (data?.job) {
+        updateBackgroundJob(data.job);
+        if (data.job.status !== 'done' && data.job.status !== 'error') {
+          scheduleJobPoll(id, 4000);
+        }
+      }
+    } catch {
+      scheduleJobPoll(id, 6000);
+    }
+  };
+
+  const refreshBackgroundJobs = async () => {
+    try {
+      const resp = await fetch(api('/api/background'));
+      if (!resp.ok) return;
+      const data = await resp.json();
+      if (Array.isArray(data?.jobs)) {
+        backgroundJobsState.clear();
+        data.jobs.forEach((job) => {
+          if (job && job.id) backgroundJobsState.set(job.id, job);
+        });
+        renderBackgroundJobs();
+        persistBackgroundJobs();
+        data.jobs.forEach((job) => {
+          if (job.status !== 'done' && job.status !== 'error') scheduleJobPoll(job.id, 2000);
+        });
+      }
+    } catch {}
+  };
+
+  const loadStoredJobs = () => {
+    try {
+      const raw = localStorage.getItem(BACKGROUND_STORE_KEY);
+      if (!raw) return;
+      const ids = JSON.parse(raw);
+      if (Array.isArray(ids)) {
+        ids.slice(0, 20).forEach((id) => scheduleJobPoll(id, 500));
+      }
+    } catch {}
+  };
 
   const shareLink = async (link) => {
     if (!link) { setToast('Belum ada link untuk dibagikan'); return; }
@@ -1398,7 +1693,15 @@ $('#queueList')?.addEventListener('click', (e) => {
       $('#id3Artist').value = data.author_name || '';
       $('#id3Album').value = data.title;
       $('#fileName').value = sanitizeFileName(data.title);
-    }catch{ $('#previewWrap').hidden = true; }
+      lastVideoMeta = {
+        title: data.title,
+        author: data.author_name || '',
+        thumbnail: data.thumbnail_url,
+      };
+    }catch{
+      $('#previewWrap').hidden = true;
+      lastVideoMeta = {};
+    }
   }
   $('#pasteBtn').addEventListener('click', async () => {
     try { $('#url').value = (await navigator.clipboard.readText() || '').trim(); } catch {}
@@ -1412,6 +1715,128 @@ $('#queueList')?.addEventListener('click', (e) => {
   $('#url').addEventListener('change', updatePreview);
   $('#trimStart').addEventListener('change', syncWaveformFromInputs);
   $('#trimEnd').addEventListener('change', syncWaveformFromInputs);
+
+  if (autoTagBtn) autoTagBtn.addEventListener('click', async () => {
+    const title = $('#id3Title').value.trim() || lastVideoMeta.title || $('#videoTitle').textContent.trim();
+    if (!title) { setToast('Isi judul terlebih dahulu'); return; }
+    updateAiStatus('Menganalisis metadata…', 'info');
+    try {
+      const resp = await fetch(api('/api/ai-tags'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title,
+          channel: $('#id3Artist').value.trim() || lastVideoMeta.author || '',
+          duration: Number(previewPlayer?.duration || 0) || undefined,
+        }),
+      });
+      const data = await resp.json();
+      if (!resp.ok) throw new Error(data.error || 'Gagal menganalisis');
+      const tags = data.tags || {};
+      if (tags.title) $('#id3Title').value = tags.title;
+      if (tags.artist) $('#id3Artist').value = tags.artist;
+      if (tags.album) $('#id3Album').value = tags.album;
+      updateAiStatus(`Genre: <strong>${tags.genre || '-'}</strong> · Mood: <strong>${tags.mood || '-'}</strong>`, 'success');
+      setToast('Metadata diperbarui otomatis');
+    } catch (err) {
+      updateAiStatus(err.message, 'danger');
+      setToast('Gagal AI tags: ' + err.message);
+    }
+  });
+
+  if (thumbnailBtn) thumbnailBtn.addEventListener('click', async () => {
+    const baseImage = lastVideoMeta.thumbnail || $('#thumb').src;
+    if (!baseImage) { setToast('Thumbnail belum tersedia'); return; }
+    const baseTitle = $('#id3Title').value.trim() || lastVideoMeta.title || 'AI Cover';
+    const title = prompt('Judul cover', baseTitle);
+    if (title === null) return;
+    const subtitle = prompt('Subjudul (opsional)', lastVideoMeta.author || '');
+    const accent = prompt('Warna aksen (#RRGGBB)', '#0d6efd') || '#0d6efd';
+    const style = prompt('Style (modern/vibrant/mono)', 'modern') || 'modern';
+    updateAiStatus('Membuat thumbnail…', 'info');
+    try {
+      const resp = await fetch(api('/api/thumbnail'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ imageUrl: baseImage, title, subtitle, accent, style }),
+      });
+      const data = await resp.json();
+      if (!resp.ok) throw new Error(data.error || 'Gagal membuat thumbnail');
+      if (data.url) {
+        const absolute = absoluteFromRelative(data.url);
+        $('#thumb').src = `${absolute}${absolute.includes('?') ? '&' : '?'}t=${Date.now()}`;
+        updateAiStatus(`Thumbnail baru siap. <a href="${absolute}" target="_blank" rel="noopener">Lihat</a>`, 'success');
+        setToast('Thumbnail diperbarui');
+        lastVideoMeta.thumbnail = absolute;
+      }
+    } catch (err) {
+      updateAiStatus(err.message, 'danger');
+      setToast('Gagal membuat thumbnail: ' + err.message);
+    }
+  });
+
+  if (stemBtn) stemBtn.addEventListener('click', async () => {
+    const payload = {};
+    if (lastResult?.jobId) payload.jobId = lastResult.jobId;
+    else if (lastResult?.downloadUrl) payload.downloadUrl = toRelativePublic(lastResult.downloadUrl);
+    else if ($('#url').value.trim()) payload.url = $('#url').value.trim();
+    else { setToast('Belum ada audio untuk diproses'); return; }
+    updateAiStatus('Memisahkan vokal dan instrumen…', 'info');
+    try {
+      const resp = await fetch(api('/api/stems'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const data = await resp.json();
+      if (!resp.ok) throw new Error(data.error || 'Gagal memisahkan');
+      if (stemResult) {
+        stemResult.hidden = false;
+        if (stemVocalsLink && data.vocals?.downloadUrl) {
+          const href = absoluteFromRelative(data.vocals.downloadUrl);
+          stemVocalsLink.href = href;
+          stemVocalsLink.setAttribute('download', data.vocals.fileName || 'vocals.mp3');
+        }
+        if (stemInstrumentalLink && data.instrumental?.downloadUrl) {
+          const href = absoluteFromRelative(data.instrumental.downloadUrl);
+          stemInstrumentalLink.href = href;
+          stemInstrumentalLink.setAttribute('download', data.instrumental.fileName || 'instrumental.mp3');
+        }
+        if (stemZipLink && data.zip?.downloadUrl) {
+          const href = absoluteFromRelative(data.zip.downloadUrl);
+          stemZipLink.href = href;
+          stemZipLink.setAttribute('download', data.zip.fileName || 'stems.zip');
+        }
+      }
+      updateAiStatus('Stems siap diunduh', 'success');
+      setToast('Stems berhasil dibuat');
+    } catch (err) {
+      updateAiStatus(err.message, 'danger');
+      setToast('Gagal membuat stems: ' + err.message);
+    }
+  });
+
+  if (stemClearBtn) stemClearBtn.addEventListener('click', () => {
+    if (stemResult) stemResult.hidden = true;
+  });
+
+  if (cloudDriveBtn) cloudDriveBtn.addEventListener('click', () => saveToCloud('drive'));
+  if (cloudDropboxBtn) cloudDropboxBtn.addEventListener('click', () => saveToCloud('dropbox'));
+  if (cloudOnedriveBtn) cloudOnedriveBtn.addEventListener('click', () => saveToCloud('onedrive'));
+
+  if (backgroundList) backgroundList.addEventListener('click', (e) => {
+    const btn = e.target.closest('button[data-cloud][data-job]');
+    if (!btn) return;
+    const target = btn.getAttribute('data-cloud');
+    const jobId = btn.getAttribute('data-job');
+    if (target && jobId) saveToCloud(target, jobId);
+  });
+
+  if (backgroundMode) backgroundMode.addEventListener('change', async () => {
+    if (backgroundMode.checked && 'Notification' in window && Notification.permission === 'default') {
+      try { await Notification.requestPermission(); } catch {}
+    }
+  });
 
   // ===== Drag & drop cookies.txt =====
   const dz = $('#dropzone');
@@ -1532,6 +1957,14 @@ $('#queueList')?.addEventListener('click', (e) => {
 
     body.normalize = $('#normalize').checked;
     if($('#thumb').src) body.coverUrl = $('#thumb').src;
+    if (denoiseInput) body.denoise = denoiseInput.checked;
+    if (volumeBoost) body.volumeBoost = Number(volumeBoost.value || 0);
+    if (enhancerSelect) body.enhancer = enhancerSelect.value || 'none';
+
+    if (backgroundMode?.checked) {
+      await submitBackgroundJob(body);
+      return;
+    }
 
     $('#statusWrap').hidden = false; $('#resultWrap').hidden = true; $('#logWrap').hidden = !$('#showLog').checked; $('#logs').textContent = '';
     $('#loadingSpinner').style.display = '';
@@ -1567,6 +2000,7 @@ $('#queueList')?.addEventListener('click', (e) => {
       };
       showAudioPreview(absoluteDownload, previewMeta);
       setToast('Berhasil diproses');
+      updateAiStatus('Konversi selesai', 'success');
       if($('#autoClear').checked && !urlOverride){ $('#clearBtn').click(); }
     }catch(err){
       $('#status').textContent = 'Error: ' + err.message;
@@ -1576,9 +2010,61 @@ $('#queueList')?.addEventListener('click', (e) => {
       $('#logs').textContent = (err && err.stack) ? err.stack : String(err);
       resetAudioPreview();
       setToast('Terjadi error: '+err.message);
+      updateAiStatus(err.message, 'danger');
     } finally {
       clearInterval(timer);
       setTimeout(()=>{ progWrap.hidden = true; }, 500);
+    }
+  }
+
+  async function submitBackgroundJob(body){
+    try {
+      updateAiStatus('Mengirim ke background…', 'info');
+      const resp = await fetch(api('/api/background'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      const data = await resp.json();
+      if (!resp.ok) throw new Error(data.error || 'Gagal membuat job');
+      if (data.job) {
+        updateBackgroundJob(data.job);
+        setToast('Job diproses di latar');
+        updateAiStatus(`Job #${data.job.id.slice(-5)} masuk antrian.`, 'info');
+        scheduleJobPoll(data.job.id, 1500);
+      }
+    } catch (err) {
+      updateAiStatus(err.message || 'Gagal membuat job', 'danger');
+      setToast('Gagal membuat job: ' + err.message);
+    }
+  }
+
+  async function saveToCloud(target, jobIdOverride){
+    const payload = { target };
+    const jobId = jobIdOverride || lastResult?.jobId;
+    if (jobId) {
+      payload.jobId = jobId;
+    } else {
+      const rel = toRelativePublic(lastResult?.downloadUrl);
+      if (!rel) { setToast('Belum ada hasil untuk disimpan'); return; }
+      payload.downloadUrl = rel;
+      if (lastResult?.fileName) payload.fileName = lastResult.fileName;
+    }
+    try {
+      updateAiStatus(`Menyimpan ke ${target}…`, 'info');
+      const resp = await fetch(api('/api/cloud/save'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const data = await resp.json();
+      if (!resp.ok) throw new Error(data.error || 'Gagal menyimpan');
+      const href = absoluteFromRelative(data.downloadUrl);
+      updateAiStatus(`Tersimpan di ${data.label}. <a href="${href}" target="_blank" rel="noopener">Buka file</a>`, 'success');
+      setToast(`Tersimpan di ${data.label}`);
+    } catch (err) {
+      updateAiStatus(err.message || 'Gagal menyimpan', 'danger');
+      setToast('Gagal menyimpan: ' + err.message);
     }
   }
 
@@ -1769,6 +2255,9 @@ $('#queueList')?.addEventListener('click', (e) => {
     renderQueue();
     updateBackendBadge();
     updatePreview();
+    renderBackgroundJobs();
+    loadStoredJobs();
+    refreshBackgroundJobs();
     if(!localStorage.getItem(tutorialKey)){
       const m = new bootstrap.Modal($('#tutorialModal'));
       m.show();

--- a/public-ui/share.html
+++ b/public-ui/share.html
@@ -77,6 +77,8 @@
     const audioSrc = params.get('src');
     const trackName = params.get('name') || params.get('title') || 'Audio hasil convert';
     const fmt = params.get('fmt') || '';
+    const srParam = Number(params.get('sr') || 0);
+    const chParam = Number(params.get('ch') || 0);
     const audioEl = document.getElementById('shareAudio');
     const titleEl = document.getElementById('trackTitle');
     const metaEl = document.getElementById('trackMeta');
@@ -186,7 +188,19 @@
       audioEl.addEventListener('play', () => { ensureFilters(); applyEq(); });
     }
     if (titleEl) titleEl.textContent = trackName;
-    if (metaEl) metaEl.textContent = fmt ? `Format ${fmt.toUpperCase()} · Streaming siap` : 'Streaming siap';
+    if (metaEl) {
+      const metaParts = [];
+      if (fmt) metaParts.push(`Format ${fmt.toUpperCase()}`);
+      if (Number.isFinite(srParam) && srParam > 0) {
+        const kHz = Math.round((srParam / 1000) * 10) / 10;
+        metaParts.push(`${kHz % 1 === 0 ? kHz.toFixed(0) : kHz.toFixed(1)} kHz`);
+      }
+      if (Number.isFinite(chParam) && chParam > 0) {
+        metaParts.push(chParam === 1 ? 'Mono' : `${chParam}-Ch`);
+      }
+      metaParts.push('Streaming siap');
+      metaEl.textContent = metaParts.join(' · ');
+    }
     if (downloadBtn){
       downloadBtn.href = resolvedSrc;
       downloadBtn.download = trackName ? `${trackName}.${fmt || 'mp3'}` : '';

--- a/public-ui/share.html
+++ b/public-ui/share.html
@@ -14,7 +14,13 @@
     body { min-height: 100vh; display: flex; align-items: center; justify-content: center; background: radial-gradient(circle at top, rgba(13,110,253,.35), transparent 55%), radial-gradient(circle at bottom, rgba(25,135,84,.35), transparent 55%); padding: 1.5rem; }
     .player-card { max-width: 540px; border-radius: 1.25rem; overflow: hidden; }
     .eq-slider label { font-size: .75rem; text-transform: uppercase; letter-spacing: .08em; color: var(--bs-secondary); }
-    .eq-slider .form-range { height: 1.25rem; }
+    .eq-slider .form-range { height: 1.25rem; appearance: none; background: linear-gradient(90deg, rgba(13,110,253,.28) 0%, rgba(111,66,193,.38) 55%, rgba(220,53,69,.32) 100%); border-radius: 999px; box-shadow: inset 0 0 0 1px rgba(255,255,255,.12), 0 6px 18px rgba(13,110,253,.18); transition: box-shadow .2s ease, background .2s ease; }
+    .eq-slider .form-range:focus-visible { outline: none; box-shadow: inset 0 0 0 1px rgba(255,255,255,.2), 0 0 0 .35rem rgba(13,110,253,.25); }
+    .eq-slider .form-range::-webkit-slider-runnable-track { height: .5rem; border-radius: 999px; background: transparent; }
+    .eq-slider .form-range::-moz-range-track { height: .5rem; border-radius: 999px; background: transparent; }
+    .eq-slider .form-range::-webkit-slider-thumb { -webkit-appearance: none; width: 18px; height: 18px; border-radius: 50%; background: radial-gradient(circle at 30% 30%, #ffffff 0%, rgba(255,255,255,.65) 40%, rgba(13,110,253,1) 100%); border: 2px solid rgba(255,255,255,.85); box-shadow: 0 0 12px rgba(13,110,253,.55), 0 4px 10px rgba(0,0,0,.25); margin-top: -6px; transition: transform .15s ease, box-shadow .2s ease; }
+    .eq-slider .form-range::-moz-range-thumb { width: 18px; height: 18px; border-radius: 50%; background: radial-gradient(circle at 30% 30%, #ffffff 0%, rgba(255,255,255,.65) 40%, rgba(13,110,253,1) 100%); border: 2px solid rgba(255,255,255,.85); box-shadow: 0 0 12px rgba(13,110,253,.55), 0 4px 10px rgba(0,0,0,.25); transition: transform .15s ease, box-shadow .2s ease; }
+    .eq-slider .form-range:active::-webkit-slider-thumb, .eq-slider .form-range:active::-moz-range-thumb { transform: scale(1.08); box-shadow: 0 0 18px rgba(111,66,193,.55), 0 6px 14px rgba(0,0,0,.3); }
     .muted { color: var(--bs-secondary); }
   </style>
 </head>

--- a/public-ui/share.html
+++ b/public-ui/share.html
@@ -1,0 +1,198 @@
+<!doctype html>
+<html lang="id" data-bs-theme="dark">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Mini Player · Share Audio</title>
+  <link rel="preload" as="style" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" onload="this.onload=null;this.rel='stylesheet'">
+  <link rel="preload" as="style" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" onload="this.onload=null;this.rel='stylesheet'">
+  <noscript>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" />
+  </noscript>
+  <style>
+    body { min-height: 100vh; display: flex; align-items: center; justify-content: center; background: radial-gradient(circle at top, rgba(13,110,253,.35), transparent 55%), radial-gradient(circle at bottom, rgba(25,135,84,.35), transparent 55%); padding: 1.5rem; }
+    .player-card { max-width: 540px; border-radius: 1.25rem; overflow: hidden; }
+    .eq-slider label { font-size: .75rem; text-transform: uppercase; letter-spacing: .08em; color: var(--bs-secondary); }
+    .eq-slider .form-range { height: 1.25rem; }
+    .muted { color: var(--bs-secondary); }
+  </style>
+</head>
+<body>
+  <div class="card shadow-lg player-card bg-body">
+    <div class="card-body p-4">
+      <div class="d-flex align-items-center mb-3">
+        <i class="bi bi-soundwave text-primary me-2 fs-4"></i>
+        <div>
+          <div class="fw-semibold" id="trackTitle">Memuat…</div>
+          <div class="small muted" id="trackMeta">Mini player siap diputar.</div>
+        </div>
+      </div>
+      <audio id="shareAudio" class="w-100 mb-3" controls preload="auto"></audio>
+      <div class="alert alert-info d-flex flex-wrap align-items-center gap-2" role="status" id="statusAlert" hidden></div>
+      <div class="border rounded p-3 mb-3 bg-body-secondary">
+        <div class="d-flex align-items-center justify-content-between mb-2">
+          <strong>Equalizer</strong>
+          <div class="btn-group btn-group-sm" role="group">
+            <button class="btn btn-outline-light" id="eqShareFlat">Flat</button>
+            <button class="btn btn-outline-light" id="eqShareWarm">Warm</button>
+            <button class="btn btn-outline-light" id="eqShareBright">Bright</button>
+          </div>
+        </div>
+        <div class="row g-2 eq-slider">
+          <div class="col-4">
+            <label class="form-label">Bass</label>
+            <input type="range" class="form-range" id="eqShareBass" min="-12" max="12" step="1" value="0">
+          </div>
+          <div class="col-4">
+            <label class="form-label">Mid</label>
+            <input type="range" class="form-range" id="eqShareMid" min="-12" max="12" step="1" value="0">
+          </div>
+          <div class="col-4">
+            <label class="form-label">Treble</label>
+            <input type="range" class="form-range" id="eqShareTreble" min="-12" max="12" step="1" value="0">
+          </div>
+        </div>
+        <div class="small muted mt-2" id="eqShareStatus">Flat</div>
+      </div>
+      <div class="d-flex flex-wrap gap-2">
+        <a class="btn btn-primary flex-grow-1" id="downloadBtn" href="#" download>
+          <i class="bi bi-download me-1"></i>Download
+        </a>
+        <button class="btn btn-outline-light" id="shareBtn" type="button"><i class="bi bi-share me-1"></i>Bagikan</button>
+        <button class="btn btn-outline-light" id="copyBtn" type="button"><i class="bi bi-clipboard"></i></button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+  (function(){
+    const params = new URLSearchParams(location.search);
+    const audioSrc = params.get('src');
+    const trackName = params.get('name') || params.get('title') || 'Audio hasil convert';
+    const fmt = params.get('fmt') || '';
+    const audioEl = document.getElementById('shareAudio');
+    const titleEl = document.getElementById('trackTitle');
+    const metaEl = document.getElementById('trackMeta');
+    const alertEl = document.getElementById('statusAlert');
+    const downloadBtn = document.getElementById('downloadBtn');
+    const shareBtn = document.getElementById('shareBtn');
+    const copyBtn = document.getElementById('copyBtn');
+    const eqInputs = {
+      bass: document.getElementById('eqShareBass'),
+      mid: document.getElementById('eqShareMid'),
+      treble: document.getElementById('eqShareTreble'),
+    };
+    const eqStatus = document.getElementById('eqShareStatus');
+    const eqPresetFlat = document.getElementById('eqShareFlat');
+    const eqPresetWarm = document.getElementById('eqShareWarm');
+    const eqPresetBright = document.getElementById('eqShareBright');
+    let audioCtx = null;
+    let sourceNode = null;
+    let filters = [];
+
+    const formatGain = (v) => `${Number(v) >= 0 ? '+' : ''}${Number(v)} dB`;
+    const updateEqStatus = () => {
+      if (!eqStatus) return;
+      eqStatus.textContent = `Bass ${formatGain(eqInputs.bass.value)} · Mid ${formatGain(eqInputs.mid.value)} · Treble ${formatGain(eqInputs.treble.value)}`;
+    };
+
+    const ensureContext = () => {
+      if (audioCtx) return audioCtx;
+      const Ctx = window.AudioContext || window.webkitAudioContext;
+      if (!Ctx) return null;
+      audioCtx = new Ctx();
+      return audioCtx;
+    };
+
+    const ensureFilters = () => {
+      const ctx = ensureContext();
+      if (!ctx || !audioEl) return false;
+      if (!sourceNode){
+        sourceNode = ctx.createMediaElementSource(audioEl);
+        const bass = ctx.createBiquadFilter();
+        bass.type = 'lowshelf';
+        bass.frequency.value = 200;
+        const mid = ctx.createBiquadFilter();
+        mid.type = 'peaking';
+        mid.frequency.value = 1000;
+        mid.Q.value = 1;
+        const treble = ctx.createBiquadFilter();
+        treble.type = 'highshelf';
+        treble.frequency.value = 4000;
+        filters = [bass, mid, treble];
+        sourceNode.connect(bass);
+        bass.connect(mid);
+        mid.connect(treble);
+        treble.connect(ctx.destination);
+      }
+      return true;
+    };
+
+    const applyEq = () => {
+      const ctx = ensureContext();
+      if (ctx && ctx.state === 'suspended') ctx.resume().catch(()=>{});
+      if (!ensureFilters()) return;
+      filters[0].gain.value = Number(eqInputs.bass.value || 0);
+      filters[1].gain.value = Number(eqInputs.mid.value || 0);
+      filters[2].gain.value = Number(eqInputs.treble.value || 0);
+      updateEqStatus();
+    };
+
+    Object.values(eqInputs).forEach((input) => input && input.addEventListener('input', applyEq));
+    if (eqPresetFlat) eqPresetFlat.addEventListener('click', () => {
+      eqInputs.bass.value = 0; eqInputs.mid.value = 0; eqInputs.treble.value = 0; applyEq();
+    });
+    if (eqPresetWarm) eqPresetWarm.addEventListener('click', () => {
+      eqInputs.bass.value = 3; eqInputs.mid.value = 1; eqInputs.treble.value = -2; applyEq();
+    });
+    if (eqPresetBright) eqPresetBright.addEventListener('click', () => {
+      eqInputs.bass.value = -1; eqInputs.mid.value = 0; eqInputs.treble.value = 4; applyEq();
+    });
+
+    const setAlert = (msg, variant = 'info') => {
+      if (!alertEl) return;
+      alertEl.hidden = !msg;
+      alertEl.className = `alert alert-${variant} d-flex align-items-center gap-2`;
+      alertEl.textContent = msg || '';
+    };
+
+    const shareLink = async () => {
+      if (!audioSrc) { setAlert('Tidak ada sumber audio untuk dibagikan', 'warning'); return; }
+      if (navigator.share){
+        try { await navigator.share({ title: trackName, url: location.href }); return; }
+        catch (err){ if (err && err.name === 'AbortError') return; }
+      }
+      try { await navigator.clipboard.writeText(location.href); setAlert('Link player tersalin ke clipboard', 'success'); }
+      catch { setAlert(location.href, 'info'); }
+    };
+
+    if (!audioSrc){
+      setAlert('Parameter src tidak ditemukan. Buka halaman ini dari hasil konversi.', 'warning');
+      if (titleEl) titleEl.textContent = 'Link tidak valid';
+      if (audioEl) audioEl.controls = false;
+      return;
+    }
+
+    const resolvedSrc = new URL(audioSrc, location.origin).href;
+    if (audioEl){
+      audioEl.src = resolvedSrc;
+      audioEl.addEventListener('play', () => { ensureFilters(); applyEq(); });
+    }
+    if (titleEl) titleEl.textContent = trackName;
+    if (metaEl) metaEl.textContent = fmt ? `Format ${fmt.toUpperCase()} · Streaming siap` : 'Streaming siap';
+    if (downloadBtn){
+      downloadBtn.href = resolvedSrc;
+      downloadBtn.download = trackName ? `${trackName}.${fmt || 'mp3'}` : '';
+    }
+    if (shareBtn) shareBtn.addEventListener('click', shareLink);
+    if (copyBtn) copyBtn.addEventListener('click', async () => {
+      try { await navigator.clipboard.writeText(resolvedSrc); setAlert('Link file audio tersalin', 'success'); }
+      catch { setAlert(resolvedSrc, 'info'); }
+    });
+
+    updateEqStatus();
+  })();
+  </script>
+</body>
+</html>

--- a/public-ui/share.html
+++ b/public-ui/share.html
@@ -68,6 +68,10 @@
         <button class="btn btn-outline-light" id="shareBtn" type="button"><i class="bi bi-share me-1"></i>Bagikan</button>
         <button class="btn btn-outline-light" id="copyBtn" type="button"><i class="bi bi-clipboard"></i></button>
       </div>
+      <div class="mt-4 text-center" id="shareQrWrap" hidden>
+        <canvas id="shareQr" width="156" height="156" class="border rounded bg-body"></canvas>
+        <div class="small muted mt-2"><i class="bi bi-qr-code"></i> Scan untuk membuka halaman ini di perangkat lain.</div>
+      </div>
     </div>
   </div>
 
@@ -86,6 +90,8 @@
     const downloadBtn = document.getElementById('downloadBtn');
     const shareBtn = document.getElementById('shareBtn');
     const copyBtn = document.getElementById('copyBtn');
+    const qrWrap = document.getElementById('shareQrWrap');
+    const qrCanvas = document.getElementById('shareQr');
     const eqInputs = {
       bass: document.getElementById('eqShareBass'),
       mid: document.getElementById('eqShareMid'),
@@ -98,6 +104,7 @@
     let audioCtx = null;
     let sourceNode = null;
     let filters = [];
+    let qrLibPromise = null;
 
     const formatGain = (v) => `${Number(v) >= 0 ? '+' : ''}${Number(v)} dB`;
     const updateEqStatus = () => {
@@ -175,10 +182,80 @@
       catch { setAlert(location.href, 'info'); }
     };
 
+    const ensureQrLib = () => {
+      if (window.QRCode && typeof window.QRCode.toCanvas === 'function') {
+        return Promise.resolve(window.QRCode);
+      }
+      if (qrLibPromise) return qrLibPromise;
+      qrLibPromise = new Promise((resolve, reject) => {
+        const onReady = () => {
+          if (window.QRCode && typeof window.QRCode.toCanvas === 'function') resolve(window.QRCode);
+          else reject(new Error('QR library belum siap'));
+        };
+        const onError = () => reject(new Error('Gagal memuat library QR'));
+        const existing = document.querySelector('script[src*="qrcode.min.js"]');
+        if (existing) {
+          existing.addEventListener('load', onReady, { once: true });
+          existing.addEventListener('error', onError, { once: true });
+        } else {
+          const script = document.createElement('script');
+          script.src = 'https://cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.min.js';
+          script.defer = true;
+          script.addEventListener('load', onReady, { once: true });
+          script.addEventListener('error', onError, { once: true });
+          document.head.appendChild(script);
+        }
+      }).catch((err) => {
+        qrLibPromise = null;
+        throw err;
+      });
+      return qrLibPromise;
+    };
+
+    const renderQr = (url) => {
+      if (!qrCanvas || !qrWrap) return;
+      const ctx = qrCanvas.getContext('2d');
+      if (!url) {
+        qrWrap.hidden = true;
+        if (ctx) ctx.clearRect(0, 0, qrCanvas.width, qrCanvas.height);
+        return;
+      }
+      qrWrap.hidden = false;
+      ensureQrLib().then((lib) => {
+        if (ctx) {
+          const styles = getComputedStyle(document.body);
+          const bg = (styles.getPropertyValue('--bs-body-bg') || '#121212').trim() || '#121212';
+          ctx.fillStyle = bg;
+          ctx.fillRect(0, 0, qrCanvas.width, qrCanvas.height);
+        }
+        const theme = document.documentElement.getAttribute('data-bs-theme') || 'dark';
+        const light = theme === 'dark' ? '#0d1117' : '#ffffff';
+        const dark = theme === 'dark' ? '#ffffff' : '#0d0d0d';
+        lib.toCanvas(qrCanvas, url, { width: qrCanvas.width || 156, margin: 1, color: { dark, light } }, (err) => {
+          if (err && ctx) {
+            ctx.fillStyle = '#dc3545';
+            ctx.font = '12px sans-serif';
+            ctx.textAlign = 'center';
+            ctx.textBaseline = 'middle';
+            ctx.fillText('QR gagal', qrCanvas.width / 2, qrCanvas.height / 2);
+          }
+        });
+      }).catch(() => {
+        if (!ctx) return;
+        ctx.fillStyle = '#dc3545';
+        ctx.font = '12px sans-serif';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText('QR gagal dimuat', qrCanvas.width / 2, qrCanvas.height / 2);
+        qrWrap.hidden = false;
+      });
+    };
+
     if (!audioSrc){
       setAlert('Parameter src tidak ditemukan. Buka halaman ini dari hasil konversi.', 'warning');
       if (titleEl) titleEl.textContent = 'Link tidak valid';
       if (audioEl) audioEl.controls = false;
+      renderQr(location.href);
       return;
     }
 
@@ -201,14 +278,15 @@
       metaParts.push('Streaming siap');
       metaEl.textContent = metaParts.join(' · ');
     }
+    renderQr(location.href);
     if (downloadBtn){
       downloadBtn.href = resolvedSrc;
       downloadBtn.download = trackName ? `${trackName}.${fmt || 'mp3'}` : '';
     }
     if (shareBtn) shareBtn.addEventListener('click', shareLink);
     if (copyBtn) copyBtn.addEventListener('click', async () => {
-      try { await navigator.clipboard.writeText(resolvedSrc); setAlert('Link file audio tersalin', 'success'); }
-      catch { setAlert(resolvedSrc, 'info'); }
+      try { await navigator.clipboard.writeText(location.href); setAlert('Link mini player tersalin', 'success'); }
+      catch { setAlert(location.href, 'info'); }
     });
 
     updateEqStatus();


### PR DESCRIPTION
## Summary
- extend the conversion pipeline with unified helpers that cover MP3, M4A, FLAC, WAV, and OGG plus new speed modes
- add a playlist ZIP API that repackages numbered tracks and expose QR-ready download links
- refresh the UI with a speed selector, mobile-friendly controls, built-in audio preview, QR codes, playlist ZIP controls, and URL drag-and-drop

## Testing
- npm start


------
https://chatgpt.com/codex/tasks/task_e_68c9847f8934833191b925ff7c151544