### PR TITLE
Add support ticket system, admin UIs, forum moderation and multiple UI/AI improvements

### DIFF
--- a/index.js
+++ b/index.js
@@ -631,7 +631,7 @@ const callGroqAPI = async (prompt, context = {}) => {
 
   const history = Array.isArray(context.history) ? context.history : [];
 
-  const systemPrompt = `Anda adalah **AI Audio Mentor & Coach** profesional di sistem **Dikalfe Project** (YouTube to MP3).
+  const systemPrompt = `Anda adalah **AI Audio Mentor & Coach + Customer Service Navigator** profesional di platform **YTConv** (YouTube to MP3).
 Tugas Anda adalah membimbing user, mendiagnosa masalah, dan menjelaskan konsep audio dengan adaptif.
 
 **1. Level Penjelasan (Adaptive Communication):**
@@ -657,6 +657,10 @@ Pahami fitur aktif saat ini:
 - **Nyambung**: Ingat konteks chat sebelumnya. Jangan lupa apa yang baru dibahas.
 - **Konsisten**: Jangan berubah pendapat dalam satu sesi kecuali ada data baru.
 - **Humanis**: Sapa user, gunakan emoji yang relevan, jangan kaku.
+
+- Gunakan bahasa yang sama dengan user. Jika user memakai bahasa campuran/daerah, tetap tanggapi dengan sopan dan mudah dipahami.
+- Pahami pertanyaan dalam berbagai bahasa (Indonesia, Inggris, Melayu, Jawa informal, dll) lalu jawab dalam bahasa user.
+- Jika user terlihat bingung, tampilkan alur jelas dalam format langkah 1-2-3.
 
 **Format Output (JSON Only jika Action diperlukan):**
 Jika user ingin melakukan aksi (convert, setting), kembalikan JSON:
@@ -3681,12 +3685,12 @@ const buildAssistantResponse = async (prompt, history = [], clientState = {}) =>
       instructions: `Kamu adalah Customer Service AI dari YTConv (situs konverter YouTube terbaik di Indonesia). 
 Nama kamu: YTConv CS Bot.
 Sifat kamu: Ramah, profesional, super helpful, dan sangat paham platform YTConv.
-Bahasa: Sesuaikan dengan bahasa yang user gunakan (Indonesia atau Inggris).
+Bahasa: Sesuaikan dengan bahasa user (multibahasa: Indonesia, Inggris, Melayu, campuran slang sopan, dll).
 Alur bantu:
 1. Sapa dan identifikasi masalah user.
 2. Tanyakan detail jika perlu.
 3. Berikan solusi langkah demi langkah yang jelas.
-4. Jika tidak bisa diselesaikan, sarankan buat tiket dengan mengembalikan action: 'open_ticket'.
+4. Jika tidak bisa diselesaikan, sarankan buat tiket dengan mengembalikan action: 'open_ticket' dan isi params.context ringkasan masalah.
 5. Selalu profesional, JANGAN sebut 'Dikalfe Project'. Selalu sebut platformnya sebagai 'YTConv'.
 
 Features di YTConv:
@@ -3712,7 +3716,7 @@ Jika user sangat butuh bantuan lanjut atau masalah teknis kompleks:
 - Respons dengan menyarankan buat tiket
 - Return JSON: {"reply": "...", "action": "open_ticket", "params": {"context": "[ringkasan masalah user]"}}
 
-Kontak darurat: forumwargaytmp3@gmail.com`,
+Kontak darurat: forumwargaytmp3@gmail.com (atau tombol Email Bantuan di footer, sebelah tombol Lapor WhatsApp).`,
       features: ["Convert", "Trim", "Metadata", "Queue", "History", "Settings"],
       timestamp: new Date().toISOString(),
       history: history,
@@ -6928,7 +6932,7 @@ app.get("/api/health", (req, res) => {
       id: process.env.MAINTENANCE_ID || null,
       title: process.env.MAINTENANCE_TITLE || null,
       description: process.env.MAINTENANCE_DESC || null,
-      detail: process.env.MAINTENANCE_DETAIL || null,
+      detail: process.env.MAINTENANCE_DETAIL || process.env.RAILWAY_GIT_COMMIT_MESSAGE || process.env.VERCEL_GIT_COMMIT_MESSAGE || null,
       steps: parseJsonEnv(process.env.MAINTENANCE_STEPS_JSON),
       whatsNew: parseJsonEnv(process.env.MAINTENANCE_WHATS_NEW_JSON),
       tip: process.env.MAINTENANCE_TIP || null,
@@ -7976,6 +7980,12 @@ const safeCompare = (left, right) => {
   }
 };
 
+const isAdminBearerValid = (req) => {
+  if (!ADMIN_ENABLED) return false;
+  const auth = req.get("Authorization") || "";
+  return auth === `Bearer ${BEARER}`;
+};
+
 app.post("/admin/login", (req, res) => {
   try {
     if (!ADMIN_ENABLED) {
@@ -8128,6 +8138,7 @@ app.get("/internal/worker/cookies", async (req, res) => {
 
 // ===== /api/contact: Ticket Submission Endpoint =====
 const userViolations = new Map(); // userId -> { count, banned, bannedAt }
+const supportTickets = new Map(); // ticketId -> ticket payload
 
 const INDONESIAN_BADWORDS = [
   'anjing','bangsat','brengsek','goblok','bodoh','tolol','idiot','bajingan',
@@ -8135,6 +8146,23 @@ const INDONESIAN_BADWORDS = [
   'cuk','jancok','jancuk','dancok','setan','laknat','nggak tau diri','mampus',
   'kurang ajar','ngentot','coli','bacot','ngaco','bgst','bgs','g0blok'
 ];
+
+
+const SUPPORT_CONTACT_EMAIL = process.env.SUPPORT_CONTACT_EMAIL || "forumwargaytmp3@gmail.com";
+
+const sendSupportEmail = async ({ subject, lines = [], html = null, to = SUPPORT_CONTACT_EMAIL }) => {
+  const transport = getMailTransport();
+  if (!transport) return { sent: false, reason: "mail_transport_unavailable" };
+  const from = process.env.NOTIFY_FROM_EMAIL || process.env.NOTIFY_EMAIL_FROM || "no-reply@youtubetomp3.app";
+  const text = Array.isArray(lines) ? lines.filter(Boolean).join("\n") : String(lines || "");
+  try {
+    await transport.sendMail({ to, from, subject: String(subject || "YTConv Notification"), text, html: html || undefined });
+    return { sent: true };
+  } catch (err) {
+    console.warn("[support-email] gagal mengirim email", err);
+    return { sent: false, reason: err?.message || String(err) };
+  }
+};
 
 app.post('/api/contact', async (req, res) => {
   try {
@@ -8154,27 +8182,339 @@ app.post('/api/contact', async (req, res) => {
       ip: req.ip
     };
 
+    const uploadedProofs = [];
+    if (Array.isArray(proofs) && proofs.length) {
+      const limited = proofs.slice(0, 4);
+      for (const proof of limited) {
+        const directUrl = typeof proof?.url === "string" ? proof.url.trim() : "";
+        if (/^https?:\/\//i.test(directUrl)) {
+          uploadedProofs.push({
+            name: String(proof?.name || "attachment"),
+            url: directUrl,
+            type: String(proof?.type || ""),
+            size: Number(proof?.size || 0) || 0,
+          });
+          continue;
+        }
+        const dataUrl = typeof proof?.dataUrl === "string" ? proof.dataUrl : "";
+        if (!dataUrl.startsWith("data:")) continue;
+        try {
+          const isVideo = /^data:video\//i.test(dataUrl);
+          const result = await cloudinary.uploader.upload(dataUrl, {
+            folder: "ytconv/support-tickets",
+            resource_type: isVideo ? "video" : "image",
+            public_id: `${tid}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
+            overwrite: false,
+          });
+          if (result?.secure_url) {
+            uploadedProofs.push({
+              name: String(proof?.name || result?.original_filename || "attachment"),
+              url: String(result.secure_url),
+              type: String(proof?.type || ""),
+              size: Number(proof?.size || 0) || 0,
+            });
+          }
+        } catch (uploadErr) {
+          console.warn("[/api/contact] gagal upload proof ke Cloudinary", uploadErr?.message || uploadErr);
+        }
+      }
+    }
+
     // Log the ticket for admin
     console.log('[YTConv CS Ticket]', JSON.stringify(ticket));
 
-    // Mock email sending: print to console (real implementation would use nodemailer or SendGrid)
     const emailBody = [
       `=== YTConv Support Ticket ===`,
       `Ticket ID : ${tid}`,
       `From      : ${name} <${email}>`,
       `Category  : ${category}`,
       `Message   : ${message}`,
-      `Proofs    : ${ticket.proofCount} attachment(s)`,
+      `Proofs    : ${uploadedProofs.length} attachment(s)`,
       `Time      : ${ticket.submittedAt}`,
-      `To        : forumwargaytmp3@gmail.com`
+      `To        : ${SUPPORT_CONTACT_EMAIL}`
     ].join('\n');
     console.log('[YTConv CS Email]\n' + emailBody);
 
-    res.json({ ok: true, ticketId: tid, message: 'Tiket diterima, tim akan membalas dalam 1x24 jam.' });
+    const firstFileLink = uploadedProofs[0]?.url || "";
+    const filesHtml = uploadedProofs.length
+      ? `<ul>${uploadedProofs.map((f) => `<li><a href="${String(f.url)}" target="_blank" rel="noopener noreferrer">${String(f.name || "Lihat File")}</a></li>`).join("")}</ul>`
+      : "<span>Tidak ada file</span>";
+    const htmlBody = `
+<p style="font-family: helvetica, arial, sans-serif;">Halo Admin,</p>
+<p style="font-family: helvetica, arial, sans-serif;">Ada pesan baru dari <b>Forum Warga</b>.</p>
+<hr>
+<p style="font-family: helvetica, arial, sans-serif;"><b>🆔 ID Tiket:</b> ${tid}</p>
+<p style="font-family: helvetica, arial, sans-serif;"><b>👤 Nama:</b> ${ticket.name}</p>
+<p style="font-family: helvetica, arial, sans-serif;"><b>📧 Email:</b> ${ticket.email}</p>
+<p style="font-family: helvetica, arial, sans-serif;"><b>📂 Kategori:</b> ${ticket.category}</p>
+<p style="font-family: helvetica, arial, sans-serif;"><b>💬 Pesan:</b><br>${ticket.message.replace(/\n/g, "<br>")}</p>
+<p style="font-family: helvetica, arial, sans-serif;"><b>📎 File:</b><br>${filesHtml}</p>
+<p style="font-family: helvetica, arial, sans-serif;"><b>🕒 Waktu:</b> ${ticket.submittedAt}</p>
+<hr>
+<p style="font-family: helvetica, arial, sans-serif; font-size: 12px; color: gray;">Pesan ini dikirim otomatis oleh sistem Forum Warga.<br>Mohon tidak membalas email ini.</p>
+`;
+
+    const subject = `[YTConv Ticket] ${tid} • ${ticket.category}`;
+    const emailResult = await sendSupportEmail({ subject, lines: [emailBody], html: htmlBody });
+    if (!emailResult.sent) {
+      console.warn(`[YTConv CS Ticket] email belum terkirim untuk ${tid}: ${emailResult.reason || 'unknown reason'}`);
+    }
+
+    const statusLink = `${DEFAULT_PUBLIC_BASE_URL || "https://ytconv.up.railway.app"}/ticket-status.html?ticket_id=${encodeURIComponent(tid)}`;
+    const autoReplyHtml = `
+<div style="font-family: Arial, sans-serif; background:#f4f6f9; padding:20px;">
+  <div style="max-width:600px; margin:auto; background:#ffffff; border-radius:12px; overflow:hidden; box-shadow:0 10px 25px rgba(0,0,0,0.08);">
+    <div style="background: linear-gradient(135deg, #4f46e5, #06b6d4); padding:20px; color:white;">
+      <h2 style="margin:0;">📩 Laporan Diterima</h2>
+      <p style="margin:5px 0 0; font-size:13px;">YtConv Support System</p>
+    </div>
+    <div style="padding:25px;">
+      <p style="font-size:16px;">Halo <b>${ticket.name}</b>,</p>
+      <p>Terima kasih telah mengirimkan laporan. Kami telah menerima pesan kamu dan saat ini sedang dalam proses penanganan.</p>
+      <div style="background:#f1f5f9; padding:15px; border-radius:8px; margin:20px 0;">
+        <p style="margin:5px 0;"><b>🆔 ID Tiket:</b> ${tid}</p>
+        <p style="margin:5px 0;"><b>📂 Kategori:</b> ${ticket.category}</p>
+        <p style="margin:5px 0;"><b>🕒 Waktu:</b> ${ticket.submittedAt}</p>
+      </div>
+      <div style="margin-top:15px;">
+        <p style="margin-bottom:5px;"><b>💬 Pesan kamu:</b></p>
+        <div style="background:#fafafa; padding:12px; border-radius:6px; font-size:14px;">${ticket.message.replace(/\n/g, "<br>")}</div>
+      </div>
+      <p style="margin-top:20px;">⏳ Estimasi respon: <b>2x24 jam</b><br>Mohon simpan ID tiket kamu untuk keperluan tracking.</p>
+      <p><a href="${statusLink}" target="_blank" rel="noopener noreferrer">Cek Status Tiket</a></p>
+      <div style="text-align:center; margin:25px 0;">
+        <span style="background:#4f46e5; color:white; padding:10px 18px; border-radius:6px; font-size:14px;">Tiket kamu sedang diproses 🚀</span>
+      </div>
+    </div>
+    <div style="background:#f9fafb; padding:15px; text-align:center; font-size:12px; color:#777;">
+      Email ini dikirim otomatis oleh sistem Forum Warga.<br>Mohon tidak membalas email ini.
+    </div>
+  </div>
+</div>`;
+    const autoReplyLines = [
+      `Halo ${ticket.name},`,
+      `Tiket ${tid} sudah diterima.`,
+      `Kategori: ${ticket.category}`,
+      `Waktu: ${ticket.submittedAt}`,
+      `Cek status: ${statusLink}`,
+    ];
+    const autoReplyResult = await sendSupportEmail({
+      to: ticket.email,
+      subject: `[TIKET ${tid}] Laporan kamu sudah diterima`,
+      lines: autoReplyLines,
+      html: autoReplyHtml,
+    });
+
+    supportTickets.set(tid, {
+      ...ticket,
+      proofs: uploadedProofs,
+      status: "received",
+      statusLabel: "Diterima",
+      statusUpdatedAt: ticket.submittedAt,
+      statusHistory: [{ status: "received", label: "Diterima", at: ticket.submittedAt, note: "Tiket dibuat oleh user" }],
+      adminReply: "",
+      statusLink,
+      autoReplyEmailStatus: autoReplyResult.sent ? "sent" : "queued",
+    });
+
+    res.json({
+      ok: true,
+      ticketId: tid,
+      message: 'Tiket diterima, tim akan membalas dalam 1x24 jam.',
+      emailStatus: emailResult.sent ? 'sent' : 'queued',
+      autoReplyEmailStatus: autoReplyResult.sent ? 'sent' : 'queued',
+      fileLink: firstFileLink || null,
+      fileLinks: uploadedProofs.map((f) => f.url),
+      statusLink,
+    });
   } catch (e) {
     console.error('[/api/contact error]', e);
     res.status(500).json({ ok: false, error: e.message });
   }
+});
+
+
+
+app.post('/api/forum/moderation-report', async (req, res) => {
+  try {
+    const body = req.body || {};
+    const reportId = 'MOD-' + Date.now().toString(36).toUpperCase().slice(-8);
+    const payload = {
+      reportId,
+      userId: String(body.userId || '').slice(0, 100),
+      name: String(body.name || 'Warga').slice(0, 80),
+      email: String(body.email || '').slice(0, 200),
+      text: String(body.text || '').slice(0, 2000),
+      violationCount: Number(body.violationCount || 0),
+      room: String(body.room || 'umum').slice(0, 50),
+      submittedAt: new Date().toISOString(),
+      ip: req.ip,
+    };
+
+    console.warn('[Forum AutoMod Report]', JSON.stringify(payload));
+
+    const lines = [
+      '=== Forum Auto Moderation Report ===',
+      `Report ID : ${payload.reportId}`,
+      `User      : ${payload.name} (${payload.userId || '-'})`,
+      `Email     : ${payload.email || '-'}`,
+      `Room      : ${payload.room}`,
+      `Count     : ${payload.violationCount}/5`,
+      `Message   : ${payload.text}`,
+      `Time      : ${payload.submittedAt}`,
+    ];
+
+    const emailResult = await sendSupportEmail({
+      subject: `[Forum AutoMod] ${payload.reportId} • ${payload.violationCount}/5`,
+      lines,
+    });
+
+    return res.json({ ok: true, reportId, emailStatus: emailResult.sent ? 'sent' : 'queued' });
+  } catch (e) {
+    console.error('[/api/forum/moderation-report error]', e);
+    return res.status(500).json({ ok: false, error: e.message });
+  }
+});
+
+app.get("/api/ticket/:ticketId", (req, res) => {
+  const ticketId = String(req.params.ticketId || "").trim().toUpperCase();
+  if (!ticketId) return res.status(400).json({ ok: false, error: "ticket_id_invalid" });
+  const ticket = supportTickets.get(ticketId);
+  if (!ticket) return res.status(404).json({ ok: false, error: "ticket_not_found" });
+  return res.json({
+    ok: true,
+    ticket: {
+      ticketId: ticket.ticketId,
+      name: ticket.name,
+      email: ticket.email,
+      category: ticket.category,
+      message: ticket.message,
+      status: ticket.status,
+      statusLabel: ticket.statusLabel,
+      statusUpdatedAt: ticket.statusUpdatedAt,
+      statusHistory: ticket.statusHistory || [],
+      adminReply: ticket.adminReply || "",
+      submittedAt: ticket.submittedAt,
+      proofs: (ticket.proofs || []).map((p) => ({ name: p.name, url: p.url, type: p.type, size: p.size })),
+    },
+  });
+});
+
+app.get("/api/admin/tickets", (req, res) => {
+  if (!isAdminBearerValid(req)) return res.status(401).json({ ok: false, error: "unauthorized" });
+  const items = Array.from(supportTickets.values())
+    .sort((a, b) => String(b.submittedAt || "").localeCompare(String(a.submittedAt || "")))
+    .map((ticket) => ({
+      ticketId: ticket.ticketId,
+      name: ticket.name,
+      email: ticket.email,
+      category: ticket.category,
+      message: ticket.message,
+      status: ticket.status,
+      statusLabel: ticket.statusLabel,
+      statusUpdatedAt: ticket.statusUpdatedAt,
+      submittedAt: ticket.submittedAt,
+      proofs: ticket.proofs || [],
+      adminReply: ticket.adminReply || "",
+    }));
+  return res.json({ ok: true, tickets: items });
+});
+
+app.get("/api/admin/stats", (req, res) => {
+  if (!isAdminBearerValid(req)) return res.status(401).json({ ok: false, error: "unauthorized" });
+  const tickets = Array.from(supportTickets.values());
+  const byStatus = tickets.reduce((acc, t) => {
+    const key = String(t?.status || "received");
+    acc[key] = (acc[key] || 0) + 1;
+    return acc;
+  }, {});
+  const memory = process.memoryUsage?.() || {};
+  return res.json({
+    ok: true,
+    timestamp: Date.now(),
+    uptimeSeconds: Math.floor(process.uptime()),
+    activeSocketClients: Number(io?.engine?.clientsCount || 0),
+    forumRooms: roomUsers.size,
+    tickets: {
+      total: tickets.length,
+      byStatus,
+      newest: tickets
+        .slice()
+        .sort((a, b) => String(b.submittedAt || "").localeCompare(String(a.submittedAt || "")))
+        .slice(0, 5)
+        .map((t) => ({
+          ticketId: t.ticketId,
+          status: t.status,
+          statusLabel: t.statusLabel,
+          submittedAt: t.submittedAt,
+          category: t.category,
+          email: t.email,
+        })),
+    },
+    runtime: {
+      rss: Number(memory.rss || 0),
+      heapUsed: Number(memory.heapUsed || 0),
+      heapTotal: Number(memory.heapTotal || 0),
+      external: Number(memory.external || 0),
+    },
+  });
+});
+
+app.patch("/api/admin/tickets/:ticketId", express.json({ limit: "512kb" }), async (req, res) => {
+  if (!isAdminBearerValid(req)) return res.status(401).json({ ok: false, error: "unauthorized" });
+  const ticketId = String(req.params.ticketId || "").trim().toUpperCase();
+  const ticket = supportTickets.get(ticketId);
+  if (!ticket) return res.status(404).json({ ok: false, error: "ticket_not_found" });
+  const status = String(req.body?.status || ticket.status || "received").trim().toLowerCase();
+  const statusLabel = String(req.body?.statusLabel || "").trim() || ({
+    received: "Diterima",
+    reviewing: "Diproses",
+    waiting_user: "Menunggu User",
+    resolved: "Selesai",
+    rejected: "Ditolak",
+  }[status] || status);
+  const adminReply = String(req.body?.adminReply || "").slice(0, 4000);
+  const nowIso = new Date().toISOString();
+  ticket.status = status;
+  ticket.statusLabel = statusLabel;
+  ticket.statusUpdatedAt = nowIso;
+  if (adminReply) ticket.adminReply = adminReply;
+  if (!Array.isArray(ticket.statusHistory)) ticket.statusHistory = [];
+  ticket.statusHistory.push({ status, label: statusLabel, at: nowIso, note: adminReply || "Update status admin" });
+  supportTickets.set(ticketId, ticket);
+
+  const statusLink = ticket.statusLink || `${DEFAULT_PUBLIC_BASE_URL || "https://ytconv.up.railway.app"}/ticket-status.html?ticket_id=${encodeURIComponent(ticketId)}`;
+  const replyHtml = `
+  <div style="font-family:Arial,sans-serif;padding:18px;background:#f8fafc;">
+    <div style="max-width:640px;margin:auto;background:#fff;border:1px solid #e5e7eb;border-radius:10px;padding:18px;">
+      <h3 style="margin-top:0;">Update Status Tiket ${ticketId}</h3>
+      <p>Status terbaru: <b>${statusLabel}</b></p>
+      ${adminReply ? `<p>Pesan admin:</p><div style="background:#f3f4f6;padding:10px;border-radius:6px;">${adminReply.replace(/\n/g, "<br>")}</div>` : ""}
+      <p><a href="${statusLink}" target="_blank" rel="noopener noreferrer">Cek Status Tiket</a></p>
+    </div>
+  </div>`;
+  await sendSupportEmail({
+    to: ticket.email,
+    subject: `[TIKET ${ticketId}] Update status: ${statusLabel}`,
+    lines: [`Tiket ${ticketId} status terbaru: ${statusLabel}`, `Cek status: ${statusLink}`],
+    html: replyHtml,
+  });
+
+  return res.json({ ok: true, ticket });
+});
+
+app.get("/ticket/:ticketId", (req, res) => {
+  const ticketId = String(req.params.ticketId || "").trim().toUpperCase();
+  if (!ticketId) return res.sendFile(join(__dirname, "public-ui", "ticket-status.html"));
+  return res.redirect(302, `/ticket-status.html?ticket_id=${encodeURIComponent(ticketId)}`);
+});
+
+app.get("/admin/tickets", (req, res) => {
+  res.sendFile(join(__dirname, "public-ui", "admin-tickets.html"));
+});
+
+app.get("/admin/dashboard", (req, res) => {
+  res.sendFile(join(__dirname, "public-ui", "admin-dashboard.html"));
 });
 
 const PORT = process.env.PORT || 3000;
@@ -8223,7 +8563,7 @@ io.on("connection", (socket) => {
     const rec = userViolations.get(userId) || { count: 0, banned: false };
     if (rec.banned) {
       socket.emit("forum:banned", {
-        message: "Kamu telah diblokir dari forum karena 5 pelanggaran bahasa. Silakan buat tiket appeal melalui YTConv CS Bot.",
+        message: "Kamu telah diblokir dari forum karena 5 pelanggaran bahasa. Silakan ajukan appeal via AI Navigator / tiket bantuan.",
         appealUrl: "#"
       });
       return;
@@ -8270,10 +8610,21 @@ io.on("connection", (socket) => {
     const rec = userViolations.get(from.userId);
     if (rec?.banned) {
       const appealId = 'APL-' + Date.now().toString(36).toUpperCase().slice(-8);
-      console.warn(`[Forum Appeal] userId=${from.userId} name=${from.name} appealId=${appealId} submittedAt=${new Date().toISOString()}`);
+      const submittedAt = new Date().toISOString();
+      console.warn(`[Forum Appeal] userId=${from.userId} name=${from.name} appealId=${appealId} submittedAt=${submittedAt}`);
+      const appealLines = [
+        '=== Forum Appeal Request ===',
+        `Appeal ID : ${appealId}`,
+        `User ID   : ${from.userId}`,
+        `Name      : ${from.name}`,
+        `Room      : ${from.room || 'umum'}`,
+        `Time      : ${submittedAt}`,
+        'SLA       : 2x24 jam',
+      ];
+      await sendSupportEmail({ subject: `[Forum Appeal] ${appealId}`, lines: appealLines });
       socket.emit("forum:appealSubmitted", {
         appealId,
-        message: `✅ Appeal kamu (${appealId}) telah diterima! Tim akan mereview dalam 2x24 jam. Email konfirmasi dari forumwargaytmp3@gmail.com akan dikirim segera.`
+        message: `✅ Appeal kamu (${appealId}) telah diterima! Tim akan mereview dalam 2x24 jam. Notifikasi juga dikirim ke ${SUPPORT_CONTACT_EMAIL}.`
       });
     }
   });

--- a/public-ui/admin-cookies.html
+++ b/public-ui/admin-cookies.html
@@ -3,208 +3,122 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Admin - Upload cookies.txt</title>
+  <title>Admin Cookies • YTConv</title>
+  <script src="https://cdn.tailwindcss.com"></script>
   <style>
-    :root { --accent:#fd7e14; --bg:#0b1220; --card:rgba(17,24,39,0.92); --card2:rgba(15,23,42,0.78); --text:#e5e7eb; --muted:rgba(229,231,235,0.72); --border:rgba(255,255,255,0.10); --shadow:0 22px 70px rgba(0,0,0,0.38); }
-    @media (prefers-color-scheme: light) { :root { --bg:#f6f7fb; --card:rgba(255,255,255,0.98); --card2:rgba(255,255,255,0.92); --text:#111827; --muted:rgba(17,24,39,0.62); --border:rgba(17,24,39,0.10); --shadow:0 20px 60px rgba(0,0,0,0.10); } }
-    * { box-sizing: border-box; }
-    body { margin:0; font-family:system-ui,-apple-system,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif; background: radial-gradient(circle at 20% 0%, rgba(253,126,20,0.18), transparent 55%), radial-gradient(circle at 80% 0%, rgba(13,110,253,0.14), transparent 45%), var(--bg); color:var(--text); }
-    .wrap { max-width: 860px; margin: 0 auto; padding: 14px 14px 28px; }
-    .top { position: sticky; top: 0; z-index: 5; padding: 10px 0 12px; backdrop-filter: blur(10px); }
-    .top-inner { display:flex; gap:10px; flex-wrap:wrap; align-items:center; justify-content:space-between; }
-    .brand { font-weight: 950; letter-spacing: 0.02em; display:flex; align-items:center; gap:10px; }
-    .dot { width:10px; height:10px; border-radius:999px; background:#94a3b8; box-shadow:0 0 0 3px rgba(255,255,255,0.12); }
-    .dot.ok{background:#22c55e;} .dot.warn{background:#f59e0b;} .dot.bad{background:#ef4444;}
-    .actions { display:flex; gap:10px; flex-wrap:wrap; }
-    @media (max-width: 540px) { .actions { flex-wrap: nowrap; overflow-x: auto; -webkit-overflow-scrolling: touch; scrollbar-width: none; } .actions::-webkit-scrollbar{display:none;} .actions>*{flex:0 0 auto;} }
-    .card { border:1px solid var(--border); background:var(--card); border-radius:18px; padding:14px; box-shadow: var(--shadow); transform: translateY(0); transition: transform 220ms ease, box-shadow 220ms ease; }
-    @media (hover:hover) and (pointer:fine) { .card:hover { transform: translateY(-2px); box-shadow: 0 28px 90px rgba(0,0,0,0.44); } }
-    .section { background: var(--card2); border:1px solid var(--border); border-radius:16px; padding:12px; margin-top: 12px; }
-    .title { font-weight: 950; letter-spacing: 0.02em; }
-    .muted { color: var(--muted); font-size: 0.92rem; }
-    label { display:block; font-size:0.85rem; font-weight:900; margin: 12px 0 6px; color: var(--muted); }
-    input[type="text"], input[type="password"] { width:100%; padding: 12px 12px; border-radius: 14px; border: 1px solid var(--border); background: rgba(255,255,255,0.06); color: var(--text); outline: none; }
-    input[type="file"] { width:100%; }
-    .row { display:flex; gap: 10px; flex-wrap: wrap; margin-top: 12px; }
-    button, a.btn { border:1px solid var(--border); background: rgba(255,255,255,0.06); color: var(--text); padding: 11px 12px; border-radius: 14px; font-weight: 950; cursor:pointer; text-decoration:none; display:inline-flex; align-items:center; justify-content:center; gap:8px; transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease, border-color 160ms ease; }
-    button.primary { background: var(--accent); border-color: transparent; color:#111827; }
-    button:hover, a.btn:hover { transform: translateY(-1px); box-shadow: 0 10px 26px rgba(0,0,0,0.18); }
-    button:active, a.btn:active { transform: translateY(0px) scale(0.98); }
-    button:focus-visible, a.btn:focus-visible { outline: 2px solid color-mix(in srgb, var(--accent) 70%, transparent); outline-offset: 2px; }
-    button:disabled { opacity: 0.6; cursor: not-allowed; }
-    .toast { margin-top: 10px; padding: 10px 12px; border-radius: 14px; border: 1px solid var(--border); background: rgba(255,255,255,0.06); display:none; }
-    .toast.show { display:block; animation: toast-in 220ms ease-out; }
-    @keyframes toast-in { from { opacity:0; transform: translateY(6px); } to { opacity:1; transform: translateY(0); } }
-    .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
-    .hidden { display:none !important; }
-    @media (prefers-reduced-motion: reduce) { button, a.btn, .card { transition:none !important; } .toast.show { animation:none !important; } }
+    @keyframes fadeIn { from {opacity:0; transform:translateY(8px);} to {opacity:1; transform:none;} }
+    .fade-in { animation: fadeIn .35s ease both; }
   </style>
 </head>
-<body>
-  <div class="wrap">
-    <div class="top">
-      <div class="top-inner">
-        <div class="brand"><span class="dot" id="pageDot"></span> Admin Cookies</div>
-        <div class="actions">
-          <a class="btn" href="./" rel="noopener">Halaman Utama</a>
-          <a class="btn" href="./status.html" rel="noopener">Status Page</a>
-          <button id="logoutBtn" class="hidden">Logout</button>
+<body class="min-h-screen bg-slate-950 text-slate-100">
+  <main class="max-w-3xl mx-auto p-4 md:p-6 space-y-4">
+    <header class="rounded-2xl border border-slate-800 bg-slate-900 p-5 flex flex-wrap items-center justify-between gap-3 fade-in">
+      <div>
+        <h1 class="text-xl md:text-2xl font-extrabold">🍪 Admin Cookies Manager</h1>
+        <p class="text-slate-400 text-sm">Upload dan monitor cookies.txt dengan UI yang lebih rapi.</p>
+      </div>
+      <div class="flex gap-2 flex-wrap">
+        <a href="/admin/dashboard" class="px-3 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-sm">Dashboard</a>
+        <a href="/admin/tickets" class="px-3 py-2 rounded-lg bg-slate-800 hover:bg-slate-700 text-sm">Admin Tickets</a>
+      </div>
+    </header>
+
+    <section id="loginView" class="rounded-2xl border border-slate-800 bg-slate-900 p-5 space-y-3 fade-in">
+      <div class="font-bold">Login Admin</div>
+      <div class="grid sm:grid-cols-2 gap-2">
+        <input id="username" class="px-3 py-2 rounded-lg bg-slate-950 border border-slate-700" placeholder="Username" autocomplete="username">
+        <input id="password" type="password" class="px-3 py-2 rounded-lg bg-slate-950 border border-slate-700" placeholder="Password" autocomplete="current-password">
+      </div>
+      <div class="flex gap-2">
+        <button id="loginBtn" class="px-4 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-500 font-semibold">Login</button>
+      </div>
+      <div id="loginToast" class="text-sm"></div>
+    </section>
+
+    <section id="uploadView" class="hidden rounded-2xl border border-slate-800 bg-slate-900 p-5 space-y-3 fade-in">
+      <div class="flex items-center justify-between gap-2">
+        <div>
+          <div class="font-bold">Upload cookies.txt</div>
+          <div class="text-sm text-slate-400">Status realtime akan refresh otomatis.</div>
         </div>
-      </div>
-    </div>
-
-    <div class="card" id="loginView">
-      <div class="title">Login dulu</div>
-      <div class="muted">Setelah login, tinggal pilih file cookies.txt dan upload.</div>
-      <label>Username</label>
-      <input id="username" type="text" value="ytmp3yulid" autocomplete="username" />
-      <label>Password</label>
-      <input id="password" type="password" autocomplete="current-password" />
-      <div class="row">
-        <button class="primary" id="loginBtn">Login</button>
-      </div>
-      <div class="toast" id="loginToast"></div>
-    </div>
-
-    <div class="card hidden" id="uploadView">
-      <div class="title">Upload cookies.txt</div>
-      <div class="muted">Pastikan format cookies Netscape. Setelah upload, sistem langsung pakai cookies terbaru.</div>
-
-      <div class="section">
-        <div class="muted">Status cookies:</div>
-        <div class="toast show" id="statusBox"></div>
+        <button id="logoutBtn" class="px-3 py-2 rounded-lg bg-slate-700 hover:bg-slate-600 text-sm">Logout</button>
       </div>
 
-      <label>Pilih file cookies.txt</label>
-      <input id="file" type="file" accept=".txt,text/plain" />
-
-      <div class="row">
-        <button class="primary" id="uploadBtn">Upload</button>
-        <button id="refreshStatusBtn">Refresh status</button>
+      <div class="rounded-xl border border-slate-700 bg-slate-950 p-3 text-sm">
+        <div class="text-slate-400">Status Cookies</div>
+        <div id="statusBox" class="font-medium mt-1">Memuat...</div>
       </div>
-      <div class="toast" id="uploadToast"></div>
-    </div>
-  </div>
 
-  <script>
-    const $ = (id) => document.getElementById(id);
-    const toast = (id, msg, ok = true) => {
-      const el = $(id);
-      el.className = 'toast show';
-      el.innerHTML = `<span class="mono">${ok ? 'OK' : 'ERR'}</span> — ${String(msg)}`;
-    };
-    const tokenKey = 'admin_bearer_token';
-    const legacyKey = 'ytmp3_admin_bearer';
-    const getToken = () => (sessionStorage.getItem(tokenKey) || localStorage.getItem(legacyKey) || '').trim();
-    const setToken = (t) => {
-      const v = String(t || '').trim();
-      sessionStorage.setItem(tokenKey, v);
-      localStorage.setItem(legacyKey, v);
-    };
-    const clearToken = () => {
-      sessionStorage.removeItem(tokenKey);
-      localStorage.removeItem(legacyKey);
-    };
+      <input id="file" type="file" accept=".txt,text/plain" class="block w-full text-sm file:mr-4 file:py-2 file:px-3 file:rounded-lg file:border-0 file:bg-slate-700 file:text-slate-100 hover:file:bg-slate-600" />
+      <div class="flex gap-2 flex-wrap">
+        <button id="uploadBtn" class="px-4 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-500 font-semibold">Upload</button>
+        <button id="refreshStatusBtn" class="px-4 py-2 rounded-lg bg-slate-700 hover:bg-slate-600">Refresh</button>
+      </div>
+      <div id="uploadToast" class="text-sm"></div>
+    </section>
+  </main>
 
-    const setLoggedInUi = (loggedIn) => {
-      const loginView = $('loginView');
-      const uploadView = $('uploadView');
-      const logoutBtn = $('logoutBtn');
-      if (loginView) loginView.classList.toggle('hidden', loggedIn);
-      if (uploadView) uploadView.classList.toggle('hidden', !loggedIn);
-      if (logoutBtn) logoutBtn.classList.toggle('hidden', !loggedIn);
-      const dot = $('pageDot');
-      if (dot) dot.className = 'dot ' + (loggedIn ? 'ok' : 'warn');
-    };
+<script>
+const $ = (id) => document.getElementById(id);
+const tokenKey = 'admin_bearer_token';
+const legacyKey = 'ytmp3_admin_bearer';
+const fmt = new Intl.DateTimeFormat(undefined, { dateStyle:'medium', timeStyle:'short' });
+const getToken = () => (sessionStorage.getItem(tokenKey) || localStorage.getItem(legacyKey) || '').trim();
+const setToken = (t) => { sessionStorage.setItem(tokenKey, t || ''); localStorage.setItem(legacyKey, t || ''); };
+const clearToken = () => { sessionStorage.removeItem(tokenKey); localStorage.removeItem(legacyKey); };
+const toast = (id, msg, ok = true) => { const el = $(id); el.className = `text-sm ${ok ? 'text-emerald-300' : 'text-rose-300'}`; el.textContent = msg; };
+const setLoggedInUi = (inState) => { $('loginView').classList.toggle('hidden', inState); $('uploadView').classList.toggle('hidden', !inState); };
 
-    const refreshStatus = async () => {
-      const res = await fetch('/admin/cookies-status?t=' + Date.now());
-      const data = await res.json().catch(() => ({}));
-      const isDisabled = Boolean(data && data.disabled);
-      const dot = $('pageDot');
-      const loginBtn = $('loginBtn');
-      if (isDisabled) {
-        if (dot) dot.className = 'dot bad';
-        if (loginBtn) loginBtn.disabled = true;
-        toast('loginToast', 'Admin belum diaktifkan di server. Set ENV: ADMIN_BEARER, ADMIN_USER_HASH, ADMIN_PASS_HASH (Railway Variables).', false);
-        const box = $('statusBox');
-        if (box) box.innerHTML = 'Admin cookies dinonaktifkan. Set ENV: ADMIN_BEARER, ADMIN_USER_HASH, ADMIN_PASS_HASH.';
-        return data;
-      }
-      if (loginBtn) loginBtn.disabled = false;
-      if (dot && !getToken()) dot.className = 'dot warn';
-      const box = $('statusBox');
-      if (!box) return data;
-      if (!data.exists) {
-        box.innerHTML = 'cookies.txt belum ada.';
-        return data;
-      }
-      box.innerHTML = `Ada cookies.txt — <span class="mono">${data.bytes}</span> bytes`;
-      return data;
-    };
+async function refreshStatus(){
+  const res = await fetch('/admin/cookies-status?t=' + Date.now());
+  const data = await res.json().catch(() => ({}));
+  if (data.disabled) {
+    $('statusBox').innerHTML = '<span class="text-rose-300">Admin disabled. Set ADMIN_BEARER / ADMIN_USER_HASH / ADMIN_PASS_HASH di Railway.</span>';
+    return;
+  }
+  if (!data.exists) {
+    $('statusBox').innerHTML = `<span class="text-amber-300">Belum ada cookies.txt</span> • ${fmt.format(new Date())}`;
+    return;
+  }
+  $('statusBox').innerHTML = `<span class="text-emerald-300">Tersedia</span> • ${Number(data.bytes || 0).toLocaleString()} bytes • ${fmt.format(new Date())}`;
+}
 
-    $('refreshStatusBtn').addEventListener('click', () => refreshStatus().catch((e) => toast('uploadToast', e.message, false)));
-
-    $('loginBtn').addEventListener('click', async () => {
-      try {
-        $('loginBtn').disabled = true;
-        const username = $('username').value || '';
-        const password = $('password').value || '';
-        const res = await fetch('/admin/login', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ username, password })
-        });
-        const data = await res.json().catch(() => ({}));
-        if (!res.ok) throw new Error(data.error || ('HTTP ' + res.status));
-        setToken(data.token || '');
-        try { $('password').value = ''; } catch {}
-        toast('loginToast', 'Login berhasil. Silakan upload cookies.txt.');
-        setLoggedInUi(true);
-        refreshStatus().catch(() => {});
-      } catch (e) {
-        toast('loginToast', e.message || 'Login gagal.', false);
-      } finally {
-        try { $('loginBtn').disabled = false; } catch {}
-      }
+$('loginBtn').addEventListener('click', async () => {
+  try {
+    const res = await fetch('/admin/login', {
+      method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({ username:$('username').value || '', password:$('password').value || '' })
     });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok || !data?.token) throw new Error(data.error || 'Login gagal');
+    setToken(data.token);
+    $('password').value = '';
+    toast('loginToast', 'Login berhasil.');
+    setLoggedInUi(true);
+    refreshStatus();
+  } catch (e) { toast('loginToast', e.message || 'Login gagal', false); }
+});
 
-    $('logoutBtn').addEventListener('click', () => {
-      clearToken();
-      setLoggedInUi(false);
-      toast('loginToast', 'Logout.');
-    });
+$('logoutBtn').addEventListener('click', () => { clearToken(); setLoggedInUi(false); toast('loginToast', 'Logout berhasil.'); });
+$('refreshStatusBtn').addEventListener('click', () => refreshStatus().catch((e) => toast('uploadToast', e.message, false)));
 
-    $('uploadBtn').addEventListener('click', async () => {
-      try {
-        const token = getToken();
-        if (!token) throw new Error('Belum login (token kosong).');
-        const f = $('file').files && $('file').files[0];
-        if (!f) throw new Error('Pilih file cookies.txt dulu.');
-        const body = await f.text();
-        if (!body.trim()) throw new Error('Isi cookies.txt kosong.');
-        $('uploadBtn').disabled = true;
-        const res = await fetch('/admin/upload-cookies', {
-          method: 'POST',
-          headers: { 'Content-Type': 'text/plain; charset=utf-8', 'Authorization': 'Bearer ' + token },
-          body
-        });
-        const data = await res.json().catch(() => ({}));
-        if (!res.ok) throw new Error(data.error || ('HTTP ' + res.status));
-        toast('uploadToast', `Upload sukses (${data.bytes} bytes).`);
-        refreshStatus().catch(() => {});
-      } catch (e) {
-        toast('uploadToast', e.message || 'Upload gagal.', false);
-      } finally {
-        try { $('uploadBtn').disabled = false; } catch {}
-      }
-    });
-    const boot = () => {
-      const token = getToken();
-      setLoggedInUi(Boolean(token));
-      refreshStatus().catch(() => {});
-    };
-    boot();
-  </script>
+$('uploadBtn').addEventListener('click', async () => {
+  try {
+    const token = getToken();
+    if (!token) throw new Error('Belum login');
+    const file = $('file').files?.[0];
+    if (!file) throw new Error('Pilih file cookies.txt dulu');
+    const body = await file.text();
+    const res = await fetch('/admin/upload-cookies', { method:'POST', headers:{ 'Content-Type':'text/plain; charset=utf-8', Authorization:'Bearer ' + token }, body });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+    toast('uploadToast', `Upload sukses (${Number(data.bytes || 0).toLocaleString()} bytes).`);
+    refreshStatus();
+  } catch (e) { toast('uploadToast', e.message || 'Upload gagal', false); }
+});
+
+setLoggedInUi(Boolean(getToken()));
+refreshStatus().catch(() => {});
+setInterval(() => { if (getToken()) refreshStatus().catch(() => {}); }, 10000);
+</script>
 </body>
 </html>

--- a/public-ui/admin-dashboard.html
+++ b/public-ui/admin-dashboard.html
@@ -1,0 +1,120 @@
+<!doctype html>
+<html lang="id">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Admin Statistik • YTConv</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    @keyframes fadeIn { from {opacity:0; transform:translateY(8px);} to {opacity:1; transform:none;} }
+    .fade-in { animation: fadeIn .35s ease both; }
+  </style>
+</head>
+<body class="min-h-screen bg-slate-950 text-slate-100">
+  <main class="max-w-6xl mx-auto p-4 md:p-6 space-y-4">
+    <header class="rounded-2xl border border-slate-800 bg-slate-900 p-5 flex flex-wrap items-center justify-between gap-3 fade-in">
+      <div>
+        <h1 class="text-2xl font-extrabold">📊 Dashboard Statistik Realtime</h1>
+        <p class="text-slate-400 text-sm">Live metrics untuk penggunaan user dan ticket support.</p>
+      </div>
+      <div class="flex gap-2">
+        <a href="/admin/tickets" class="px-3 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-sm">Admin Tickets</a>
+        <button id="refreshBtn" class="px-3 py-2 rounded-lg bg-slate-700 hover:bg-slate-600 text-sm">Refresh</button>
+      </div>
+    </header>
+
+    <section class="rounded-2xl border border-slate-800 bg-slate-900 p-4 fade-in">
+      <form id="loginForm" class="grid sm:grid-cols-4 gap-2">
+        <input id="username" class="px-3 py-2 rounded-lg bg-slate-950 border border-slate-700" placeholder="Username" required>
+        <input id="password" type="password" class="px-3 py-2 rounded-lg bg-slate-950 border border-slate-700" placeholder="Password" required>
+        <button class="px-3 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-500 font-semibold" type="submit">Login</button>
+        <div id="authState" class="px-3 py-2 rounded-lg bg-slate-950 border border-slate-700 text-sm">Belum login</div>
+      </form>
+    </section>
+
+    <section class="grid md:grid-cols-4 gap-3 fade-in">
+      <div class="rounded-2xl border border-slate-800 bg-slate-900 p-4"><div class="text-slate-400 text-xs">Total Ticket</div><div id="mTotalTickets" class="text-2xl font-bold">0</div></div>
+      <div class="rounded-2xl border border-slate-800 bg-slate-900 p-4"><div class="text-slate-400 text-xs">Socket Active</div><div id="mSocket" class="text-2xl font-bold">0</div></div>
+      <div class="rounded-2xl border border-slate-800 bg-slate-900 p-4"><div class="text-slate-400 text-xs">Forum Rooms</div><div id="mRooms" class="text-2xl font-bold">0</div></div>
+      <div class="rounded-2xl border border-slate-800 bg-slate-900 p-4"><div class="text-slate-400 text-xs">Uptime</div><div id="mUptime" class="text-sm font-bold">-</div></div>
+    </section>
+
+    <section class="grid md:grid-cols-2 gap-3 fade-in">
+      <div class="rounded-2xl border border-slate-800 bg-slate-900 p-4">
+        <h2 class="font-bold mb-2">Distribusi Status Ticket</h2>
+        <div id="statusBars" class="space-y-2"></div>
+      </div>
+      <div class="rounded-2xl border border-slate-800 bg-slate-900 p-4">
+        <h2 class="font-bold mb-2">Runtime Memory</h2>
+        <ul id="runtimeMem" class="space-y-1 text-sm text-slate-300"></ul>
+      </div>
+    </section>
+
+    <section class="rounded-2xl border border-slate-800 bg-slate-900 p-4 fade-in">
+      <h2 class="font-bold mb-2">Ticket Terbaru</h2>
+      <div class="overflow-auto">
+        <table class="min-w-full text-sm"><thead class="text-slate-400"><tr><th class="text-left py-2 pr-2">ID</th><th class="text-left py-2 pr-2">Kategori</th><th class="text-left py-2 pr-2">Status</th><th class="text-left py-2">Waktu Lokal</th></tr></thead><tbody id="newestRows"></tbody></table>
+      </div>
+    </section>
+  </main>
+
+<script>
+const TOKEN_KEY = 'ytconv_admin_bearer';
+const fmt = new Intl.DateTimeFormat(undefined, { dateStyle:'medium', timeStyle:'short' });
+const getToken = () => (localStorage.getItem(TOKEN_KEY) || '').trim();
+const setToken = (v) => localStorage.setItem(TOKEN_KEY, v || '');
+const formatBytes = (n) => `${(Number(n || 0) / (1024 * 1024)).toFixed(2)} MB`;
+const el = (id) => document.getElementById(id);
+const formatUptime = (sec=0) => {
+  sec = Number(sec || 0);
+  const h = Math.floor(sec / 3600); const m = Math.floor((sec % 3600) / 60); const s = Math.floor(sec % 60);
+  return `${h}j ${m}m ${s}d`;
+};
+
+async function login(evt){
+  evt.preventDefault();
+  const res = await fetch('/admin/login', { method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({ username:el('username').value, password:el('password').value }) });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok || !data.ok || !data.token) { el('authState').textContent = 'Login gagal'; return; }
+  setToken(data.token);
+  el('authState').textContent = 'Login aktif';
+  loadStats();
+}
+
+async function loadStats(){
+  const token = getToken();
+  if (!token) return;
+  const res = await fetch('/api/admin/stats', { headers:{ Authorization:`Bearer ${token}` } });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok || !data.ok) { el('authState').textContent = 'Token invalid'; return; }
+  el('authState').textContent = `Aktif • ${fmt.format(new Date(data.timestamp))}`;
+  el('mTotalTickets').textContent = data.tickets?.total || 0;
+  el('mSocket').textContent = data.activeSocketClients || 0;
+  el('mRooms').textContent = data.forumRooms || 0;
+  el('mUptime').textContent = formatUptime(data.uptimeSeconds || 0);
+
+  const byStatus = data.tickets?.byStatus || {};
+  const total = Math.max(1, Number(data.tickets?.total || 0));
+  el('statusBars').innerHTML = Object.entries(byStatus).map(([k,v]) => {
+    const pct = Math.round((Number(v) / total) * 100);
+    return `<div><div class="flex justify-between text-xs mb-1"><span>${k}</span><span>${v} (${pct}%)</span></div><div class="h-2 rounded-full bg-slate-800"><div class="h-2 rounded-full bg-indigo-500" style="width:${pct}%"></div></div></div>`;
+  }).join('') || '<div class="text-sm text-slate-400">Belum ada data status.</div>';
+
+  el('runtimeMem').innerHTML = `
+    <li>RSS: <b>${formatBytes(data.runtime?.rss)}</b></li>
+    <li>Heap Used: <b>${formatBytes(data.runtime?.heapUsed)}</b></li>
+    <li>Heap Total: <b>${formatBytes(data.runtime?.heapTotal)}</b></li>
+    <li>External: <b>${formatBytes(data.runtime?.external)}</b></li>`;
+
+  el('newestRows').innerHTML = (data.tickets?.newest || []).map((t) => `
+    <tr class="border-t border-slate-800"><td class="py-2 pr-2">${t.ticketId}</td><td class="py-2 pr-2">${t.category || '-'}</td><td class="py-2 pr-2">${t.statusLabel || t.status || '-'}</td><td class="py-2">${t.submittedAt ? fmt.format(new Date(t.submittedAt)) : '-'}</td></tr>
+  `).join('') || '<tr><td class="py-2 text-slate-400" colspan="4">Belum ada tiket.</td></tr>';
+}
+
+el('loginForm').addEventListener('submit', login);
+el('refreshBtn').addEventListener('click', () => loadStats().catch(() => {}));
+if (getToken()) { el('authState').textContent = 'Token tersimpan'; loadStats(); }
+setInterval(() => { if (getToken()) loadStats().catch(() => {}); }, 5000);
+</script>
+</body>
+</html>

--- a/public-ui/admin-tickets.html
+++ b/public-ui/admin-tickets.html
@@ -1,0 +1,214 @@
+<!doctype html>
+<html lang="id">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Admin Tickets • YTConv</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    @keyframes fadeInUp { from { opacity:.0; transform:translateY(8px);} to {opacity:1; transform:translateY(0);} }
+    .fade-in-up { animation: fadeInUp .28s ease both; }
+  </style>
+</head>
+<body class="min-h-screen bg-slate-950 text-slate-100">
+  <div class="max-w-7xl mx-auto p-4 md:p-6 space-y-4">
+    <header class="rounded-2xl border border-slate-800 bg-slate-900/80 backdrop-blur p-4 md:p-5 fade-in-up">
+      <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+        <div>
+          <h1 class="text-xl md:text-2xl font-extrabold tracking-tight">🎫 Admin Ticket Dashboard</h1>
+          <p class="text-slate-400 text-sm">Realtime ticket monitoring + update status user.</p>
+        </div>
+        <div class="flex gap-2 flex-wrap">
+          <a href="/admin/dashboard" class="px-3 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-sm font-semibold">Statistik</a>
+          <a href="/admin/cookies.html" class="px-3 py-2 rounded-lg bg-slate-800 hover:bg-slate-700 text-sm font-semibold">Admin Cookies</a>
+          <a href="/status.html" class="px-3 py-2 rounded-lg bg-slate-800 hover:bg-slate-700 text-sm font-semibold">Status Page</a>
+        </div>
+      </div>
+    </header>
+
+    <section class="grid md:grid-cols-3 gap-3">
+      <form id="loginForm" class="md:col-span-2 rounded-2xl border border-slate-800 bg-slate-900 p-4 space-y-3 fade-in-up">
+        <div class="font-bold">Login Admin</div>
+        <div class="grid sm:grid-cols-3 gap-2">
+          <input id="username" placeholder="Username" class="px-3 py-2 rounded-lg bg-slate-950 border border-slate-700" required>
+          <input id="password" type="password" placeholder="Password" class="px-3 py-2 rounded-lg bg-slate-950 border border-slate-700" required>
+          <div class="flex gap-2">
+            <button class="flex-1 px-3 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-500 font-semibold" type="submit">Login</button>
+            <button class="px-3 py-2 rounded-lg bg-slate-700 hover:bg-slate-600" type="button" onclick="logout()">Logout</button>
+          </div>
+        </div>
+      </form>
+      <div class="rounded-2xl border border-slate-800 bg-slate-900 p-4 space-y-1 fade-in-up">
+        <div class="text-sm text-slate-400">Status Auth</div>
+        <div id="authState" class="font-semibold">Belum login</div>
+        <div id="lastSync" class="text-xs text-slate-500">Belum ada sinkronisasi</div>
+      </div>
+    </section>
+
+    <section class="rounded-2xl border border-slate-800 bg-slate-900 p-4 fade-in-up">
+      <div class="flex items-center justify-between mb-3">
+        <h2 class="font-bold">Daftar Tiket</h2>
+        <button onclick="loadTickets()" class="px-3 py-2 rounded-lg bg-sky-600 hover:bg-sky-500 text-sm font-semibold">Refresh</button>
+      </div>
+      <div class="overflow-x-auto">
+        <table class="min-w-full text-sm">
+          <thead class="text-slate-400 border-b border-slate-800">
+            <tr>
+              <th class="text-left py-2 pr-2">ID</th><th class="text-left py-2 pr-2">Pengirim</th><th class="text-left py-2 pr-2">Kategori</th><th class="text-left py-2 pr-2">Pesan</th><th class="text-left py-2 pr-2">Status</th><th class="text-left py-2 pr-2">Balasan</th><th class="text-left py-2">Aksi</th>
+            </tr>
+          </thead>
+          <tbody id="rows"></tbody>
+        </table>
+      </div>
+    </section>
+  </div>
+
+<script>
+const TOKEN_KEY = 'ytconv_admin_bearer';
+const DRAFT_KEY = 'ytconv_ticket_drafts_v1';
+const fmt = new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+const esc = (v='') => String(v).replace(/[&<>'\"]/g, (c) => ({'&':'&amp;','<':'&lt;','>':'&gt;',"'":'&#39;','"':'&quot;'}[c]));
+const STATUS_TEMPLATES = {
+  received: 'Halo, tiket kamu sudah kami terima. Tim kami akan review secepatnya.',
+  reviewing: 'Halo, tiket kamu sedang kami proses. Mohon tunggu update berikutnya ya.',
+  waiting_user: 'Halo, kami butuh info tambahan dari kamu supaya tiket bisa lanjut diproses.',
+  resolved: 'Halo, masalah kamu sudah kami selesaikan. Kalau masih ada kendala, balas tiket ini ya.',
+  rejected: 'Halo, tiket ditolak karena data belum cukup/invalid. Silakan kirim detail tambahan.'
+};
+const draftStore = (() => {
+  try { return JSON.parse(localStorage.getItem(DRAFT_KEY) || '{}') || {}; } catch { return {}; }
+})();
+const saveDraftStore = () => localStorage.setItem(DRAFT_KEY, JSON.stringify(draftStore));
+
+const statusBadge = (status='received', label='Diterima') => {
+  const map = {
+    received:'bg-blue-500/20 text-blue-300 border-blue-500/40',
+    reviewing:'bg-amber-500/20 text-amber-300 border-amber-500/40',
+    waiting_user:'bg-purple-500/20 text-purple-300 border-purple-500/40',
+    resolved:'bg-emerald-500/20 text-emerald-300 border-emerald-500/40',
+    rejected:'bg-rose-500/20 text-rose-300 border-rose-500/40'
+  };
+  return `<span class="px-2 py-1 rounded-full border text-xs font-semibold ${map[status] || 'bg-slate-700/50 text-slate-200 border-slate-600'}">${esc(label)}</span>`;
+};
+
+function setAuthState(text){ document.getElementById('authState').textContent = text; }
+function setLastSync(){ document.getElementById('lastSync').textContent = 'Sinkronisasi: ' + fmt.format(new Date()); }
+function getToken(){ return (localStorage.getItem(TOKEN_KEY) || '').trim(); }
+function saveToken(token){ localStorage.setItem(TOKEN_KEY, token || ''); }
+function setDraft(id, patch = {}) {
+  draftStore[id] = { ...(draftStore[id] || {}), ...patch, updatedAt: Date.now() };
+  saveDraftStore();
+}
+function getDraft(id) { return draftStore[id] || null; }
+function clearDraft(id) { delete draftStore[id]; saveDraftStore(); }
+
+async function loginAdmin(evt){
+  evt?.preventDefault();
+  const username = document.getElementById('username').value.trim();
+  const password = document.getElementById('password').value;
+  try {
+    const r = await fetch('/admin/login', { method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({ username, password }) });
+    const d = await r.json().catch(() => ({}));
+    if (!r.ok || !d.ok || !d.token) throw new Error(d.error || 'Login gagal');
+    saveToken(d.token);
+    setAuthState('Login aktif');
+    await loadTickets();
+  } catch (e) {
+    setAuthState('Login gagal: ' + e.message);
+  }
+}
+
+async function loadTickets(){
+  const token = getToken();
+  const tb = document.getElementById('rows');
+  if (!token) { tb.innerHTML = `<tr><td colspan="7" class="py-5 text-center text-slate-400">Login admin dulu.</td></tr>`; return; }
+  const r = await fetch('/api/admin/tickets', { headers:{ Authorization:`Bearer ${token}` } });
+  const d = await r.json().catch(() => ({}));
+  if (!r.ok || !d.ok) {
+    tb.innerHTML = `<tr><td colspan="7" class="py-5 text-center text-rose-300">${esc(d.error || 'unauthorized')}</td></tr>`;
+    setAuthState('Token invalid/expired');
+    return;
+  }
+  tb.innerHTML = '';
+  if (!d.tickets?.length) {
+    tb.innerHTML = `<tr><td colspan="7" class="py-5 text-center text-slate-400">Belum ada tiket masuk.</td></tr>`;
+  }
+  d.tickets.forEach((t) => {
+    const row = document.createElement('tr');
+    row.className = 'border-b border-slate-800 align-top';
+    const submitted = t.submittedAt ? fmt.format(new Date(t.submittedAt)) : '-';
+    row.innerHTML = `
+      <td class="py-3 pr-2">
+        <div class="font-semibold">${esc(t.ticketId)}</div>
+        <div class="text-xs text-slate-500">${submitted}</div>
+      </td>
+      <td class="py-3 pr-2"><div>${esc(t.name || '-')}</div><div class="text-xs text-slate-400">${esc(t.email || '-')}</div></td>
+      <td class="py-3 pr-2"><span class="px-2 py-1 rounded-md bg-slate-800 text-xs">${esc(t.category || '-')}</span></td>
+      <td class="py-3 pr-2 max-w-sm"><div class="line-clamp-4 whitespace-pre-wrap text-slate-300">${esc(t.message || '-')}</div></td>
+      <td class="py-3 pr-2">
+        <div class="mb-2">${statusBadge(t.status, t.statusLabel || t.status)}</div>
+        <select id="st-${esc(t.ticketId)}" class="w-full px-2 py-1.5 rounded-lg bg-slate-950 border border-slate-700 text-xs">
+          <option value="received">Diterima</option><option value="reviewing">Diproses</option><option value="waiting_user">Menunggu User</option><option value="resolved">Selesai</option><option value="rejected">Ditolak</option>
+        </select>
+      </td>
+      <td class="py-3 pr-2">
+        <div class="space-y-2">
+          <textarea id="rp-${esc(t.ticketId)}" rows="3" class="w-full px-2 py-1.5 rounded-lg bg-slate-950 border border-slate-700 text-xs" placeholder="Balasan admin...">${esc(t.adminReply || '')}</textarea>
+          <div class="flex flex-wrap gap-1">
+            <button type="button" data-template="${esc(t.ticketId)}" class="px-2 py-1 text-[11px] rounded bg-slate-700 hover:bg-slate-600">Gunakan template status</button>
+          </div>
+        </div>
+      </td>
+      <td class="py-3">
+        <div class="flex flex-col gap-2">
+          <button onclick="updateTicket('${esc(t.ticketId)}')" class="px-2 py-1.5 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-xs font-semibold">Simpan</button>
+          <a href="/ticket-status.html?ticket_id=${encodeURIComponent(t.ticketId)}" target="_blank" class="px-2 py-1.5 rounded-lg bg-slate-800 hover:bg-slate-700 text-xs text-center">Lihat Status</a>
+        </div>
+      </td>`;
+    tb.appendChild(row);
+    const id = t.ticketId;
+    const sel = row.querySelector(`#st-${CSS.escape(id)}`);
+    if (sel) sel.value = t.status || 'received';
+    const replyEl = row.querySelector(`#rp-${CSS.escape(id)}`);
+    const draft = getDraft(id);
+    if (draft) {
+      if (sel && draft.status) sel.value = draft.status;
+      if (replyEl && typeof draft.adminReply === 'string') replyEl.value = draft.adminReply;
+    }
+    sel?.addEventListener('change', () => setDraft(id, { status: sel.value, adminReply: replyEl?.value || '' }));
+    replyEl?.addEventListener('input', () => setDraft(id, { status: sel?.value || 'received', adminReply: replyEl.value }));
+    row.querySelector(`[data-template=\"${CSS.escape(id)}\"]`)?.addEventListener('click', () => {
+      const template = STATUS_TEMPLATES[sel?.value || 'received'] || '';
+      if (!replyEl) return;
+      if (replyEl.value.trim()) {
+        if (!confirm('Balasan sudah ada. Ganti dengan template status?')) return;
+      }
+      replyEl.value = template;
+      setDraft(id, { status: sel?.value || 'received', adminReply: replyEl.value });
+    });
+  });
+  setAuthState('Login aktif');
+  setLastSync();
+}
+
+async function updateTicket(id){
+  const token = getToken();
+  const status = document.getElementById(`st-${id}`).value;
+  const adminReply = document.getElementById(`rp-${id}`).value;
+  const r = await fetch(`/api/admin/tickets/${encodeURIComponent(id)}`, { method:'PATCH', headers:{ 'Content-Type':'application/json', Authorization:`Bearer ${token}` }, body:JSON.stringify({ status, adminReply }) });
+  const d = await r.json().catch(() => ({}));
+  alert(d.ok ? 'Update berhasil.' : 'Gagal: ' + (d.error || 'unknown'));
+  if (d.ok) {
+    clearDraft(id);
+    loadTickets();
+  }
+}
+
+function logout(){ localStorage.removeItem(TOKEN_KEY); setAuthState('Logout berhasil'); loadTickets(); }
+
+document.getElementById('loginForm').addEventListener('submit', loginAdmin);
+if (getToken()) loadTickets(); else document.getElementById('rows').innerHTML = `<tr><td colspan="7" class="py-5 text-center text-slate-400">Login admin dulu.</td></tr>`;
+setInterval(() => { if (getToken()) loadTickets(); }, 8000);
+</script>
+</body>
+</html>

--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -5469,7 +5469,9 @@
                         <i class="bi bi-music-note-beamed text-success"></i>
                         <strong id="sourcePreviewLabel">Preview Spotify</strong>
                       </div>
-                      <audio id="sourcePreviewAudio" class="w-100 mt-2" controls preload="none"></audio>
+                      <audio id="sourcePreviewAudio" class="w-100 mt-2" controls preload="none"
+                        controlslist="nodownload noplaybackrate noremoteplayback" disablepictureinpicture
+                        oncontextmenu="return false"></audio>
                     </div>
                   </div>
                 </div>
@@ -5636,6 +5638,40 @@
                     data-i18n-placeholder="placeholderId3Album" />
                   <input id="id3Genre" type="text" class="form-control" placeholder="Genre"
                     data-i18n-placeholder="placeholderId3Genre" />
+                  <div class="form-check form-switch mt-2">
+                    <input class="form-check-input" type="checkbox" id="autoMetaSmart" checked>
+                    <label class="form-check-label" for="autoMetaSmart">Smart Auto Metadata + Cover HD</label>
+                  </div>
+                  <div class="d-flex align-items-center gap-2 mt-2 small text-secondary">
+                    <img id="id3CoverPreview" alt="Cover Preview" class="rounded border" style="width:40px;height:40px;object-fit:cover;" hidden>
+                    <span id="id3CoverText">Cover akan terisi otomatis dari source terbaik.</span>
+                  </div>
+                </div>
+
+                <div class="row g-2 mb-3">
+                  <div class="col-md-4">
+                    <label class="form-label" for="convertServerMode">Multi Server Selector</label>
+                    <select id="convertServerMode" class="form-select">
+                      <option value="auto" selected>Auto</option>
+                      <option value="fast">Server cepat</option>
+                      <option value="stable">Server stabil</option>
+                    </select>
+                  </div>
+                  <div class="col-md-4">
+                    <label class="form-label" for="crossfadeSeconds">Crossfade</label>
+                    <select id="crossfadeSeconds" class="form-select">
+                      <option value="0" selected>Off</option>
+                      <option value="2">2 detik</option>
+                      <option value="4">4 detik</option>
+                      <option value="6">6 detik</option>
+                    </select>
+                  </div>
+                  <div class="col-md-4 d-flex align-items-end">
+                    <div class="form-check form-switch mb-2">
+                      <input class="form-check-input" type="checkbox" id="gaplessPlayback" checked>
+                      <label class="form-check-label" for="gaplessPlayback">Gapless playback</label>
+                    </div>
+                  </div>
                 </div>
 
                 <div class="form-check form-switch mb-3">
@@ -6078,9 +6114,41 @@
                           <i class="bi bi-play-circle-fill text-primary"></i>
                           <strong>Preview Media</strong>
                         </div>
-                        <audio id="previewPlayer" class="w-100 mt-2" controls preload="none"></audio>
+                        <audio id="previewPlayer" class="w-100 mt-2" controls preload="none"
+                          controlslist="nodownload noplaybackrate noremoteplayback" disablepictureinpicture
+                          oncontextmenu="return false"></audio>
                         <video id="previewVideo" class="w-100 mt-3" controls preload="metadata" playsinline
+                          controlslist="nodownload noplaybackrate noremoteplayback" disablepictureinpicture
+                          oncontextmenu="return false"
                           hidden></video>
+                        <div class="d-flex flex-wrap align-items-center gap-2 mt-2">
+                          <button id="prevRewindBtn" class="btn btn-sm btn-outline-secondary" type="button"><i class="bi bi-skip-backward"></i> 10s</button>
+                          <button id="prevPlayPauseBtn" class="btn btn-sm btn-outline-primary" type="button"><i class="bi bi-play-fill"></i> Play/Pause</button>
+                          <button id="prevForwardBtn" class="btn btn-sm btn-outline-secondary" type="button">10s <i class="bi bi-skip-forward"></i></button>
+                          <label class="small text-secondary ms-1 mb-0">Kecepatan</label>
+                          <select id="previewSpeedSelect" class="form-select form-select-sm" style="max-width:120px">
+                            <option value="0.75">0.75x</option>
+                            <option value="1" selected>1.0x</option>
+                            <option value="1.25">1.25x</option>
+                            <option value="1.5">1.5x</option>
+                          </select>
+                          <span class="badge text-bg-dark"><i class="bi bi-shield-lock"></i> Download dinonaktifkan di preview</span>
+                        </div>
+                        <div class="card border-0 bg-body-secondary mt-3">
+                          <div class="card-body py-2">
+                            <div class="d-flex flex-wrap align-items-center gap-2">
+                              <strong class="me-auto">Paket User</strong>
+                              <span class="badge text-bg-info" id="activePlanBadge">Belum pilih paket</span>
+                              <button id="chooseFreePlanBtn" type="button" class="btn btn-sm btn-outline-success">Pilih Free</button>
+                              <button id="choosePremiumPlanBtn" type="button" class="btn btn-sm btn-outline-primary">Pilih Premium (Gratis)</button>
+                            </div>
+                            <div class="small text-secondary mt-1">Keduanya gratis saat ini. Pilih salah satu untuk lanjut fitur simpan cloud.</div>
+                          </div>
+                        </div>
+                        <div class="d-flex flex-wrap align-items-center gap-2 mt-2">
+                          <button id="saveCloudinaryBtn" type="button" class="btn btn-sm btn-outline-warning"><i class="bi bi-cloud-upload"></i> Simpan lagu ke Cloudinary</button>
+                          <span class="small text-secondary" id="saveCloudinaryStatus">Login Google + pilih paket untuk menyimpan.</span>
+                        </div>
 
                         <div id="shareWrap" class="mt-3" hidden>
                           <div class="d-flex flex-wrap align-items-center gap-2">
@@ -8009,7 +8077,7 @@
             </div>
           </div>
           <div class="modal-footer border-top-0 d-flex justify-content-center bg-body-tertiary">
-            <small class="text-muted fw-bold">By Dikalfe Project</small>
+            <small class="text-muted fw-bold">By YTConv Team</small>
           </div>
         </div>
       </div>
@@ -8846,7 +8914,7 @@
             <p class="small text-secondary mb-2">
               Platform konversi media modern yang cepat, aman, dan mudah digunakan.
             </p>
-            <div class="small text-secondary">By Dikalfe Project</div>
+            <div class="small text-secondary">By YTConv Team</div>
           </div>
           <div class="col-md-4 mb-3 mb-md-0">
             <h6 class="fw-bold mb-3">Tentang Kami</h6>
@@ -8876,7 +8944,7 @@
               </a>
               <button type="button" class="btn btn-sm btn-outline-secondary rounded-pill" data-bs-toggle="modal"
                 data-bs-target="#emailModal">
-                <i class="bi bi-envelope"></i> Email
+                <i class="bi bi-envelope"></i> Email Bantuan
               </button>
             </div>
           </div>
@@ -8966,7 +9034,7 @@
 
         <div class="border-top mt-4 pt-3 text-center small text-secondary">
           <div class="mb-2">
-            • 2026 Dikalfe Project
+            • 2026 YTConv
             <span id="appVersionBadge" class="badge rounded-pill bg-light text-dark border ms-2">Loading...</span>
             <span id="serverStatusDot" class="badge rounded-pill bg-secondary border ms-2"><i
                 class="bi bi-activity me-1"></i>Checking...</span>
@@ -9330,15 +9398,36 @@
                   placeholder="email@contoh.com" required>
               </div>
               <div class="mb-3">
+                <label for="emailTicketId" class="form-label small fw-semibold text-secondary">ID Tiket</label>
+                <input type="text" class="form-control rounded-pill bg-body-tertiary" id="emailTicketId" readonly>
+              </div>
+              <div class="mb-3">
+                <label for="emailCategory" class="form-label small fw-semibold text-secondary">Kategori</label>
+                <select class="form-select rounded-pill bg-body-tertiary" name="category" id="emailCategory">
+                  <option value="teknis">Masalah Teknis</option>
+                  <option value="forum">Forum & Moderasi</option>
+                  <option value="akun">Akun & Login</option>
+                  <option value="fitur">Saran Fitur</option>
+                </select>
+              </div>
+              <div class="mb-3">
                 <label for="emailMsg" class="form-label small fw-semibold text-secondary">Pesan</label>
                 <textarea class="form-control bg-body-tertiary" name="message" id="emailMsg" rows="4"
                   style="border-radius: 1rem;" placeholder="Ceritakan masalah atau saranmu..." required></textarea>
+              </div>
+              <div class="mb-3">
+                <label for="emailProof" class="form-label small fw-semibold text-secondary">Upload bukti (foto/video)</label>
+                <input type="file" class="form-control" id="emailProof" accept="image/*,video/*" multiple>
+                <div id="emailProofPreview" class="small text-secondary mt-1"></div>
+              </div>
+              <div class="alert alert-info small py-2">
+                <i class="bi bi-info-circle me-1"></i>Ticket otomatis dikirim ke <strong>forumwargaytmp3@gmail.com</strong>. Waktu respon estimasi 2x24 jam.
               </div>
               <!-- Hidden Date Field -->
               <input type="hidden" name="date" id="emailDate">
 
               <button type="submit" id="emailSubmitBtn" class="btn btn-primary w-100 rounded-pill fw-bold py-2 mt-2">
-                <i class="bi bi-send-fill me-2"></i> Kirim Pesan
+                <i class="bi bi-send-fill me-2"></i> Kirim Tiket CS
               </button>
             </form>
           </div>
@@ -12902,48 +12991,207 @@
         const EMAILJS_PUBLIC_KEY = 'jT-4e85nCgIpRJak5';
         const EMAILJS_SERVICE_ID = 'service_733722j';
         const EMAILJS_TEMPLATE_ID = 'template_rdmekih';
+        const EMAILJS_AUTOREPLY_TEMPLATE_ID = 'template_58uztm9';
+
+        function showTicketSuccessCard({ ticketId = '', statusLink = '', autoReplySent = true } = {}) {
+          const old = document.getElementById('ticketSuccessOverlay');
+          if (old) old.remove();
+          const overlay = document.createElement('div');
+          overlay.id = 'ticketSuccessOverlay';
+          overlay.style.cssText = 'position:fixed;inset:0;z-index:1085;background:rgba(2,6,23,.62);display:flex;align-items:center;justify-content:center;padding:16px;opacity:0;transition:opacity .25s ease;';
+          overlay.innerHTML = `
+            <div style="max-width:420px;width:100%;background:#0f172a;border:1px solid rgba(148,163,184,.35);border-radius:18px;padding:20px;color:#e2e8f0;box-shadow:0 20px 45px rgba(2,6,23,.5);transform:translateY(18px) scale(.96);transition:transform .28s cubic-bezier(.2,.8,.2,1);">
+              <div style="display:flex;align-items:center;gap:10px;margin-bottom:10px;">
+                <div style="width:38px;height:38px;border-radius:999px;background:linear-gradient(135deg,#4f46e5,#06b6d4);display:flex;align-items:center;justify-content:center;font-size:20px;">✅</div>
+                <div>
+                  <div style="font-weight:800;font-size:1.05rem;">Tiket berhasil terkirim</div>
+                  <div style="font-size:.9rem;color:#cbd5e1;">ID Tiket: <b>${ticketId || '-'}</b></div>
+                </div>
+              </div>
+              <div style="font-size:.9rem;color:#cbd5e1;line-height:1.45;">
+                Tim support akan memproses laporan kamu. Simpan ID tiket ini untuk tracking status.
+              </div>
+              <div style="font-size:.83rem;color:${autoReplySent ? '#93c5fd' : '#fbbf24'};margin-top:10px;">
+                ${autoReplySent ? 'Email admin + auto-reply user berhasil dikirim.' : 'Tiket berhasil dibuat, tapi sebagian email (admin/auto-reply) belum terkirim. Cek folder spam atau ulangi.'}
+              </div>
+              <div style="display:flex;gap:8px;margin-top:14px;flex-wrap:wrap;">
+                ${statusLink ? `<a href="${statusLink}" target="_blank" rel="noopener noreferrer" class="btn btn-sm btn-primary">Cek Status Tiket</a>` : ''}
+                <button type="button" class="btn btn-sm btn-outline-light" id="ticketSuccessCloseBtn">Tutup</button>
+              </div>
+            </div>`;
+          document.body.appendChild(overlay);
+          requestAnimationFrame(() => {
+            overlay.style.opacity = '1';
+            const card = overlay.firstElementChild;
+            if (card) card.style.transform = 'translateY(0) scale(1)';
+          });
+          let closed = false;
+          const close = () => {
+            if (closed) return;
+            closed = true;
+            overlay.style.opacity = '0';
+            const card = overlay.firstElementChild;
+            if (card) card.style.transform = 'translateY(16px) scale(.96)';
+            setTimeout(() => overlay.remove(), 220);
+          };
+          overlay.addEventListener('click', (e) => {
+            if (e.target === overlay) close();
+          });
+          overlay.querySelector('#ticketSuccessCloseBtn')?.addEventListener('click', close);
+          setTimeout(close, 3200);
+        }
 
         function initEmailContact() {
           const form = document.getElementById('emailForm');
           const submitBtn = document.getElementById('emailSubmitBtn');
           const dateInput = document.getElementById('emailDate');
+          const ticketIdInput = document.getElementById('emailTicketId');
+          const proofInput = document.getElementById('emailProof');
+          const proofPreview = document.getElementById('emailProofPreview');
           if (!form || !submitBtn) return;
+
+          const generateTicketId = () => `TKT-${Date.now().toString(36).toUpperCase().slice(-8)}`;
+
+          const ensureTicketId = () => {
+            if (ticketIdInput && !ticketIdInput.value) ticketIdInput.value = generateTicketId();
+          };
+
+          document.getElementById('emailModal')?.addEventListener('show.bs.modal', ensureTicketId);
+          ensureTicketId();
+
+          if (proofInput && proofPreview) {
+            proofInput.addEventListener('change', () => {
+              const files = Array.from(proofInput.files || []).slice(0, 4);
+              if (!files.length) {
+                proofPreview.textContent = 'Belum ada file bukti dipilih.';
+                return;
+              }
+              proofPreview.textContent = files.map((f) => `${f.name} (${Math.ceil(f.size / 1024)} KB)`).join(' • ');
+            });
+          }
 
           form.addEventListener('submit', async (e) => {
             e.preventDefault();
 
-            if (!window.emailjs || !EMAILJS_PUBLIC_KEY || !EMAILJS_SERVICE_ID || !EMAILJS_TEMPLATE_ID) {
-              setToast('Form laporan email belum dikonfigurasi. Hubungi admin.', 'danger');
-              return;
-            }
-
-            if (dateInput) {
-              dateInput.value = new Date().toLocaleString('id-ID');
-            }
+            if (dateInput) dateInput.value = new Date().toLocaleString('id-ID');
+            ensureTicketId();
 
             const originalHtml = submitBtn.innerHTML;
             submitBtn.disabled = true;
-            submitBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>Mengirim...';
+            submitBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>Mengirim tiket...';
 
             try {
-              window.emailjs.init({ publicKey: EMAILJS_PUBLIC_KEY });
+              const files = Array.from((proofInput && proofInput.files) ? proofInput.files : []).slice(0, 4);
+              const proofs = [];
+              for (const file of files) {
+                let uploadedUrl = '';
+                try {
+                  if (typeof uploadToCloudinaryAuto === 'function') {
+                    uploadedUrl = await uploadToCloudinaryAuto(file, 'ytconv/support-tickets');
+                  }
+                } catch (uploadErr) {
+                  console.warn('Upload Cloudinary langsung gagal, fallback dataUrl', uploadErr);
+                }
 
-              const formData = {
-                name: form.name?.value || '',
-                email: form.email?.value || '',
-                message: form.message?.value || '',
+                if (uploadedUrl) {
+                  proofs.push({ name: file.name, type: file.type, size: file.size, url: uploadedUrl });
+                  continue;
+                }
+
+                const fallbackProof = await new Promise((resolve, reject) => {
+                  const reader = new FileReader();
+                  reader.onload = () => resolve({ name: file.name, type: file.type, size: file.size, dataUrl: reader.result });
+                  reader.onerror = () => reject(new Error(`Gagal membaca file ${file.name}`));
+                  reader.readAsDataURL(file);
+                });
+                proofs.push(fallbackProof);
+              }
+
+              const payload = {
+                ticketId: ticketIdInput?.value || generateTicketId(),
+                name: form.name?.value?.trim() || '',
+                email: form.email?.value?.trim() || '',
+                category: form.category?.value || 'teknis',
+                message: form.message?.value?.trim() || '',
+                proofs,
+                file_link: proofs[0]?.url || '',
                 date: dateInput?.value || new Date().toISOString(),
-                user_agent: navigator.userAgent || '',
-                page_url: window.location.href,
+                userAgent: navigator.userAgent || '',
+                pageUrl: window.location.href,
               };
 
-              await window.emailjs.send(EMAILJS_SERVICE_ID, EMAILJS_TEMPLATE_ID, formData, { publicKey: EMAILJS_PUBLIC_KEY });
+              const sendTemplateEmailJs = async (templateId, templateParams) => {
+                if (!window.emailjs || !EMAILJS_PUBLIC_KEY || !EMAILJS_SERVICE_ID || !templateId) {
+                  throw new Error('EmailJS belum dikonfigurasi');
+                }
+                window.emailjs.init({ publicKey: EMAILJS_PUBLIC_KEY });
+                let lastErr = null;
+                for (let i = 0; i < 3; i++) {
+                  try {
+                    await window.emailjs.send(EMAILJS_SERVICE_ID, templateId, templateParams, { publicKey: EMAILJS_PUBLIC_KEY });
+                    return true;
+                  } catch (err) {
+                    lastErr = err;
+                    await new Promise((r) => setTimeout(r, 400 * (i + 1)));
+                  }
+                }
+                throw lastErr || new Error('Gagal mengirim auto-reply EmailJS');
+              };
 
-              setToast('Pesan berhasil dikirim. Terima kasih!', 'success');
+              const resp = await fetch('/api/contact', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload),
+              });
+              const result = await resp.json().catch(() => ({}));
+              if (!resp.ok || !result?.ok) {
+                throw new Error(result?.error || 'Gagal membuat tiket ke server');
+              }
+              const firstLink = result?.fileLink || payload.file_link || '';
+              const statusLink = result?.statusLink || `${window.location.origin}/ticket-status.html?ticket_id=${encodeURIComponent(payload.ticketId || '')}`;
+              const sharedParams = {
+                ticket_id: payload.ticketId,
+                name: payload.name,
+                email: payload.email,
+                category: payload.category,
+                message: payload.message,
+                file_link: firstLink || 'Tidak ada file',
+                date: payload.date,
+                status_link: statusLink,
+              };
+              let autoReplySent = false;
+              let adminEmailSent = false;
+              try {
+                const [adminResult, autoReplyResult] = await Promise.allSettled([
+                  sendTemplateEmailJs(EMAILJS_TEMPLATE_ID, sharedParams),
+                  sendTemplateEmailJs(EMAILJS_AUTOREPLY_TEMPLATE_ID, sharedParams),
+                ]);
+                adminEmailSent = adminResult.status === 'fulfilled';
+                autoReplySent = autoReplyResult.status === 'fulfilled';
+              } catch (mailErr) {
+                console.error('Auto-reply EmailJS gagal', mailErr);
+              }
+
+              const allSent = autoReplySent && adminEmailSent;
+              setToast(`Tiket ${payload.ticketId} berhasil dikirim. Tunggu respon maksimal 2x24 jam.`, allSent ? 'success' : 'warning');
+              showTicketSuccessCard({
+                ticketId: payload.ticketId,
+                statusLink,
+                autoReplySent: allSent
+              });
+              try {
+                const modalEl = document.getElementById('emailModal');
+                if (modalEl && window.bootstrap?.Modal) {
+                  const instance = window.bootstrap.Modal.getInstance(modalEl) || new window.bootstrap.Modal(modalEl);
+                  instance.hide();
+                }
+              } catch {}
               form.reset();
+              if (proofPreview) proofPreview.textContent = '';
+              if (ticketIdInput) ticketIdInput.value = generateTicketId();
             } catch (err) {
-              console.error('EmailJS error', err);
-              setToast('Gagal mengirim pesan. Coba lagi atau gunakan kontak admin.', 'danger');
+              console.error('Email ticket error', err);
+              setToast('Gagal mengirim tiket. Silakan email langsung ke forumwargaytmp3@gmail.com', 'danger');
             } finally {
               submitBtn.disabled = false;
               submitBtn.innerHTML = originalHtml;
@@ -13535,6 +13783,15 @@
         const previewPlayer = $('#previewPlayer');
         const previewWrap = $('#previewWrap');
         const previewVideo = $('#previewVideo');
+        const prevRewindBtn = $('#prevRewindBtn');
+        const prevPlayPauseBtn = $('#prevPlayPauseBtn');
+        const prevForwardBtn = $('#prevForwardBtn');
+        const previewSpeedSelect = $('#previewSpeedSelect');
+        const chooseFreePlanBtn = $('#chooseFreePlanBtn');
+        const choosePremiumPlanBtn = $('#choosePremiumPlanBtn');
+        const activePlanBadge = $('#activePlanBadge');
+        const saveCloudinaryBtn = $('#saveCloudinaryBtn');
+        const saveCloudinaryStatus = $('#saveCloudinaryStatus');
         const qrCanvas = $('#downloadQr');
         const qrWrap = $('#qrWrap');
         const thumbEl = $('#thumb');
@@ -14263,6 +14520,12 @@
         const id3ArtistInput = $('#id3Artist');
         const id3AlbumInput = $('#id3Album');
         const id3Genre = $('#id3Genre');
+        const autoMetaSmartToggle = $('#autoMetaSmart');
+        const id3CoverPreview = $('#id3CoverPreview');
+        const id3CoverText = $('#id3CoverText');
+        const convertServerMode = $('#convertServerMode');
+        const crossfadeSecondsSelect = $('#crossfadeSeconds');
+        const gaplessPlaybackToggle = $('#gaplessPlayback');
         const markManualInput = (input) => {
           if (!input) return;
           const handleManualFlag = () => {
@@ -17901,6 +18164,27 @@
                 const tips = data.suggestions.slice(0, 3).map((tip) => `- ${tip}`).join('\n');
                 reply += `\n\nSaran cepat:\n${tips}`;
               }
+
+              if (data.action === 'open_ticket') {
+                const modalEl = document.getElementById('emailModal');
+                const ticketMsg = document.getElementById('emailMsg');
+                const ticketIdEl = document.getElementById('emailTicketId');
+                const categoryEl = document.getElementById('emailCategory');
+                if (ticketIdEl && !ticketIdEl.value) {
+                  const seed = Date.now().toString(36).toUpperCase().slice(-8);
+                  ticketIdEl.value = `TKT-${seed}`;
+                }
+                if (ticketMsg && data?.params?.context) {
+                  ticketMsg.value = `Ringkasan dari AI Navigator:\n${data.params.context}\n\nDetail tambahan:`;
+                }
+                if (categoryEl && /forum|kasar|moderasi/i.test(String(data?.params?.context || ''))) {
+                  categoryEl.value = 'forum';
+                }
+                if (modalEl && window.bootstrap?.Modal) {
+                  window.bootstrap.Modal.getOrCreateInstance(modalEl).show();
+                }
+                reply += '\n\nSaya sudah siapkan form tiket bantuan. Silakan cek data lalu kirim ya.';
+              }
             }
           } catch (err) {
             console.error('Gagal mengambil jawaban AI', err);
@@ -17936,7 +18220,7 @@
         const ensureAssistantWelcome = () => {
           if (!assistantMessages) return;
           if (!state.assistantHistory.length) {
-            addAssistantMessage('Navigator siap bantu. Tanyakan apa saja soal fitur converter ini.', 'bot');
+            addAssistantMessage('Navigator YTConv siap bantu seperti customer service. Tanyakan apa saja dengan bahasa kamu, nanti aku kasih alur langkah yang jelas.', 'bot');
           } else {
             state.assistantHistory.forEach((msg) => addAssistantMessage(msg.text, msg.role));
           }
@@ -19348,29 +19632,41 @@
               resetSourcePreview();
             }
           }
+          const smartAutoMetaOn = !autoMetaSmartToggle || !!autoMetaSmartToggle.checked;
           const metaId3 = info.id3 || {};
-          if (autoFillId3 || (fillEmptyId3 && id3TitleInput && !id3TitleInput.value.trim())) {
+          if (smartAutoMetaOn && (autoFillId3 || (fillEmptyId3 && id3TitleInput && !id3TitleInput.value.trim()))) {
             if (id3TitleInput) {
               id3TitleInput.value = metaId3.title || displayTitle;
               id3TitleInput.dataset.auto = '1';
             }
           }
-          if (autoFillId3 || (fillEmptyId3 && id3ArtistInput && !id3ArtistInput.value.trim())) {
+          if (smartAutoMetaOn && (autoFillId3 || (fillEmptyId3 && id3ArtistInput && !id3ArtistInput.value.trim()))) {
             if (id3ArtistInput) {
               id3ArtistInput.value = metaId3.artist || artist;
               id3ArtistInput.dataset.auto = '1';
             }
           }
-          if (autoFillId3 || (fillEmptyId3 && id3AlbumInput && !id3AlbumInput.value.trim())) {
+          if (smartAutoMetaOn && (autoFillId3 || (fillEmptyId3 && id3AlbumInput && !id3AlbumInput.value.trim()))) {
             if (id3AlbumInput) {
               id3AlbumInput.value = metaId3.album || displayTitle;
               id3AlbumInput.dataset.auto = '1';
             }
           }
-          if (autoFillId3 || (fillEmptyId3 && id3Genre && !id3Genre.value.trim())) {
+          if (smartAutoMetaOn && (autoFillId3 || (fillEmptyId3 && id3Genre && !id3Genre.value.trim()))) {
             if (id3Genre && metaId3.genre) {
               id3Genre.value = metaId3.genre;
               id3Genre.dataset.auto = '1';
+            }
+          }
+          const coverCandidate = info.cover || info.thumbnail || '';
+          if (id3CoverPreview) {
+            if (coverCandidate) {
+              id3CoverPreview.src = coverCandidate;
+              id3CoverPreview.hidden = false;
+              if (id3CoverText) id3CoverText.textContent = 'Cover HD siap dipakai untuk metadata file.';
+            } else {
+              id3CoverPreview.hidden = true;
+              if (id3CoverText) id3CoverText.textContent = 'Cover belum ditemukan. Coba link lain / sumber lain.';
             }
           }
           if (fileNameInput && (autoFillId3 || !fileNameInput.value.trim() || fileNameInput.dataset.autoName === fileNameInput.value)) {
@@ -20371,6 +20667,16 @@
 
         // ===== History =====
         const historyKey = 'ytmp3.history.v1';
+        const loadCloudHistoryOnly = () => {
+          const raw = JSON.parse(localStorage.getItem(historyKey) || '[]');
+          const cleaned = Array.isArray(raw)
+            ? raw.filter((item) => item && typeof item.cloudUrl === 'string' && item.cloudUrl.trim())
+            : [];
+          if (cleaned.length !== (Array.isArray(raw) ? raw.length : 0)) {
+            localStorage.setItem(historyKey, JSON.stringify(cleaned));
+          }
+          return cleaned;
+        };
 
         (() => {
           const overlay = document.getElementById('miniPlayerOverlay');
@@ -20599,7 +20905,7 @@
         })();
 
         const renderBasicHistory = () => {
-          const list = JSON.parse(localStorage.getItem(historyKey) || '[]');
+          const list = loadCloudHistoryOnly();
           const container = document.getElementById('basic-history-list');
           if (!container) return;
           container.innerHTML = '';
@@ -20631,7 +20937,7 @@
           }
 
           if (list.length === 0) {
-            container.innerHTML = '<div class="text-center opacity-50 p-4">Belum ada riwayat</div>';
+            container.innerHTML = '<div class="text-center opacity-50 p-4">Belum ada riwayat cloud. Login Google + simpan ke Cloudinary dulu.</div>';
             return;
           }
 
@@ -20654,7 +20960,7 @@
                  <button type="button" class="btn btn-outline-info btn-insight" title="Audio Insight (LUFS)">
                     <i class="bi bi-graph-up-arrow"></i>
                  </button>
-                 <a href="${item.downloadUrl}" class="btn btn-primary" download onclick="if(navigator.vibrate) navigator.vibrate(20)">
+                 <a href="${item.cloudUrl || item.downloadUrl}" class="btn btn-primary" download onclick="if(navigator.vibrate) navigator.vibrate(20)">
                     <i class="bi bi-download me-1"></i> Download
                  </a>
             </div>
@@ -20777,21 +21083,29 @@
         };
 
         const pushHistory = (entry) => {
-          const list = JSON.parse(localStorage.getItem(historyKey) || '[]');
+          if (!state?.auth?.user) {
+            setToast('Login Google dulu supaya riwayat tersimpan lintas deploy.', 'warning');
+            return;
+          }
+          if (!entry?.cloudUrl) {
+            // User asked history should only keep cloud-saved items.
+            return;
+          }
+          const list = loadCloudHistoryOnly();
           if (!entry.originalUrl) entry.originalUrl = $('#url')?.value?.trim() || '';
-          list.unshift({ ...entry, at: Date.now() });
+          list.unshift({ ...entry, at: Date.now(), savedType: 'cloudinary' });
           localStorage.setItem(historyKey, JSON.stringify(list.slice(0, 20))); // Increased limit slightly
           renderHistory();
           if (typeof renderBasicHistory === 'function') renderBasicHistory();
         };
         const removeHistory = (idx) => {
-          const list = JSON.parse(localStorage.getItem(historyKey) || '[]');
+          const list = loadCloudHistoryOnly();
           list.splice(idx, 1);
           localStorage.setItem(historyKey, JSON.stringify(list));
           renderHistory();
         };
         const renderHistory = () => {
-          const list = JSON.parse(localStorage.getItem(historyKey) || '[]');
+          const list = loadCloudHistoryOnly();
           const ul = $('#historyList');
           const emptyState = $('#historyEmpty');
           if (!ul) return;
@@ -20824,7 +21138,10 @@
             ul.appendChild(statsDiv);
           }
 
-          if (emptyState) emptyState.style.display = list.length ? 'none' : '';
+          if (emptyState) {
+            emptyState.style.display = list.length ? 'none' : '';
+            if (!list.length) emptyState.textContent = 'Belum ada riwayat cloud. Login Google lalu simpan ke Cloudinary.';
+          }
 
           list.forEach((item, idx) => {
             const li = document.createElement('li');
@@ -20870,7 +21187,7 @@
             titleLink.addEventListener('click', (e) => {
               e.preventDefault();
               if (typeof window.openMiniPlayer === 'function') {
-                window.openMiniPlayer(item.cloudUrl || item.downloadUrl, item?.meta?.title || item.fileName, item?.meta?.artist || 'Unknown Artist', item?.meta?.cover, item?.format);
+                window.openMiniPlayer(item.cloudUrl, item?.meta?.title || item.fileName, item?.meta?.artist || 'Unknown Artist', item?.meta?.cover, item?.format);
               } else {
                 window.open(item.cloudUrl || item.downloadUrl, '_blank');
               }
@@ -22176,6 +22493,105 @@
           miniSubtitle.textContent = parts.join(' • ');
         };
 
+        const getActivePreviewMedia = () => {
+          if (previewVideo && !previewVideo.hidden && previewVideo.src) return previewVideo;
+          return previewPlayer;
+        };
+        const seekPreview = (deltaSec = 0) => {
+          const media = getActivePreviewMedia();
+          if (!media || !Number.isFinite(media.duration)) return;
+          media.currentTime = Math.max(0, Math.min(media.duration, (media.currentTime || 0) + deltaSec));
+        };
+        prevRewindBtn?.addEventListener('click', () => seekPreview(-10));
+        prevForwardBtn?.addEventListener('click', () => seekPreview(10));
+        prevPlayPauseBtn?.addEventListener('click', () => {
+          const media = getActivePreviewMedia();
+          if (!media) return;
+          if (media.paused) media.play().catch(() => { });
+          else media.pause();
+        });
+        previewSpeedSelect?.addEventListener('change', () => {
+          const rate = Number(previewSpeedSelect.value || 1);
+          if (previewPlayer) previewPlayer.playbackRate = rate;
+          if (previewVideo) previewVideo.playbackRate = rate;
+        });
+
+        const PLAN_KEY = 'ytconv_subscription_plan';
+        const readPlan = () => {
+          try { return localStorage.getItem(PLAN_KEY) || ''; } catch { return ''; }
+        };
+        const writePlan = (plan) => {
+          try { localStorage.setItem(PLAN_KEY, plan); } catch { }
+        };
+        const renderPlan = () => {
+          const plan = readPlan();
+          if (!activePlanBadge) return;
+          if (!plan) {
+            activePlanBadge.className = 'badge text-bg-secondary';
+            activePlanBadge.textContent = 'Belum pilih paket';
+            return;
+          }
+          const isPremium = plan === 'premium';
+          activePlanBadge.className = `badge ${isPremium ? 'text-bg-primary' : 'text-bg-success'}`;
+          activePlanBadge.textContent = isPremium ? 'Premium (Gratis)' : 'Free';
+        };
+        const choosePlan = (plan) => {
+          const label = plan === 'premium' ? 'Premium (Gratis)' : 'Free';
+          if (!confirm(`Pilih paket ${label}? Kamu bisa ganti lagi kapan saja.`)) return;
+          writePlan(plan);
+          renderPlan();
+          if (saveCloudinaryStatus) saveCloudinaryStatus.textContent = `Paket aktif: ${label}. Kamu bisa simpan lagu ke Cloudinary.`;
+          setToast(`Paket ${label} aktif.`, 'success');
+        };
+        chooseFreePlanBtn?.addEventListener('click', () => choosePlan('free'));
+        choosePremiumPlanBtn?.addEventListener('click', () => choosePlan('premium'));
+        renderPlan();
+
+        const savePreviewToCloudinary = async () => {
+          if (!state?.auth?.user) {
+            setToast('Login Google dulu untuk simpan lagu ke Cloudinary.', 'warning');
+            if (saveCloudinaryStatus) saveCloudinaryStatus.textContent = 'Gagal: wajib login Google dulu.';
+            return;
+          }
+          const plan = readPlan();
+          if (!plan) {
+            setToast('Pilih paket Free/Premium dulu sebelum simpan.', 'warning');
+            if (saveCloudinaryStatus) saveCloudinaryStatus.textContent = 'Gagal: paket belum dipilih.';
+            return;
+          }
+          if (!currentDownloadUrl) {
+            setToast('Belum ada lagu yang bisa disimpan.', 'warning');
+            return;
+          }
+          if (saveCloudinaryBtn) saveCloudinaryBtn.disabled = true;
+          if (saveCloudinaryStatus) saveCloudinaryStatus.textContent = 'Mengunggah ke Cloudinary...';
+          try {
+            const resp = await fetch(currentDownloadUrl);
+            if (!resp.ok) throw new Error(`Fetch file gagal (${resp.status})`);
+            const blob = await resp.blob();
+            const baseName = (currentDownloadName || 'ytconv-audio').replace(/[^\w.\- ]+/g, '').trim() || 'ytconv-audio';
+            const ext = (lastPreviewMeta?.format || 'mp3').toLowerCase();
+            const file = new File([blob], `${baseName}.${ext}`, { type: blob.type || 'audio/mpeg' });
+            const uploader = window.uploadToCloudinaryAuto || window.uploadToCloudinary || null;
+            if (typeof uploader !== 'function') {
+              throw new Error('Uploader Cloudinary belum siap. Reload halaman lalu coba lagi.');
+            }
+            const cloudUrl = await uploader(file, `ytconv/user-library/${state.auth.user.id || 'anon'}`);
+            if (!cloudUrl) throw new Error('Cloudinary tidak mengembalikan URL');
+            if (saveCloudinaryStatus) {
+              saveCloudinaryStatus.innerHTML = `Berhasil disimpan: <a href=\"${cloudUrl}\" target=\"_blank\" rel=\"noopener noreferrer\">Buka file cloud</a>`;
+            }
+            setToast('Lagu berhasil disimpan ke Cloudinary.', 'success');
+          } catch (err) {
+            console.error('savePreviewToCloudinary error', err);
+            if (saveCloudinaryStatus) saveCloudinaryStatus.textContent = `Gagal simpan: ${err.message || 'unknown error'}`;
+            setToast('Gagal simpan ke Cloudinary.', 'danger');
+          } finally {
+            if (saveCloudinaryBtn) saveCloudinaryBtn.disabled = false;
+          }
+        };
+        saveCloudinaryBtn?.addEventListener('click', () => savePreviewToCloudinary());
+
         const updateMiniPlayState = () => {
           if (!miniPlayBtn || !previewPlayer) return;
           const paused = previewPlayer.paused;
@@ -23246,6 +23662,22 @@
           return xp;
         };
 
+        function toFriendlyConvertError(message = '') {
+          const raw = String(message || '').toLowerCase();
+          if (raw.includes('age') || raw.includes('restricted') || raw.includes('cookies')) return 'Video ini diblokir atau butuh cookies. Coba video lain atau update cookies ya.';
+          if (raw.includes('429') || raw.includes('too many') || raw.includes('rate')) return 'Server lagi padat. Santai, coba lagi sebentar ya.';
+          if (raw.includes('invalid') && raw.includes('url')) return 'Link belum valid. Cek lagi lalu kirim ulang ya.';
+          if (raw.includes('captcha')) return 'Verifikasi keamanan belum lolos. Coba klik convert sekali lagi ya.';
+          return `Hmm gagal nih, coba lagi yaa… (${message || 'unknown'})`;
+        }
+
+        function getSpeedServerLabel(mode = 'auto') {
+          if (mode === 'fast') return 'Server A / Fast Lane';
+          if (mode === 'stable') return 'Server B / Stable';
+          const pool = ['Server A', 'Server B', 'Server C'];
+          return `${pool[Math.floor(Math.random() * pool.length)]} / Auto`;
+        }
+
         async function doConvert(target, autoDownload = false) {
           // Request notification permission if default
           if ('Notification' in window && Notification.permission === 'default') {
@@ -23381,6 +23813,11 @@
             atmos: $('#atmos').checked,
             speedMode: $('#speedMode').value,
             preferredLang: currentLang,
+            serverMode: convertServerMode?.value || 'auto',
+            playbackPrefs: {
+              crossfade: Number(crossfadeSecondsSelect?.value || 0),
+              gapless: !!gaplessPlaybackToggle?.checked,
+            },
           };
 
           if (videoQualitySelect && !videoQualityWrap?.hidden) {
@@ -23438,6 +23875,7 @@
 
           $('#statusWrap').hidden = false;
           $('#resultWrap').hidden = true;
+          setToast(`⚡ Speed Boost: ${getSpeedServerLabel(body.serverMode)} aktif`);
 
           // Reset Rating UI
           const rBtns = document.getElementById('ratingButtons');
@@ -23628,7 +24066,7 @@
             };
             updateDriveUi();
             showAudioPreview(absolutePlayUrl, previewMeta);
-            setToast(translateMessage('Berhasil diproses'));
+            setToast('Done! Enjoy your music 🎧');
             updateAiStatus('Konversi selesai', 'success');
             registerConversionSuccess('direct', {
               vpnFriendly: convertData.vpnFriendly ?? body.vpnFriendly,
@@ -23659,9 +24097,10 @@
             $('#logs').textContent = (err && err.stack) ? err.stack : String(err);
             resetAudioPreview();
             convertProgressAnimator.fail(translateMessage('Gagal'));
-            setToast(`${translateMessage('Terjadi error: ')}${err.message}`);
-            announceNarrator(`Konversi gagal: ${err.message}`);
-            updateAiStatus(err.message, 'danger');
+            const friendlyErr = toFriendlyConvertError(err?.message || '');
+            setToast(friendlyErr);
+            announceNarrator(`Konversi gagal: ${friendlyErr}`);
+            updateAiStatus(friendlyErr, 'danger');
           } finally {
             stopConvertProgressWatcher();
             convertProgressAnimator.hide();
@@ -24235,7 +24674,7 @@
         };
 
         const checkDuplicate = (url, title = '') => {
-          const history = JSON.parse(localStorage.getItem(historyKey) || '[]');
+          const history = loadCloudHistoryOnly();
 
           const extractId = (u) => {
             try {
@@ -24722,7 +25161,7 @@
 
           } catch (err) {
             if (loadingEl) loadingEl.hidden = true;
-            setToast('Gagal: ' + err.message);
+            setToast(toFriendlyConvertError(err?.message || ''));
             vibrate(200);
           } finally {
             if (btn) btn.disabled = false;
@@ -28015,6 +28454,7 @@
               xhr.send(formData);
             });
           }
+          try { window.uploadToCloudinary = uploadToCloudinary; } catch { }
 
           async function uploadToCloudinaryAuto(file, folder = null) {
             const apiKey = '422728616314883';
@@ -28055,6 +28495,7 @@
               xhr.send(formData);
             });
           }
+          try { window.uploadToCloudinaryAuto = uploadToCloudinaryAuto; } catch { }
 
           async function uploadToCloudinaryVideo(file, folder = null) {
             const apiKey = '422728616314883';
@@ -28730,11 +29171,60 @@
             forumDeleteAllBtn.addEventListener('click', deleteAllForumMessages);
           }
 
+          const FORUM_BADWORDS = ['anjing', 'bangsat', 'brengsek', 'goblok', 'tolol', 'kontol', 'memek', 'jancok', 'ngentot', 'bacot'];
+          const FORUM_VIOLATION_LIMIT = 5;
+          const forumViolationKey = () => `ytconv:forum:violations:${currentUser?.uid || 'guest'}`;
+
+          function getForumViolationCount() {
+            try { return Number(localStorage.getItem(forumViolationKey()) || '0') || 0; } catch { return 0; }
+          }
+
+          function setForumViolationCount(val) {
+            try { localStorage.setItem(forumViolationKey(), String(Math.max(0, Number(val) || 0))); } catch { }
+          }
+
+          async function reportForumModeration(text, violationCount) {
+            try {
+              await fetch('/api/forum/moderation-report', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                  userId: currentUser?.uid || '',
+                  name: currentUser?.displayName || 'Warga',
+                  email: currentUser?.email || '',
+                  text,
+                  violationCount,
+                  room: activeForumRoom || 'umum',
+                }),
+              });
+            } catch (err) {
+              console.warn('Gagal kirim laporan automod', err);
+            }
+          }
+
           async function sendForumMessage() {
             if (isLaporanRoom()) { setToast('Room Laporan tidak menerima chat. Gunakan tombol Laporkan ya.'); return; }
             const text = forumInput.value.trim();
             if (!text && selectedFiles.length === 0) return;
             if (!currentUser) { setToast('Anda belum login!', 'warning'); return; }
+
+            const normalized = text.toLowerCase();
+            const hasBadWord = FORUM_BADWORDS.some((w) => normalized.includes(w));
+            if (hasBadWord) {
+              const nextCount = getForumViolationCount() + 1;
+              setForumViolationCount(nextCount);
+              await reportForumModeration(text, nextCount);
+              if (nextCount >= FORUM_VIOLATION_LIMIT) {
+                setToast('🚫 Kamu diblokir sementara setelah 5x pelanggaran. Ajukan appeal lewat AI Navigator / tiket email. Estimasi review 2x24 jam.', 'danger');
+                forumInput.value = '';
+                updateSendButtonState();
+                return;
+              }
+              setToast(`⚠️ Pesan kasar otomatis dihapus (${nextCount}/5). Gunakan bahasa yang baik ya.`, 'warning');
+              forumInput.value = '';
+              updateSendButtonState();
+              return;
+            }
 
             const { db, collection, addDoc, serverTimestamp, auth, storage, ref, uploadBytes, getDownloadURL } = window.firebaseModules;
 
@@ -28797,6 +29287,12 @@
             }
             if (isLaporanRoom()) {
               forumSendBtn.disabled = true;
+              return;
+            }
+            if (getForumViolationCount() >= FORUM_VIOLATION_LIMIT) {
+              forumSendBtn.disabled = true;
+              forumInput.disabled = true;
+              forumInput.placeholder = 'Akun forum dibatasi karena 5x pelanggaran. Ajukan appeal via AI Navigator / tiket email (respon 2x24 jam).';
               return;
             }
             if (voiceState.isRecording) {

--- a/public-ui/status.html
+++ b/public-ui/status.html
@@ -3,620 +3,185 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Status Server - YouTube to MP3</title>
+  <title>Status & Maintenance • YTConv</title>
+  <script src="https://cdn.tailwindcss.com"></script>
   <style>
-    :root {
-      --accent: #fd7e14;
-      --bg: #0b1220;
-      --card: rgba(17, 24, 39, 0.92);
-      --card2: rgba(15, 23, 42, 0.78);
-      --text: #e5e7eb;
-      --muted: rgba(229,231,235,0.72);
-      --border: rgba(255,255,255,0.10);
-      --shadow: 0 22px 70px rgba(0,0,0,0.38);
-      --radius: 18px;
-    }
-    @media (prefers-color-scheme: light) {
-      :root {
-        --bg: #f6f7fb;
-        --card: rgba(255,255,255,0.98);
-        --card2: rgba(255,255,255,0.92);
-        --text: #111827;
-        --muted: rgba(17,24,39,0.62);
-        --border: rgba(17,24,39,0.08);
-        --shadow: 0 20px 60px rgba(0,0,0,0.10);
-      }
-    }
-    body {
-      margin: 0;
-      font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-      background: radial-gradient(circle at 20% 0%, rgba(253,126,20,0.18), transparent 55%),
-                  radial-gradient(circle at 80% 0%, rgba(13,110,253,0.14), transparent 45%),
-                  var(--bg);
-      color: var(--text);
-    }
-    * { box-sizing: border-box; }
-    .wrap {
-      max-width: 1020px;
-      margin: 0 auto;
-      padding: 14px 14px 28px;
-    }
-    .top {
-      position: sticky;
-      top: 0;
-      z-index: 5;
-      padding: 10px 0 12px;
-      backdrop-filter: blur(10px);
-    }
-    .top-inner {
-      display: grid;
-      grid-template-columns: 1fr;
-      gap: 10px;
-    }
-    @media (min-width: 860px) {
-      .top-inner { grid-template-columns: 1.2fr 0.8fr; align-items: end; }
-    }
-    .brand {
-      display: flex;
-      align-items: center;
-      gap: 10px;
-      font-weight: 950;
-      letter-spacing: 0.02em;
-      font-size: 1.02rem;
-    }
-    .meta {
-      display: flex;
-      gap: 10px;
-      flex-wrap: wrap;
-      justify-content: flex-start;
-      align-items: center;
-      color: var(--muted);
-      font-size: 0.9rem;
-    }
-    @media (min-width: 860px) {
-      .meta { justify-content: flex-end; }
-    }
-    .dot {
-      width: 10px;
-      height: 10px;
-      border-radius: 999px;
-      background: #94a3b8;
-      box-shadow: 0 0 0 3px rgba(255,255,255,0.12);
-    }
-    .dot.ok { background: #22c55e; }
-    .dot.warn { background: #f59e0b; }
-    .dot.bad { background: #ef4444; }
-    .pill {
-      display: inline-flex;
-      align-items: center;
-      gap: 8px;
-      padding: 8px 10px;
-      border-radius: 999px;
-      border: 1px solid var(--border);
-      background: rgba(255,255,255,0.06);
-      color: var(--text);
-      font-weight: 900;
-      white-space: nowrap;
-    }
-    .actions {
-      display: flex;
-      gap: 10px;
-      flex-wrap: wrap;
-      margin-top: 10px;
-    }
-    @media (max-width: 540px) {
-      .actions {
-        flex-wrap: nowrap;
-        overflow-x: auto;
-        -webkit-overflow-scrolling: touch;
-        scrollbar-width: none;
-      }
-      .actions::-webkit-scrollbar { display: none; }
-      .actions > * { flex: 0 0 auto; }
-    }
-    button, a.btn {
-      border: 1px solid var(--border);
-      background: rgba(255,255,255,0.06);
-      color: var(--text);
-      padding: 11px 12px;
-      border-radius: 14px;
-      font-weight: 900;
-      cursor: pointer;
-      text-decoration: none;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      gap: 8px;
-      transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease, border-color 160ms ease;
-    }
-    button.primary {
-      background: var(--accent);
-      border-color: transparent;
-      color: #111827;
-    }
-    button:hover, a.btn:hover { transform: translateY(-1px); box-shadow: 0 10px 26px rgba(0,0,0,0.18); }
-    button:active, a.btn:active { transform: translateY(0px) scale(0.98); }
-    button:focus-visible, a.btn:focus-visible { outline: 2px solid color-mix(in srgb, var(--accent) 70%, transparent); outline-offset: 2px; }
-    button:disabled { opacity: 0.6; cursor: not-allowed; }
-    .grid {
-      display: grid;
-      grid-template-columns: 1fr;
-      gap: 12px;
-    }
-    @media (min-width: 860px) {
-      .grid { grid-template-columns: 1.25fr 0.75fr; }
-    }
-    .card {
-      border: 1px solid var(--border);
-      background: var(--card);
-      border-radius: var(--radius);
-      padding: 14px;
-      box-shadow: var(--shadow);
-      transform: translateY(0);
-      transition: transform 220ms ease, box-shadow 220ms ease;
-    }
-    @media (hover: hover) and (pointer: fine) {
-      .card:hover { transform: translateY(-2px); box-shadow: 0 28px 90px rgba(0,0,0,0.44); }
-    }
-    .card-head {
-      display: flex;
-      gap: 10px;
-      align-items: flex-start;
-      justify-content: space-between;
-      margin-bottom: 10px;
-    }
-    .card-head h1 {
-      font-size: 1.15rem;
-      margin: 0;
-      letter-spacing: 0.02em;
-      font-weight: 950;
-    }
-    .card-sub { color: var(--muted); font-size: 0.92rem; }
-    .muted { color: var(--muted); }
-    .badges { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 12px; }
-    .badge {
-      display: inline-flex;
-      align-items: center;
-      gap: 8px;
-      padding: 8px 10px;
-      border-radius: 999px;
-      border: 1px solid var(--border);
-      background: rgba(255,255,255,0.06);
-      font-weight: 800;
-      font-size: 0.85rem;
-    }
-    .section {
-      background: var(--card2);
-      border: 1px solid var(--border);
-      border-radius: 16px;
-      padding: 12px;
-      margin-top: 12px;
-    }
-    .section-title {
-      font-weight: 950;
-      font-size: 0.82rem;
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-      margin-bottom: 8px;
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 10px;
-    }
-    .list {
-      list-style: none;
-      padding: 0;
-      margin: 0;
-      display: grid;
-      gap: 8px;
-    }
-    .list li {
-      display: flex;
-      align-items: flex-start;
-      gap: 10px;
-      padding: 10px 10px;
-      border: 1px solid var(--border);
-      border-radius: 14px;
-      background: rgba(255,255,255,0.05);
-    }
-    .k { font-weight: 950; }
-    .mini {
-      display: grid;
-      gap: 8px;
-      margin: 0;
-      padding: 0;
-      list-style: none;
-    }
-    .mini li {
-      display: flex;
-      align-items: flex-start;
-      gap: 10px;
-      padding: 10px 10px;
-      border: 1px solid var(--border);
-      border-radius: 14px;
-      background: rgba(255,255,255,0.05);
-    }
-    .mini .k { font-weight: 900; }
-    .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
-    .mono.break { word-break: break-word; overflow-wrap: anywhere; }
-    .progress {
-      height: 12px;
-      border-radius: 999px;
-      background: rgba(255,255,255,0.10);
-      border: 1px solid var(--border);
-      overflow: hidden;
-      margin-top: 10px;
-    }
-    .bar {
-      height: 100%;
-      width: 0%;
-      background: linear-gradient(90deg, rgba(255,255,255,0.20), rgba(255,255,255,0.05), rgba(255,255,255,0.20));
-      background-size: 200% 100%;
-      animation: shimmer 1.6s ease-in-out infinite;
-    }
-    .bar.fill {
-      background: var(--accent);
-      animation: none;
-    }
-    @keyframes shimmer {
-      0% { background-position: 200% 0; }
-      100% { background-position: -200% 0; }
-    }
-    .skeleton {
-      height: 12px;
-      border-radius: 10px;
-      background: linear-gradient(90deg, rgba(255,255,255,0.08), rgba(255,255,255,0.16), rgba(255,255,255,0.08));
-      background-size: 200% 100%;
-      animation: shimmer 1.6s ease-in-out infinite;
-    }
-    @media (prefers-color-scheme: light) {
-      .skeleton {
-        background: linear-gradient(90deg, rgba(17,24,39,0.06), rgba(17,24,39,0.12), rgba(17,24,39,0.06));
-      }
-    }
-    .footer {
-      margin-top: 14px;
-      color: var(--muted);
-      font-size: 0.88rem;
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: space-between;
-      gap: 10px;
-    }
-    @media (prefers-reduced-motion: reduce) {
-      button, a.btn, .card, .bar, .skeleton { transition: none !important; animation: none !important; }
-    }
+    @keyframes fadeIn { from {opacity:0; transform:translateY(8px);} to {opacity:1; transform:none;} }
+    .fade-in { animation: fadeIn .35s ease both; }
+    @keyframes pulseSoft { 0%,100% { box-shadow:0 0 0 0 rgba(59,130,246,.2);} 50% { box-shadow:0 0 0 12px rgba(59,130,246,0);} }
+    .pulse-soft { animation: pulseSoft 2.4s ease-in-out infinite; }
+    @keyframes marqueeSlide { 0% { transform: translateX(8px); opacity:0;} 10%,90% { transform:translateX(0); opacity:1;} 100% { transform:translateX(-8px); opacity:0;} }
+    .tip-animate { animation: marqueeSlide 5s ease-in-out infinite; }
   </style>
 </head>
-<body>
-  <div class="wrap">
-    <div class="top">
-      <div class="top-inner">
-        <div>
-          <div class="brand"><span class="dot" id="overallDot"></span> Status Server</div>
-          <div class="meta">
-            <span class="pill"><span class="dot" id="netDot"></span><span id="netText">Mengecek koneksi...</span></span>
-            <span class="pill mono" id="updated">--:-- WIB</span>
-            <span class="pill mono" id="tz">TZ</span>
-          </div>
-          <div class="actions">
-            <button class="primary" id="refreshBtn">Refresh</button>
-            <button id="copyBtn">Salin status</button>
-            <button id="notifyBtn">Beri tahu saat online</button>
-            <button id="laterBtn">Cek lagi 5 menit</button>
-            <a class="btn" href="./" target="_blank" rel="noopener">Kembali</a>
-          </div>
+<body class="min-h-screen bg-slate-950 text-slate-100">
+  <main class="max-w-5xl mx-auto p-4 md:p-6 space-y-4">
+    <header class="rounded-2xl border border-slate-800 bg-slate-900 p-5 flex flex-wrap items-center justify-between gap-3 fade-in">
+      <div>
+        <h1 class="text-2xl font-extrabold">📡 YTConv Status Page</h1>
+        <p class="text-slate-400 text-sm">Realtime health, maintenance info, dan uptime server.</p>
+      </div>
+      <div class="flex gap-2 flex-wrap">
+        <span id="healthChip" class="px-3 py-2 rounded-lg bg-slate-800 text-sm">Memuat...</span>
+        <button id="refreshBtn" class="px-3 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-sm font-semibold">Refresh</button>
+      </div>
+    </header>
+
+    <section class="grid md:grid-cols-3 gap-3 fade-in">
+      <div class="rounded-2xl border border-slate-800 bg-slate-900 p-4"><div class="text-slate-400 text-sm">Server Time</div><div id="serverTime" class="font-bold mt-1">-</div></div>
+      <div class="rounded-2xl border border-slate-800 bg-slate-900 p-4"><div class="text-slate-400 text-sm">Uptime</div><div id="uptime" class="font-bold mt-1">-</div></div>
+      <div class="rounded-2xl border border-slate-800 bg-slate-900 p-4"><div class="text-slate-400 text-sm">Next Check</div><div id="nextTick" class="font-bold mt-1">-</div></div>
+    </section>
+
+    <section class="rounded-2xl border border-slate-800 bg-slate-900 p-5 space-y-4 fade-in">
+      <h2 class="text-lg font-bold">🔧 Maintenance Mode</h2>
+      <div id="maintenanceBox" class="rounded-xl border border-slate-700 bg-slate-950 p-4 text-slate-300">Memuat data maintenance...</div>
+      <div>
+        <div class="text-sm text-slate-400 mb-1">Progress</div>
+        <div class="w-full h-3 rounded-full bg-slate-800 overflow-hidden"><div id="progressBar" class="h-full w-0 bg-amber-500 transition-all duration-500"></div></div>
+      </div>
+      <div class="grid md:grid-cols-2 gap-3 text-sm">
+        <div class="rounded-xl border border-slate-700 bg-slate-950 p-3"><div class="text-slate-400">Detail</div><div id="maintDetail" class="mt-1">-</div></div>
+        <div class="rounded-xl border border-slate-700 bg-slate-950 p-3"><div class="text-slate-400">ETA Lokal User</div><div id="maintEta" class="mt-1">-</div></div>
+      </div>
+      <div class="rounded-xl border border-indigo-700/40 bg-indigo-500/10 p-3 pulse-soft">
+        <div class="text-xs text-indigo-300 uppercase tracking-wide">Live Tip</div>
+        <div id="liveTip" class="font-semibold tip-animate">Sambil menunggu maintenance, kamu bisa bookmark halaman ini agar update status lebih cepat.</div>
+      </div>
+      <div class="grid md:grid-cols-2 gap-3">
+        <div class="rounded-xl border border-slate-700 bg-slate-950 p-3">
+          <div class="font-semibold mb-2">🧭 Progress Steps</div>
+          <ul id="stepsList" class="space-y-2 text-sm"></ul>
+        </div>
+        <div class="rounded-xl border border-slate-700 bg-slate-950 p-3">
+          <div class="font-semibold mb-2">🧩 Service Status</div>
+          <div id="servicesGrid" class="grid grid-cols-1 gap-2 text-sm"></div>
         </div>
       </div>
+    </section>
+
+    <section class="rounded-2xl border border-slate-800 bg-slate-900 p-5 fade-in">
+      <h2 class="text-lg font-bold mb-3">✨ Visualized Response</h2>
+      <div id="visualSummary" class="grid md:grid-cols-3 gap-3 text-sm"></div>
+    </section>
+
+    <section class="rounded-2xl border border-slate-800 bg-slate-900 p-5 fade-in">
+      <h2 class="text-lg font-bold mb-3">📋 Raw Response</h2>
+      <details class="rounded-xl border border-slate-700 bg-slate-950 p-2" open>
+        <summary class="cursor-pointer text-sm text-slate-300 px-2 py-1">Tampilkan / sembunyikan JSON raw</summary>
+        <pre id="raw" class="text-xs whitespace-pre-wrap p-4 overflow-auto"></pre>
+      </details>
+    </section>
+  </main>
+
+<script>
+const fmt = new Intl.DateTimeFormat(undefined, { dateStyle:'full', timeStyle:'long' });
+let countdown = 20;
+let tipIdx = 0;
+const tips = [
+  'Tip: Saat maintenance aktif, hasil download lama tetap aman.',
+  'Tip: Kamu bisa refresh manual kapan saja dengan tombol Refresh.',
+  'Tip: Simpan page ini di bookmark supaya gampang cek update.',
+  'Tip: ETA dihitung berdasarkan zona waktu perangkat kamu.'
+];
+
+function formatDuration(sec){
+  if (!Number.isFinite(sec)) return '-';
+  const d = Math.floor(sec / 86400);
+  const h = Math.floor((sec % 86400) / 3600);
+  const m = Math.floor((sec % 3600) / 60);
+  const s = Math.floor(sec % 60);
+  return `${d ? d + 'h ' : ''}${h}j ${m}m ${s}d`;
+}
+
+async function loadStatus(){
+  countdown = 20;
+  const res = await fetch('/api/health?t=' + Date.now());
+  const data = await res.json().catch(() => ({}));
+  const maint = Boolean(data?.maintenance);
+  document.getElementById('healthChip').textContent = maint ? 'Maintenance Aktif' : 'Server Normal';
+  document.getElementById('healthChip').className = 'px-3 py-2 rounded-lg text-sm ' + (maint ? 'bg-amber-500/20 text-amber-300 border border-amber-500/30' : 'bg-emerald-500/20 text-emerald-300 border border-emerald-500/30');
+  document.getElementById('serverTime').textContent = fmt.format(new Date(data?.timestamp || Date.now()));
+  document.getElementById('uptime').textContent = formatDuration(Number(data?.uptime || 0));
+
+  const info = data?.maintenanceInfo || {};
+  document.getElementById('maintenanceBox').innerHTML = maint
+    ? `<div class="font-semibold text-amber-300">${info?.title || 'Maintenance sedang berjalan'}</div><div class="mt-1">${info?.description || 'Kami sedang melakukan peningkatan sistem.'}</div>`
+    : '<div class="font-semibold text-emerald-300">Tidak ada maintenance aktif.</div>';
+
+  const pct = Number.isFinite(Number(info?.progress)) ? Math.max(0, Math.min(100, Number(info.progress))) : 0;
+  document.getElementById('progressBar').style.width = `${pct}%`;
+  document.getElementById('maintDetail').textContent = info?.detail || '-';
+  document.getElementById('maintEta').textContent = info?.etaEndAt ? fmt.format(new Date(info.etaEndAt)) : (info?.etaSeconds ? `~ ${formatDuration(info.etaSeconds)}` : '-');
+  renderSteps(info?.steps);
+  renderServices(info?.services);
+  renderVisualSummary(data);
+  document.getElementById('raw').textContent = JSON.stringify(data, null, 2);
+}
+
+function renderSteps(steps){
+  const el = document.getElementById('stepsList');
+  const arr = Array.isArray(steps) ? steps : [];
+  if (!arr.length) {
+    el.innerHTML = '<li class=\"text-slate-400\">Belum ada langkah maintenance.</li>';
+    return;
+  }
+  el.innerHTML = arr.map((step) => {
+    const status = String(step?.status || 'pending').toLowerCase();
+    const style = status === 'in_progress'
+      ? 'border-amber-500/50 bg-amber-500/10 text-amber-200'
+      : status === 'completed'
+        ? 'border-emerald-500/50 bg-emerald-500/10 text-emerald-200'
+        : 'border-slate-600 bg-slate-800/60 text-slate-300';
+    return `<li class=\"rounded-lg border px-3 py-2 ${style}\"><div class=\"font-semibold\">${step?.text || '-'}</div><div class=\"text-xs opacity-80 mt-1\">${step?.detail || '-'}</div></li>`;
+  }).join('');
+}
+
+function renderServices(services){
+  const el = document.getElementById('servicesGrid');
+  const entries = services && typeof services === 'object' ? Object.entries(services) : [];
+  if (!entries.length) {
+    el.innerHTML = '<div class=\"text-slate-400\">Belum ada data service.</div>';
+    return;
+  }
+  el.innerHTML = entries.map(([name, value]) => {
+    const v = String(value || '').toLowerCase();
+    const cls = v.includes('maintenance') ? 'text-amber-300 border-amber-500/40 bg-amber-500/10' : v.includes('up') || v.includes('online') ? 'text-emerald-300 border-emerald-500/40 bg-emerald-500/10' : 'text-slate-300 border-slate-600 bg-slate-800/60';
+    return `<div class=\"rounded-lg border px-3 py-2 ${cls}\"><div class=\"font-semibold\">${name}</div><div class=\"text-xs mt-1\">${value}</div></div>`;
+  }).join('');
+}
+
+function renderVisualSummary(data){
+  const info = data?.maintenanceInfo || {};
+  const cards = [
+    ['Status', data?.maintenance ? 'Maintenance' : 'Online'],
+    ['Healthcheck Path', data?.healthcheckPath || '-'],
+    ['Maintenance ID', info?.id || '-'],
+    ['Progress', Number.isFinite(Number(info?.progress)) ? `${Number(info.progress)}%` : '-'],
+    ['Uptime', formatDuration(Number(data?.uptime || 0))],
+    ['Timestamp', fmt.format(new Date(data?.timestamp || Date.now()))],
+  ];
+  document.getElementById('visualSummary').innerHTML = cards.map(([k,v]) => `
+    <div class=\"rounded-xl border border-slate-700 bg-slate-950 p-3\">
+      <div class=\"text-xs text-slate-400 uppercase tracking-wide\">${k}</div>
+      <div class=\"font-semibold mt-1 break-words\">${v}</div>
     </div>
+  `).join('');
+}
 
-    <div class="grid">
-      <div class="card">
-        <div class="card-head">
-          <div>
-            <h1 id="headline">Memuat status...</h1>
-            <div class="card-sub" id="desc">Mengambil data dari /api/health.</div>
-          </div>
-          <div class="pill mono break" id="healthPath">/api/health</div>
-        </div>
-        <div class="progress"><div class="bar" id="progressBar"></div></div>
-        <div class="badges" id="serviceBadges">
-          <div class="badge"><span class="dot"></span><span class="skeleton" style="width: 180px;"></span></div>
-          <div class="badge"><span class="dot"></span><span class="skeleton" style="width: 160px;"></span></div>
-        </div>
+document.getElementById('refreshBtn').addEventListener('click', () => loadStatus().catch((e) => alert(e.message)));
+setInterval(() => {
+  countdown = Math.max(0, countdown - 1);
+  document.getElementById('nextTick').textContent = `${countdown} detik`;
+  if (countdown === 0) loadStatus().catch(() => {});
+}, 1000);
+setInterval(() => {
+  tipIdx = (tipIdx + 1) % tips.length;
+  const tipEl = document.getElementById('liveTip');
+  if (tipEl) tipEl.textContent = tips[tipIdx];
+}, 5000);
 
-        <div class="section" id="maintBlock" hidden>
-          <div class="section-title">
-            <span>Progress Detail</span>
-            <span class="mono break" id="maintId">MT-000000</span>
-          </div>
-          <ul class="list" id="maintSteps"></ul>
-          <div class="muted" id="etaHuman" style="margin-top:10px;"></div>
-        </div>
-
-        <div class="section" id="whatsNewBlock" hidden>
-          <div class="section-title"><span>Setelah Maintenance</span><span class="muted">what’s new</span></div>
-          <ul class="list" id="whatsNew"></ul>
-        </div>
-      </div>
-
-      <div class="card">
-        <div class="card-head">
-          <div>
-            <h1>Detail</h1>
-            <div class="card-sub">Ringkasan teknis yang gampang dipahami</div>
-          </div>
-          <div class="pill mono break" id="uptime">uptime</div>
-        </div>
-        <ul class="mini" id="detailList"></ul>
-        <div class="section">
-          <div class="section-title"><span>Data Kamu</span><span class="muted">aman</span></div>
-          <div class="muted"><b>Data kamu aman.</b> Maintenance tidak menghapus file, link, atau riwayat download.</div>
-        </div>
-        <div class="section">
-          <div class="section-title"><span>Kontak Darurat</span><span class="muted">support</span></div>
-          <div class="muted">Kalau maintenance lama atau ada kendala, hubungi: <a href="mailto:help.ytconv@proton.me">help.ytconv@proton.me</a></div>
-        </div>
-      </div>
-    </div>
-
-    <div class="footer">
-      <div>System version: <span class="mono" id="ver">v4.0 stable</span></div>
-      <div>Jika tampilan belum berubah setelah online, coba refresh (Ctrl + F5).</div>
-    </div>
-  </div>
-
-  <script>
-    const $ = (id) => document.getElementById(id);
-    const state = { data: null };
-    const APP_VERSION = 'v4.0 stable';
-    try { $('ver').textContent = APP_VERSION; } catch {}
-
-    const setDot = (cls) => {
-      const d = $('overallDot');
-      d.className = 'dot ' + cls;
-    };
-
-    const toWib = (ms) => {
-      try {
-        const d = new Date(ms);
-        return d.toLocaleTimeString('id-ID', { hour12: false, hour: '2-digit', minute: '2-digit' }) + ' WIB';
-      } catch {
-        return '--:-- WIB';
-      }
-    };
-
-    const badgeDot = (status) => {
-      const v = String(status || '').toLowerCase();
-      if (v.includes('ok') || v.includes('online') || v.includes('up')) return 'ok';
-      if (v.includes('warn') || v.includes('rate')) return 'warn';
-      if (v.includes('down') || v.includes('error') || v.includes('offline')) return 'bad';
-      if (v.includes('maint')) return 'warn';
-      return '';
-    };
-
-    const setNet = () => {
-      const netDot = $('netDot');
-      const netText = $('netText');
-      if (!netDot || !netText) return;
-      let warn = '';
-      try {
-        if (navigator && navigator.onLine === false) warn = 'Offline';
-      } catch {}
-      try {
-        const c = navigator && navigator.connection ? navigator.connection : null;
-        const et = c && typeof c.effectiveType === 'string' ? c.effectiveType : '';
-        const dl = c && typeof c.downlink === 'number' ? c.downlink : null;
-        if (!warn && (et === 'slow-2g' || et === '2g' || (dl != null && dl < 1.2))) warn = 'Koneksi tidak stabil';
-      } catch {}
-      if (warn) {
-        netDot.className = 'dot warn';
-        netText.textContent = warn;
-      } else {
-        netDot.className = 'dot ok';
-        netText.textContent = 'Koneksi OK';
-      }
-    };
-
-    const safeText = (v) => String(v ?? '').replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
-    const normalizeMaintId = (raw) => {
-      const s = String(raw ?? '').trim();
-      if (!s) return '';
-      const m = s.match(/MT-[0-9A-Za-z_-]{6,}/);
-      if (m && m[0]) return m[0];
-      return s.split(/\s+/)[0].slice(0, 40);
-    };
-
-    const renderSteps = (steps, pct) => {
-      const el = $('maintSteps');
-      if (!el) return;
-      const renderItem = (status, text, detail) => {
-        const s = status === 'done' || status === 'doing' || status === 'todo' ? status : 'todo';
-        const dotCls = s === 'done' ? 'ok' : (s === 'doing' ? 'warn' : '');
-        const dot = `<span class="dot ${dotCls}"></span>`;
-        return `<li>${dot}<div><div class="k">${safeText(text)}</div>${detail ? `<div class="muted">${safeText(detail)}</div>` : ''}</div></li>`;
-      };
-      if (Array.isArray(steps) && steps.length) {
-        el.innerHTML = steps.slice(0, 7).map((s) => renderItem(String(s?.status || 'todo'), s?.text || s?.title || 'Task', s?.detail || s?.sub || '')).join('');
-        return;
-      }
-      const p = Number.isFinite(Number(pct)) ? Number(pct) : 45;
-      const s1 = p >= 30 ? 'done' : 'doing';
-      const s2 = p >= 70 ? 'done' : (p >= 30 ? 'doing' : 'todo');
-      const s3 = p >= 100 ? 'done' : (p >= 70 ? 'doing' : 'todo');
-      el.innerHTML = [
-        renderItem(s1, 'Database backup', s1 === 'done' ? 'Selesai' : 'Berjalan'),
-        renderItem(s2, 'Optimasi server', s2 === 'done' ? 'Selesai' : (s2 === 'doing' ? 'Berjalan' : 'Menunggu')),
-        renderItem(s3, 'Deploy rilis baru', s3 === 'done' ? 'Selesai' : (s3 === 'doing' ? 'Berjalan' : 'Menunggu')),
-      ].join('');
-    };
-
-    const renderWhatsNew = (wn) => {
-      const el = $('whatsNew');
-      if (!el) return;
-      const items = Array.isArray(wn) && wn.length ? wn.slice(0, 7) : ['⚡ Download lebih cepat', '🧠 Error converter dikurangi', '📱 Tampilan mobile lebih ringan'];
-      el.innerHTML = items.map((t) => `<li><span class="dot ok"></span><div class="k">${safeText(t)}</div></li>`).join('');
-    };
-
-    const render = (data) => {
-      state.data = data;
-      const now = Date.now();
-      $('updated').textContent = toWib(now);
-      $('tz').textContent = Intl.DateTimeFormat().resolvedOptions().timeZone || 'Timezone';
-      setNet();
-
-      const maint = Boolean(data && data.maintenance);
-      if (maint) {
-        setDot('warn');
-        $('headline').textContent = 'Maintenance (sedang berlangsung)';
-        const info = data.maintenanceInfo || {};
-        $('desc').textContent = String(info.description || 'Kami lagi ngerapihin sistem biar layanan lebih cepat dan stabil.');
-        const pct = Number.isFinite(Number(info.progress)) ? Math.max(0, Math.min(100, Number(info.progress))) : null;
-        const bar = $('progressBar');
-        if (pct == null) {
-          bar.className = 'bar';
-          bar.style.width = '100%';
-        } else {
-          bar.className = 'bar fill';
-          bar.style.width = pct + '%';
-        }
-
-        try { $('healthPath').textContent = String(data.healthcheckPath || '/api/health'); } catch {}
-        try { $('maintBlock').hidden = false; } catch {}
-        try { $('whatsNewBlock').hidden = false; } catch {}
-        try { $('maintId').textContent = normalizeMaintId(info.id || ('MT-' + new Date().toISOString().slice(0,10).replaceAll('-',''))); } catch {}
-        renderSteps(info.steps, pct);
-        renderWhatsNew(info.whatsNew);
-        try {
-          const eta = $('etaHuman');
-          if (eta) {
-            const endAtMs = Number.isFinite(Number(info.etaEndAt)) ? Number(info.etaEndAt) : null;
-            if (endAtMs) {
-              eta.textContent = `Estimasi selesai sekitar ${toWib(endAtMs)}. Biasanya selesai lebih cepat kalau tidak ada kendala.`;
-            } else {
-              eta.textContent = 'Kami usahakan online sebelum estimasi. Progress akan terus diperbarui.';
-            }
-          }
-        } catch {}
-      } else {
-        setDot('ok');
-        $('headline').textContent = 'Online';
-        $('desc').textContent = 'Semua layanan utama berjalan.';
-        const bar = $('progressBar');
-        bar.className = 'bar fill';
-        bar.style.width = '100%';
-        try { $('healthPath').textContent = String(data.healthcheckPath || '/api/health'); } catch {}
-        try { $('maintBlock').hidden = true; } catch {}
-        try { $('whatsNewBlock').hidden = true; } catch {}
-      }
-
-      const badges = $('serviceBadges');
-      badges.innerHTML = '';
-      const info = (data && data.maintenanceInfo) ? data.maintenanceInfo : {};
-      const services = info && info.services ? info.services : null;
-      const items = Array.isArray(services) ? services : (services && typeof services === 'object' ? Object.entries(services).map(([name, status]) => ({ name, status })) : null);
-      (items || []).slice(0, 10).forEach((it) => {
-        const dotCls = badgeDot(it.status);
-        const el = document.createElement('div');
-        el.className = 'badge';
-        el.innerHTML = `<span class="dot ${dotCls}"></span><span>${it.name}: <span class="mono">${it.status}</span></span>`;
-        badges.appendChild(el);
-      });
-      if (!items || !items.length) {
-        const el = document.createElement('div');
-        el.className = 'badge';
-        el.innerHTML = `<span class="dot ${maint ? 'warn' : 'ok'}"></span><span>Server: <span class="mono">${maint ? 'Maintenance' : 'Online'}</span></span>`;
-        badges.appendChild(el);
-      }
-
-      const list = $('detailList');
-      const out = [];
-      out.push(['Healthcheck', data && data.healthcheckPath ? data.healthcheckPath : '/api/health']);
-      out.push(['Uptime', data && typeof data.uptime === 'number' ? Math.round(data.uptime) + 's' : '-']);
-      out.push(['Start', data && data.startTime ? toWib(data.startTime) : '-']);
-      if (maint) {
-        const id = normalizeMaintId(info && info.id ? info.id : '');
-        if (id) out.push(['Maintenance ID', id]);
-        if (info && info.detail) out.push(['Status', info.detail]);
-        if (Number.isFinite(Number(info.etaEndAt))) out.push(['Estimasi selesai', toWib(Number(info.etaEndAt))]);
-      }
-      list.innerHTML = out.map(([k, v]) => `<li><div class="k">${k}</div><div class="mono muted">${String(v)}</div></li>`).join('');
-      try {
-        const u = $('uptime');
-        if (u) u.textContent = data && typeof data.uptime === 'number' ? `uptime ${Math.round(data.uptime)}s` : 'uptime';
-      } catch {}
-    };
-
-    const notifyOnline = () => {
-      try { localStorage.setItem('maint_notify_online', '1'); } catch {}
-      if (!('Notification' in window)) return;
-      if (Notification.permission === 'granted') return;
-      if (Notification.permission === 'denied') return;
-      Notification.requestPermission().catch(() => {});
-    };
-
-    const maybeFireNotify = (data) => {
-      try {
-        const wants = localStorage.getItem('maint_notify_online') === '1';
-        if (!wants) return;
-        if (data && data.maintenance === false) {
-          localStorage.removeItem('maint_notify_online');
-          const title = 'Server sudah online';
-          const body = 'Maintenance selesai. Kamu bisa coba lagi sekarang.';
-          if ('Notification' in window && Notification.permission === 'granted') {
-            try { new Notification(title, { body }); } catch {}
-          } else {
-            alert(title + '\n' + body);
-          }
-        }
-      } catch {}
-    };
-
-    const fetchHealth = async () => {
-      const res = await fetch('/api/health?t=' + Date.now(), { cache: 'no-store' });
-      if (!res.ok) throw new Error('HTTP ' + res.status);
-      const data = await res.json();
-      render(data);
-      maybeFireNotify(data);
-    };
-
-    $('refreshBtn').addEventListener('click', () => {
-      $('refreshBtn').disabled = true;
-      fetchHealth().catch(() => {}).finally(() => { try { $('refreshBtn').disabled = false; } catch {} });
-    });
-    $('notifyBtn').addEventListener('click', () => notifyOnline());
-    $('laterBtn').addEventListener('click', () => {
-      try { $('laterBtn').disabled = true; } catch {}
-      setTimeout(() => { try { location.reload(); } catch {} }, 5 * 60 * 1000);
-    });
-    $('copyBtn').addEventListener('click', async () => {
-      const d = state.data || {};
-      const info = d.maintenanceInfo || {};
-      const text = [
-        'Status Server',
-        `Maintenance: ${d.maintenance ? 'YA' : 'TIDAK'}`,
-        info.id ? `Maintenance ID: ${info.id}` : '',
-        info.detail ? `Detail: ${info.detail}` : '',
-        Number.isFinite(Number(info.progress)) ? `Progress: ${info.progress}%` : '',
-        Number.isFinite(Number(info.etaEndAt)) ? `Estimasi selesai: ${toWib(Number(info.etaEndAt))}` : '',
-        `URL: ${location.href}`,
-      ].filter(Boolean).join('\n');
-      try {
-        if (navigator.clipboard && navigator.clipboard.writeText) await navigator.clipboard.writeText(text);
-        else alert(text);
-      } catch {
-        alert(text);
-      }
-    });
-
-    setInterval(() => fetchHealth().catch(() => {}), 10000);
-    fetchHealth().catch(() => {
-      setDot('bad');
-      $('headline').textContent = 'Tidak bisa memuat status';
-      $('desc').textContent = 'Coba refresh atau cek koneksi internet.';
-      $('progressBar').style.width = '100%';
-      setNet();
-    });
-  </script>
+loadStatus().catch((e) => { document.getElementById('raw').textContent = String(e?.message || e); });
+</script>
 </body>
 </html>

--- a/public-ui/ticket-status.html
+++ b/public-ui/ticket-status.html
@@ -1,0 +1,99 @@
+<!doctype html>
+<html lang="id">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Status Tiket • YTConv</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="min-h-screen bg-slate-950 text-slate-100">
+  <main class="max-w-3xl mx-auto p-4 md:p-6 space-y-4">
+    <section class="rounded-2xl border border-slate-800 bg-slate-900 p-5">
+      <div class="flex items-start justify-between gap-4">
+        <div>
+          <h1 class="text-2xl font-extrabold">🔎 Tracking Status Tiket</h1>
+          <p id="hint" class="text-sm text-slate-400 mt-1"></p>
+        </div>
+        <a href="/" class="text-sm px-3 py-2 rounded-lg bg-slate-800 hover:bg-slate-700">Kembali</a>
+      </div>
+      <div class="grid sm:grid-cols-2 gap-3 mt-4">
+        <div class="rounded-xl border border-slate-700 bg-slate-950 p-3"><div class="text-xs text-slate-400">ID Tiket</div><div id="tid" class="font-bold text-lg">-</div></div>
+        <div class="rounded-xl border border-slate-700 bg-slate-950 p-3"><div class="text-xs text-slate-400">Status</div><div id="statusWrap" class="mt-1"></div></div>
+      </div>
+      <div class="mt-3 text-sm text-slate-400">Terakhir update: <span id="updated">-</span></div>
+    </section>
+
+    <section class="rounded-2xl border border-slate-800 bg-slate-900 p-5 space-y-4">
+      <div>
+        <div class="font-semibold mb-1">💬 Pesan User</div>
+        <div id="msg" class="rounded-xl border border-slate-700 bg-slate-950 p-3 text-slate-300 whitespace-pre-wrap">-</div>
+      </div>
+      <div>
+        <div class="font-semibold mb-1">🧑‍💼 Balasan Admin</div>
+        <div id="reply" class="rounded-xl border border-slate-700 bg-slate-950 p-3 text-slate-300 whitespace-pre-wrap">Belum ada balasan admin.</div>
+      </div>
+      <div>
+        <div class="font-semibold mb-2">🕒 Riwayat Status</div>
+        <ul id="history" class="space-y-2"></ul>
+      </div>
+    </section>
+  </main>
+<script>
+const query = new URLSearchParams(location.search);
+const queryTicketId = (query.get('ticket_id') || query.get('id') || '').trim().toUpperCase();
+const pathParts = location.pathname.split('/').filter(Boolean);
+const routeTicketId = pathParts[0] === 'ticket' && pathParts[1] ? String(pathParts[1]).trim().toUpperCase() : '';
+const ticketId = queryTicketId || routeTicketId;
+const fmt = new Intl.DateTimeFormat(undefined, { dateStyle:'full', timeStyle:'medium' });
+
+const statusColor = (st) => ({ received:'bg-blue-500/20 text-blue-300 border-blue-500/40', reviewing:'bg-amber-500/20 text-amber-300 border-amber-500/40', waiting_user:'bg-purple-500/20 text-purple-300 border-purple-500/40', resolved:'bg-emerald-500/20 text-emerald-300 border-emerald-500/40', rejected:'bg-rose-500/20 text-rose-300 border-rose-500/40' }[st] || 'bg-slate-700 text-slate-100 border-slate-500');
+const badge = (label, st) => `<span class="inline-flex px-2.5 py-1 rounded-full border text-sm font-semibold ${statusColor(st)}">${label || '-'}</span>`;
+
+const tidEl = document.getElementById('tid');
+const statusWrap = document.getElementById('statusWrap');
+const updatedEl = document.getElementById('updated');
+const msgEl = document.getElementById('msg');
+const replyEl = document.getElementById('reply');
+const historyEl = document.getElementById('history');
+const hintEl = document.getElementById('hint');
+
+tidEl.textContent = ticketId || '-';
+if (!queryTicketId && routeTicketId) hintEl.textContent = `Mode kompatibilitas aktif dari route lama /ticket/${routeTicketId}`;
+else if (!ticketId) hintEl.textContent = 'Tambahkan ?ticket_id=TKT-XXXX di URL untuk cek status tiket kamu.';
+
+function asLocal(iso){
+  if (!iso) return '-';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return fmt.format(d);
+}
+
+async function refresh(){
+  if (!ticketId) return;
+  try {
+    const r = await fetch(`/api/ticket/${encodeURIComponent(ticketId)}`);
+    const d = await r.json().catch(() => ({}));
+    if (!r.ok || !d.ok) throw new Error(d.error || 'ticket_not_found');
+    const t = d.ticket || {};
+    statusWrap.innerHTML = badge(t.statusLabel || t.status, t.status);
+    updatedEl.textContent = asLocal(t.statusUpdatedAt);
+    msgEl.textContent = t.message || '-';
+    replyEl.textContent = t.adminReply || 'Belum ada balasan admin.';
+    historyEl.innerHTML = '';
+    (t.statusHistory || []).slice().reverse().forEach((x) => {
+      const li = document.createElement('li');
+      li.className = 'rounded-xl border border-slate-700 bg-slate-950 p-3';
+      li.innerHTML = `<div class="flex items-center justify-between gap-2"><div>${badge(x.label || x.status, x.status)}</div><div class="text-xs text-slate-500">${asLocal(x.at)}</div></div>${x.note ? `<div class="text-sm text-slate-300 mt-1">${x.note}</div>` : ''}`;
+      historyEl.appendChild(li);
+    });
+  } catch (e) {
+    statusWrap.innerHTML = badge('Tiket tidak ditemukan', 'rejected');
+    replyEl.textContent = e.message || 'unknown_error';
+  }
+}
+
+refresh();
+setInterval(refresh, 5000);
+</script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a built-in customer support flow so users can submit tickets, receive auto-replies, and allow admins to manage tickets from the app. 
- Improve admin operations by adding token-based admin endpoints and a modern admin UI for cookies, tickets and realtime stats. 
- Harden forum moderation, enhance AI assistant/customer-service behavior, and add UX improvements across the public UI (preview protections, metadata auto-fill, cloud saves). 

### Description
- Enhanced AI/assistant prompts and behavior by updating the `systemPrompt` and assistant instructions to act as a Customer Service Navigator and support `open_ticket` actions. 
- Added a lightweight ticketing backend: new `supportTickets` Map, `sendSupportEmail` helper, Cloudinary attachment uploads in `/api/contact`, and richer JSON response including `statusLink` and `fileLinks`. 
- Added admin authentication helpers and endpoints: `isAdminBearerValid`, `/admin/login`, `/admin/upload-cookies`, `/api/admin/tickets`, `/api/admin/stats`, and `PATCH /api/admin/tickets/:ticketId` for status updates and admin replies. 
- Exposed ticket lookup and moderation endpoints: `GET /api/ticket/:ticketId` and `POST /api/forum/moderation-report`, plus socket-level forum moderation changes to auto-ban on violations and emit appeals which now trigger email notifications. 
- UI additions and overhauls: redesigned `public-ui/admin-cookies.html`, added `public-ui/admin-dashboard.html`, `public-ui/admin-tickets.html`, and `public-ui/ticket-status.html` for admin and user-facing ticket workflows. 
- Large client-side feature work in `public-ui/index.html`: smart auto-metadata toggle, preview protections (`controlslist`, `disablepictureinpicture`, `oncontextmenu`), multi-server selector, crossfade/gapless playback options, playback controls (seek, speed), plan chooser and Cloudinary save integration, EmailJS + local ticket creation flow that posts to `/api/contact` and shows an inline success card, plus history/cloud-only filtering. 
- Miscellaneous: improved `/api/health` maintenance info (`detail` fallback to commit message envs), support email config via `SUPPORT_CONTACT_EMAIL`, and added friendly error mapping for conversion errors. 

### Testing
- No automated tests were added or executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7f6108450832f9153c1bb79f0540b)