### PR TITLE
Add local jsQR fallback for profile QR file uploads

### DIFF
--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -16008,6 +16008,17 @@ function showMaintenanceOverlay(show, type = 'maintenance') {
 
   const supportsBarcodeDetector = () => 'BarcodeDetector' in window;
 
+  let jsQrDecodePromise = null;
+  const loadJsQrDecoder = async () => {
+    if (window.jsQR) return window.jsQR;
+    if (!jsQrDecodePromise) {
+      jsQrDecodePromise = import('https://cdn.jsdelivr.net/npm/jsqr@1.4.0/dist/jsQR.es6.min.js')
+        .then((mod) => mod?.default || mod?.jsQR || window.jsQR || null)
+        .catch(() => null);
+    }
+    return jsQrDecodePromise;
+  };
+
   const readFileAsDataUrl = (file) => new Promise((resolve, reject) => {
     const reader = new FileReader();
     reader.onload = () => resolve(reader.result);
@@ -16043,6 +16054,23 @@ function showMaintenanceOverlay(show, type = 'maintenance') {
     return canvas.toDataURL('image/png', 0.92);
   };
 
+  const decodeQrWithJsQr = async (file) => {
+    const jsQr = await loadJsQrDecoder();
+    if (typeof jsQr !== 'function') return '';
+    const bitmap = await createImageBitmap(file);
+    const canvas = document.createElement('canvas');
+    canvas.width = bitmap.width;
+    canvas.height = bitmap.height;
+    const ctx = canvas.getContext('2d', { willReadFrequently: true });
+    if (!ctx) return '';
+    ctx.drawImage(bitmap, 0, 0);
+    const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+    const decoded = jsQr(imageData.data, imageData.width, imageData.height, {
+      inversionAttempts: 'attemptBoth',
+    });
+    return decoded?.data || '';
+  };
+
   const scanQrFromFile = async (file) => {
     if (!file) return;
     try {
@@ -16055,6 +16083,12 @@ function showMaintenanceOverlay(show, type = 'maintenance') {
           await consumeQrLogin(raw);
           return;
         }
+      }
+      setProfileQrMessage('Mencoba membaca QR lokal...', 'text-secondary');
+      const localRaw = await decodeQrWithJsQr(file);
+      if (localRaw) {
+        await consumeQrLogin(localRaw);
+        return;
       }
       setProfileQrMessage('Membaca QR lewat server...', 'text-secondary');
       const dataUrl = await readFileAsDataUrl(file);


### PR DESCRIPTION
### Motivation
- Uploaded QR images sometimes fail to decode with `BarcodeDetector` and server-side decoding can be unreliable, causing "Gagal membaca QR dari file" errors for users. 
- Provide a robust client-side fallback to increase success rate for reading QR images without affecting existing flows.

### Description
- Added a lazy loader `loadJsQrDecoder()` that dynamically imports `jsQR` from CDN to avoid extra initial payload. 
- Implemented `decodeQrWithJsQr(file)` which creates an `ImageBitmap`, draws it to a canvas, extracts pixel data and decodes via `jsQR` with `inversionAttempts: 'attemptBoth'`. 
- Updated `scanQrFromFile(file)` to try in this order: `BarcodeDetector` → local `jsQR` → server `/api/qr-login/decode`, and added the user feedback message `Mencoba membaca QR lokal...`. 
- All changes are contained in `public-ui/index.html` and do not change any backend APIs or storage.

### Testing
- Started the server with `node index.js` to validate boot and confirm no runtime errors during startup (succeeded). 
- Attempted an automated browser validation with Playwright to capture UI behavior, but the headless Chromium crashed in this environment (SIGSEGV), so end-to-end browser verification could not be completed here (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a02ded3d44832f97963e6fdfd4a79a)