### PR TITLE
Add forum appeal pipeline and admin appeal management (AI Navigator integration)

### DIFF
--- a/index.js
+++ b/index.js
@@ -3677,6 +3677,7 @@ const ASSISTANT_TOPICS = [
 
 const buildAssistantResponse = async (prompt, history = [], clientState = {}) => {
   const raw = typeof prompt === "string" ? prompt.trim() : String(prompt ?? "").trim();
+  const lowerRaw = raw.toLowerCase();
   if (!raw) {
     return {
       reply: "Hai! Mau bantuan convert video?",
@@ -3696,6 +3697,26 @@ const buildAssistantResponse = async (prompt, history = [], clientState = {}) =>
     return {
       reply: "**FAQ**: **M4A** tercepat, **MP3** universal, **FLAC** studio.",
       suggestions: ["Format", "Trim", "Cookies"],
+    };
+  }
+
+  if (
+    /(appeal|banding|diban|di ban|keban|kena ban|forum diblokir|forum dikunci)/i.test(lowerRaw) ||
+    /(saya mau appeal|mau appeal|ajukan appeal)/i.test(lowerRaw)
+  ) {
+    const forumState = clientState?.forum || {};
+    const violationCount = Number(forumState?.violationCount || 0);
+    const disabledFeatures = Array.isArray(forumState?.disabledFeatures) ? forumState.disabledFeatures : [];
+    const hasForumBlockSignal = violationCount >= 5 || disabledFeatures.length > 0 || Boolean(forumState?.forumDisabled);
+    return {
+      reply: hasForumBlockSignal
+        ? "Siap, aku proses appeal kamu sekarang dan kirim ke admin dashboard. Mohon tunggu, aku akan sertakan data akun, socket, dan fitur yang terblokir."
+        : "Siap, aku bantu kirim appeal. Kalau forum kamu memang diblokir, appeal akan langsung masuk ke admin dashboard untuk direview.",
+      suggestions: ["Tulis alasan singkat", "Cek status appeal", "Buat tiket tambahan"],
+      action: "submit_forum_appeal",
+      params: {
+        reason: raw,
+      },
     };
   }
 
@@ -3795,7 +3816,6 @@ Kontak darurat: forumwargaytmp3@gmail.com (atau tombol Email Bantuan di footer, 
       "halo": "**Halo!** Ready to convert! **Kirim URLnya!**"
     };
 
-    const lowerRaw = raw.toLowerCase();
     let reply = "**Hai!** Mau convert video? **Kirim URLnya!**";
 
     for (const [key, value] of Object.entries(fallbackResponses)) {
@@ -8220,6 +8240,7 @@ const controlState = {
 };
 const retentionUsers = new Map();
 const apiRouteStats = new Map();
+const forumAppeals = new Map();
 const abMetrics = {
   A: { started: 0, success: 0 },
   B: { started: 0, success: 0 },
@@ -8250,6 +8271,76 @@ const INDONESIAN_BADWORDS = [
 
 
 const SUPPORT_CONTACT_EMAIL = process.env.SUPPORT_CONTACT_EMAIL || "forumwargaytmp3@gmail.com";
+
+const buildAppealId = () => `APL-${Date.now().toString(36).toUpperCase().slice(-8)}`;
+
+const submitForumAppeal = async ({
+  source = "unknown",
+  userId = "",
+  name = "Warga",
+  email = "",
+  room = "umum",
+  reason = "",
+  socketId = "",
+  disabledFeatures = [],
+  metadata = {},
+} = {}) => {
+  const appealId = buildAppealId();
+  const submittedAt = new Date().toISOString();
+  const normalizedDisabled = Array.isArray(disabledFeatures)
+    ? disabledFeatures.map((x) => String(x || "").trim()).filter(Boolean).slice(0, 12)
+    : [];
+  const appeal = {
+    appealId,
+    source,
+    userId: String(userId || "").slice(0, 120),
+    name: String(name || "Warga").slice(0, 120),
+    email: String(email || "").slice(0, 240),
+    room: String(room || "umum").slice(0, 60),
+    reason: String(reason || "").slice(0, 2400),
+    socketId: String(socketId || "").slice(0, 120),
+    disabledFeatures: normalizedDisabled,
+    metadata: metadata && typeof metadata === "object" ? metadata : {},
+    status: "pending",
+    statusLabel: "Pending",
+    submittedAt,
+    updatedAt: submittedAt,
+    reviewedAt: null,
+    reviewedBy: "",
+    reviewNote: "",
+  };
+  forumAppeals.set(appealId, appeal);
+  pushActivityLog("forum_appeal_submitted", `Forum appeal ${appealId} dibuat`, {
+    appealId,
+    userId: appeal.userId,
+    source,
+  });
+  io.emit("admin:appealCreated", {
+    appealId,
+    submittedAt,
+    userId: appeal.userId,
+    name: appeal.name,
+    status: appeal.status,
+    source,
+  });
+
+  const appealLines = [
+    "=== Forum Appeal Request ===",
+    `Appeal ID : ${appeal.appealId}`,
+    `Source    : ${appeal.source}`,
+    `User ID   : ${appeal.userId || "-"}`,
+    `Name      : ${appeal.name || "-"}`,
+    `Email     : ${appeal.email || "-"}`,
+    `Room      : ${appeal.room || "-"}`,
+    `Socket ID : ${appeal.socketId || "-"}`,
+    `Disabled  : ${appeal.disabledFeatures.join(", ") || "-"}`,
+    `Reason    : ${appeal.reason || "-"}`,
+    `Time      : ${appeal.submittedAt}`,
+    "SLA       : 2x24 jam",
+  ];
+  await sendSupportEmail({ subject: `[Forum Appeal] ${appeal.appealId}`, lines: appealLines });
+  return appeal;
+};
 
 const sendSupportEmail = async ({ subject, lines = [], html = null, to = SUPPORT_CONTACT_EMAIL }) => {
   const transport = getMailTransport();
@@ -8509,6 +8600,56 @@ app.post('/api/forum/moderation-report', async (req, res) => {
   }
 });
 
+app.post("/api/forum/appeal", express.json({ limit: "512kb" }), async (req, res) => {
+  try {
+    const body = req.body || {};
+    const userId = String(body.userId || "").trim();
+    const reason = String(body.reason || body.message || "").trim();
+    if (!userId) return res.status(400).json({ ok: false, error: "user_id_required" });
+    if (!reason) return res.status(400).json({ ok: false, error: "reason_required" });
+
+    const violationRec = userViolations.get(userId);
+    const blockedByServer = Boolean(violationRec?.banned);
+    const disabledFeatures = Array.isArray(body.disabledFeatures) ? body.disabledFeatures : [];
+    const blockedByClient = disabledFeatures.length > 0 || Number(body.violationCount || 0) >= 5;
+
+    if (!blockedByServer && !blockedByClient) {
+      return res.status(400).json({
+        ok: false,
+        error: "not_blocked",
+        message: "Status blocked belum terdeteksi dari server/client.",
+      });
+    }
+
+    const appeal = await submitForumAppeal({
+      source: "ai_navigator",
+      userId,
+      name: body.name || "Warga",
+      email: body.email || "",
+      room: body.room || "umum",
+      reason,
+      socketId: body.socketId || "",
+      disabledFeatures,
+      metadata: {
+        violationCount: Number(body.violationCount || 0),
+        googleAccount: body.googleAccount || null,
+        blockedByServer,
+        blockedByClient,
+      },
+    });
+    return res.json({
+      ok: true,
+      appealId: appeal.appealId,
+      status: appeal.status,
+      submittedAt: appeal.submittedAt,
+      message: `✅ Appeal ${appeal.appealId} berhasil dikirim ke admin dashboard.`,
+    });
+  } catch (e) {
+    console.error("[/api/forum/appeal error]", e);
+    return res.status(500).json({ ok: false, error: e?.message || "appeal_failed" });
+  }
+});
+
 app.get("/api/ticket/:ticketId", (req, res) => {
   const ticketId = String(req.params.ticketId || "").trim().toUpperCase();
   if (!ticketId) return res.status(400).json({ ok: false, error: "ticket_id_invalid" });
@@ -8554,6 +8695,42 @@ app.get("/api/admin/tickets", (req, res) => {
   return res.json({ ok: true, tickets: items });
 });
 
+app.get("/api/admin/appeals", (req, res) => {
+  if (!isAdminBearerValid(req)) return res.status(401).json({ ok: false, error: "unauthorized" });
+  const appeals = Array.from(forumAppeals.values())
+    .sort((a, b) => String(b.submittedAt || "").localeCompare(String(a.submittedAt || "")));
+  return res.json({ ok: true, appeals });
+});
+
+app.patch("/api/admin/appeals/:appealId", express.json({ limit: "256kb" }), (req, res) => {
+  if (!isAdminBearerValid(req)) return res.status(401).json({ ok: false, error: "unauthorized" });
+  const appealId = String(req.params.appealId || "").trim().toUpperCase();
+  const appeal = forumAppeals.get(appealId);
+  if (!appeal) return res.status(404).json({ ok: false, error: "appeal_not_found" });
+  const status = String(req.body?.status || "").trim().toLowerCase();
+  if (!["accepted", "rejected", "pending"].includes(status)) {
+    return res.status(400).json({ ok: false, error: "invalid_status" });
+  }
+  const statusLabelMap = { accepted: "Diterima", rejected: "Ditolak", pending: "Pending" };
+  appeal.status = status;
+  appeal.statusLabel = statusLabelMap[status] || status;
+  appeal.reviewNote = String(req.body?.reviewNote || "").slice(0, 1200);
+  appeal.reviewedBy = String(req.body?.reviewedBy || "admin").slice(0, 120);
+  appeal.reviewedAt = status === "pending" ? null : new Date().toISOString();
+  appeal.updatedAt = new Date().toISOString();
+  forumAppeals.set(appealId, appeal);
+  pushActivityLog("forum_appeal_updated", `Appeal ${appealId} -> ${appeal.statusLabel}`, {
+    appealId,
+    status: appeal.status,
+  });
+  io.emit("admin:appealUpdated", {
+    appealId,
+    status: appeal.status,
+    statusLabel: appeal.statusLabel,
+  });
+  return res.json({ ok: true, appeal });
+});
+
 app.get("/api/admin/stats", (req, res) => {
   if (!isAdminBearerValid(req)) return res.status(401).json({ ok: false, error: "unauthorized" });
   const now = new Date();
@@ -8596,6 +8773,21 @@ app.get("/api/admin/stats", (req, res) => {
   })).sort((a, b) => b.hits - a.hits).slice(0, 20);
   const returningUsers = Array.from(retentionUsers.values()).filter((u) => Number(u.sessions || 0) > 1).length;
   const newUsers = Math.max(0, retentionUsers.size - returningUsers);
+  const appeals = Array.from(forumAppeals.values()).sort((a, b) => String(b.submittedAt || "").localeCompare(String(a.submittedAt || "")));
+  const appealsByStatus = appeals.reduce((acc, item) => {
+    const key = String(item?.status || "pending");
+    acc[key] = (acc[key] || 0) + 1;
+    return acc;
+  }, {});
+  const blockedForumUsers = Array.from(userViolations.values()).filter((x) => x?.banned).length;
+  const disabledFeatureUsage = {};
+  appeals.forEach((a) => {
+    (a.disabledFeatures || []).forEach((f) => {
+      const key = String(f || "").trim();
+      if (!key) return;
+      disabledFeatureUsage[key] = (disabledFeatureUsage[key] || 0) + 1;
+    });
+  });
   const successRate = conversionMetrics.started ? (conversionMetrics.success / conversionMetrics.started) * 100 : 0;
   const predictedNextHourUsers = Number(((conversionMetrics.entered / Math.max(1, process.uptime() / 3600))).toFixed(0));
   const smartInsights = [];
@@ -8679,6 +8871,15 @@ app.get("/api/admin/stats", (req, res) => {
       totalUsers: retentionUsers.size,
       newUsers,
       returningUsers,
+    },
+    appeals: {
+      total: appeals.length,
+      byStatus: appealsByStatus,
+      all: appeals.slice(0, 200),
+    },
+    moderation: {
+      blockedForumUsers,
+      disabledFeatureUsage,
     },
     abTesting: abMetrics,
     smartInsights,
@@ -9113,22 +9314,21 @@ io.on("connection", (socket) => {
     if (!from) return;
     const rec = userViolations.get(from.userId);
     if (rec?.banned) {
-      const appealId = 'APL-' + Date.now().toString(36).toUpperCase().slice(-8);
-      const submittedAt = new Date().toISOString();
-      console.warn(`[Forum Appeal] userId=${from.userId} name=${from.name} appealId=${appealId} submittedAt=${submittedAt}`);
-      const appealLines = [
-        '=== Forum Appeal Request ===',
-        `Appeal ID : ${appealId}`,
-        `User ID   : ${from.userId}`,
-        `Name      : ${from.name}`,
-        `Room      : ${from.room || 'umum'}`,
-        `Time      : ${submittedAt}`,
-        'SLA       : 2x24 jam',
-      ];
-      await sendSupportEmail({ subject: `[Forum Appeal] ${appealId}`, lines: appealLines });
+      const appeal = await submitForumAppeal({
+        source: "forum_socket",
+        userId: from.userId,
+        name: from.name,
+        room: from.room || "umum",
+        reason: String(payload?.reason || "Appeal via forum socket"),
+        socketId: socket.id,
+        metadata: {
+          bannedByServer: true,
+          violationCount: Number(rec?.count || 0),
+        },
+      });
       socket.emit("forum:appealSubmitted", {
-        appealId,
-        message: `✅ Appeal kamu (${appealId}) telah diterima! Tim akan mereview dalam 2x24 jam. Notifikasi juga dikirim ke ${SUPPORT_CONTACT_EMAIL}.`
+        appealId: appeal.appealId,
+        message: `✅ Appeal kamu (${appeal.appealId}) telah diterima! Tim akan mereview dalam 2x24 jam. Notifikasi juga dikirim ke ${SUPPORT_CONTACT_EMAIL}.`
       });
     }
   });

--- a/public-ui/admin-dashboard.html
+++ b/public-ui/admin-dashboard.html
@@ -209,6 +209,24 @@
       <h2 class="font-bold mb-2">🧾 Activity Log (Audit Trail)</h2>
       <ul id="activityLogs" class="max-h-48 overflow-auto text-xs space-y-1"></ul>
     </section>
+
+    <section class="rounded-2xl border border-slate-800 bg-slate-900 p-4">
+      <div class="flex items-center justify-between gap-2 mb-2">
+        <h2 class="font-bold">⚖️ Forum Appeal (Prioritas)</h2>
+        <button id="refreshAppealsBtn" class="px-2 py-1 rounded bg-indigo-600 text-xs">Refresh Appeal</button>
+      </div>
+      <div class="text-xs text-slate-400 mb-2">Appeal dari AI Navigator/forum akan masuk ke sini dan bisa di-accept/reject.</div>
+      <div id="appealSummary" class="text-sm mb-2">Pending: 0 • Diterima: 0 • Ditolak: 0</div>
+      <div class="overflow-auto rounded-xl border border-slate-800">
+        <table class="min-w-full text-xs">
+          <thead class="bg-slate-800/80 text-slate-300">
+            <tr><th class="text-left p-2">Appeal ID</th><th class="text-left p-2">User</th><th class="text-left p-2">Socket</th><th class="text-left p-2">Fitur Disabled</th><th class="text-left p-2">Reason</th><th class="text-left p-2">Status</th><th class="text-left p-2">Aksi</th></tr>
+          </thead>
+          <tbody id="appealRows"></tbody>
+        </table>
+      </div>
+      <div class="mt-2 text-xs text-slate-400" id="disabledFeatureStats">-</div>
+    </section>
   </main>
 
 <script>
@@ -219,7 +237,7 @@ const getToken=()=> (localStorage.getItem(TOKEN_KEY)||'').trim();
 const setToken=(v)=> localStorage.setItem(TOKEN_KEY,v||'');
 const formatBytes=(n)=>`${(Number(n||0)/(1024*1024)).toFixed(2)} MB`;
 const formatUptime=(sec=0)=>`${Math.floor(sec/3600)}j ${Math.floor((sec%3600)/60)}m ${Math.floor(sec%60)}d`;
-let state={allTickets:[],filteredTickets:[],currentTicket:null,unread:0,lineChart:null,pieChart:null,alerts:[],lastSnapshot:null,latestUsers:[]};
+let state={allTickets:[],filteredTickets:[],currentTicket:null,unread:0,lineChart:null,pieChart:null,alerts:[],lastSnapshot:null,latestUsers:[],appeals:[]};
 let socket=null;
 
 const toast=(m,type='info')=>{const n=document.createElement('div');n.className=`px-3 py-2 rounded-lg border text-sm shadow ${type==='error'?'bg-rose-950 border-rose-700':type==='warn'?'bg-amber-950 border-amber-700':'bg-slate-900 border-slate-700'}`;n.textContent=m;el('toastWrap').appendChild(n);setTimeout(()=>n.remove(),3800);};
@@ -287,11 +305,16 @@ function renderAdvanced(data){
   el('geoStats').innerHTML=Object.entries(geoCounts).map(([k,v])=>`<li>${k}: <b>${v}</b></li>`).join('')||'<li>-</li>';
   el('apiStats').innerHTML=(data.apiMonitoring||[]).map((a)=>`<li class="border border-slate-800 rounded p-1">${a.route}<br>hits:${a.hits} • err:${a.errors} • avg:${a.avgMs}ms</li>`).join('')||'<li>-</li>';
   el('activityLogs').innerHTML=(data.activityLogs||[]).map((l)=>`<li class="rounded border border-slate-800 bg-slate-950 p-2">${l.type}: ${l.message}<div class="text-[10px] text-slate-400">${fmt.format(new Date(l.at))}</div></li>`).join('')||'<li>-</li>';
+  const disabledStats=data.moderation?.disabledFeatureUsage||{};
+  const disabledText=Object.entries(disabledStats).map(([k,v])=>`${k}:${v}`).join(' • ');
+  el('disabledFeatureStats').textContent=`Blocked user: ${data.moderation?.blockedForumUsers||0} • Disabled feature usage: ${disabledText||'-'}`;
   el('toggleConvertBtn').textContent=(data.control?.convertEnabled ? 'Disable Convert Sementara' : 'Enable Convert Lagi');
   evaluateAlerts(data);
 }
 
-async function loadStats(){const token=getToken();if(!token)return;const res=await fetch('/api/admin/stats',{headers:{Authorization:`Bearer ${token}`}});const data=await res.json().catch(()=>({}));if(!res.ok||!data.ok){el('authState').textContent='Token invalid';return;}el('authState').textContent=`Aktif • ${fmt.format(new Date(data.timestamp))}`;state.allTickets=data.tickets?.all||[];renderMetrics(data);updateCharts(data);renderLive(data);renderAdvanced(data);applyFilters();}
+function renderAppeals(){const items=state.appeals||[];const by={pending:0,accepted:0,rejected:0};items.forEach((a)=>{if(by[a.status]!==undefined)by[a.status]+=1;});el('appealSummary').textContent=`Pending: ${by.pending||0} • Diterima: ${by.accepted||0} • Ditolak: ${by.rejected||0}`;el('appealRows').innerHTML=items.map((a)=>`<tr class="border-t border-slate-800"><td class="p-2 font-semibold">${a.appealId}</td><td class="p-2">${(a.name||'-').replace(/</g,'&lt;')}<div class="text-[10px] text-slate-400">${(a.userId||'-').replace(/</g,'&lt;')}</div></td><td class="p-2">${(a.socketId||'-').replace(/</g,'&lt;')}</td><td class="p-2">${(a.disabledFeatures||[]).join(', ')||'-'}</td><td class="p-2">${(a.reason||'-').replace(/</g,'&lt;')}</td><td class="p-2">${a.statusLabel||a.status||'-'}</td><td class="p-2"><div class="flex gap-1"><button data-appeal="${a.appealId}" data-status="accepted" class="px-2 py-1 rounded bg-emerald-600 text-[10px]">Accept</button><button data-appeal="${a.appealId}" data-status="rejected" class="px-2 py-1 rounded bg-rose-600 text-[10px]">Reject</button></div></td></tr>`).join('')||'<tr><td class="p-2 text-slate-400" colspan="7">Belum ada appeal masuk.</td></tr>';}
+
+async function loadStats(){const token=getToken();if(!token)return;const res=await fetch('/api/admin/stats',{headers:{Authorization:`Bearer ${token}`}});const data=await res.json().catch(()=>({}));if(!res.ok||!data.ok){el('authState').textContent='Token invalid';return;}el('authState').textContent=`Aktif • ${fmt.format(new Date(data.timestamp))}`;state.allTickets=data.tickets?.all||[];state.appeals=data.appeals?.all||[];renderMetrics(data);updateCharts(data);renderLive(data);renderAdvanced(data);renderAppeals();applyFilters();}
 
 function renderChatHistory(items){el('chatHistory').innerHTML=items.map((c)=>`<div class="text-xs rounded p-2 ${c.sender==='admin'?'bg-indigo-900/50 border border-indigo-700':'bg-slate-900 border border-slate-700'}"><div class="text-slate-400 mb-1">${c.sender||'system'} • ${c.at?fmt.format(new Date(c.at)):'-'}</div><div>${(c.message||'').replace(/</g,'&lt;')}</div></div>`).join('')||'<div class="text-slate-500 text-xs">Belum ada chat.</div>';const adminCount=items.filter((x)=>x?.sender==='admin').length;const remain=Math.max(0,3-adminCount);el('chatLimitHint').textContent=`Sisa chat admin: ${remain}`;el('chatInput').disabled=remain<=0;el('chatHistory').scrollTop=el('chatHistory').scrollHeight;}
 
@@ -301,14 +324,16 @@ async function sendChat(evt){evt.preventDefault();if(!state.currentTicket)return
 
 function exportExcel(){const rows=state.filteredTickets.map((t)=>({ID:t.ticketId,Nama:t.name,Email:t.email,Kategori:t.category,Status:t.statusLabel||t.status,SubmittedAt:t.submittedAt}));const ws=XLSX.utils.json_to_sheet(rows);const wb=XLSX.utils.book_new();XLSX.utils.book_append_sheet(wb,ws,'Tickets');XLSX.writeFile(wb,`tickets-${Date.now()}.xlsx`);}
 
-function initSocket(){if(socket)return;socket=io({transports:['websocket','polling']});socket.on('connect',()=>socket.emit('page_change',{page:'/admin/dashboard'}));socket.on('dashboard_stats',(payload)=>renderLive({live:{...payload,conversion:payload.conversion||{}}}));socket.on('admin:newTicket',(payload)=>{setBadge(state.unread+1);toast(`Ticket baru: ${payload.ticketId}`);playNotif();loadStats().catch(()=>{});});socket.on('admin:ticketUpdated',()=>loadStats().catch(()=>{}));socket.on('admin:ticketChat',(payload)=>{if(state.currentTicket?.ticketId===payload.ticketId){state.currentTicket.chatHistory=[...(state.currentTicket.chatHistory||[]),payload.chat];renderChatHistory(state.currentTicket.chatHistory||[]);}toast(`Chat baru di ${payload.ticketId}`);playNotif();});socket.on('admin:controlUpdated',()=>loadStats().catch(()=>{}));}
+function initSocket(){if(socket)return;socket=io({transports:['websocket','polling']});socket.on('connect',()=>socket.emit('page_change',{page:'/admin/dashboard'}));socket.on('dashboard_stats',(payload)=>renderLive({live:{...payload,conversion:payload.conversion||{}}}));socket.on('admin:newTicket',(payload)=>{setBadge(state.unread+1);toast(`Ticket baru: ${payload.ticketId}`);playNotif();loadStats().catch(()=>{});});socket.on('admin:ticketUpdated',()=>loadStats().catch(()=>{}));socket.on('admin:ticketChat',(payload)=>{if(state.currentTicket?.ticketId===payload.ticketId){state.currentTicket.chatHistory=[...(state.currentTicket.chatHistory||[]),payload.chat];renderChatHistory(state.currentTicket.chatHistory||[]);}toast(`Chat baru di ${payload.ticketId}`);playNotif();});socket.on('admin:controlUpdated',()=>loadStats().catch(()=>{}));socket.on('admin:appealCreated',(payload)=>{toast(`Appeal baru: ${payload.appealId}`);playNotif();loadStats().catch(()=>{});});socket.on('admin:appealUpdated',()=>loadStats().catch(()=>{}));}
 
 async function control(action,extra={}){const token=getToken();const r=await fetch('/api/admin/control',{method:'POST',headers:{'Content-Type':'application/json',Authorization:`Bearer ${token}`},body:JSON.stringify({action,...extra})});const d=await r.json().catch(()=>({}));if(!r.ok||!d.ok)return toast(d.error||'Control gagal','error');toast(`Action ${action} berhasil`);loadStats().catch(()=>{});}
+async function updateAppeal(appealId,status){const token=getToken();const r=await fetch(`/api/admin/appeals/${encodeURIComponent(appealId)}`,{method:'PATCH',headers:{'Content-Type':'application/json',Authorization:`Bearer ${token}`},body:JSON.stringify({status,reviewedBy:'admin_dashboard'})});const d=await r.json().catch(()=>({}));if(!r.ok||!d.ok)return toast(d.error||'Update appeal gagal','error');toast(`Appeal ${appealId} -> ${status}`);loadStats().catch(()=>{});}
 
 async function login(evt){evt.preventDefault();const res=await fetch('/admin/login',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({username:el('username').value,password:el('password').value})});const data=await res.json().catch(()=>({}));if(!res.ok||!data.ok||!data.token)return toast('Login gagal','error');setToken(data.token);el('authState').textContent='Login aktif';toast('Login berhasil');await loadStats();initSocket();}
 
 el('loginForm').addEventListener('submit',login);el('refreshBtn').addEventListener('click',()=>loadStats().catch(()=>{}));el('closeDetailBtn').addEventListener('click',()=>el('detailPanel').classList.add('hidden'));el('chatForm').addEventListener('submit',sendChat);el('exportBtn').addEventListener('click',exportExcel);['searchId','filterStatus','filterCategory','filterDate'].forEach((id)=>el(id).addEventListener('input',applyFilters));el('ticketRows').addEventListener('click',(evt)=>{const btn=evt.target.closest('button[data-open]');if(!btn)return;openDetail(btn.getAttribute('data-open'));});el('adminTicketsBtn').addEventListener('click',()=>setBadge(0));
 el('toggleConvertBtn').addEventListener('click',()=>control('toggle_convert'));el('clearQueueBtn').addEventListener('click',()=>control('clear_queue'));el('kickUserBtn').addEventListener('click',()=>control('kick_user',{socketId:el('kickSocketId').value.trim()}));
+el('refreshAppealsBtn').addEventListener('click',()=>loadStats().catch(()=>{}));el('appealRows').addEventListener('click',(evt)=>{const btn=evt.target.closest('button[data-appeal]');if(!btn)return;updateAppeal(btn.getAttribute('data-appeal'),btn.getAttribute('data-status'));});
 el('themeBtn').addEventListener('click',()=>{document.body.classList.toggle('bg-slate-950');document.body.classList.toggle('bg-slate-100');document.body.classList.toggle('text-slate-100');document.body.classList.toggle('text-slate-900');});
 el('replayBtn').addEventListener('click',()=>{const sid=el('replaySocketId').value.trim();const user=state.latestUsers.find((u)=>u.socketId===sid);const timeline=Array.isArray(user?.actions)?user.actions:[];el('replayTimeline').innerHTML=timeline.map((a)=>`<li class=\"border border-slate-800 rounded p-1\">${a.action}${a.detail?` — ${a.detail}`:''}<div class=\"text-[10px] text-slate-500\">${fmt.format(new Date(a.at))}</div></li>`).join('')||'<li class=\"text-slate-500\">Timeline kosong / socket tidak ditemukan.</li>';});
 el('exportPngBtn').addEventListener('click',async()=>{const canvas=await html2canvas(document.querySelector('main'));const a=document.createElement('a');a.href=canvas.toDataURL('image/png');a.download=`dashboard-${Date.now()}.png`;a.click();});

--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -18159,7 +18159,22 @@
                 clientState: {
                   preferences: state.preferences,
                   experience: state.experience,
-                  mode: localStorage.getItem('ytmp3_mode_pref') || 'advanced'
+                  mode: localStorage.getItem('ytmp3_mode_pref') || 'advanced',
+                  auth: {
+                    uid: currentUser?.uid || '',
+                    email: currentUser?.email || '',
+                    name: currentUser?.displayName || 'Warga',
+                  },
+                  forum: {
+                    room: activeForumRoom || 'umum',
+                    socketId: ensureForumSocket?.()?.id || '',
+                    violationCount: Number(getForumViolationCount?.() || 0),
+                    forumDisabled: Boolean(getForumViolationCount?.() >= FORUM_VIOLATION_LIMIT),
+                    disabledFeatures: [
+                      ...(getForumViolationCount?.() >= FORUM_VIOLATION_LIMIT ? ['forum_chat_input_disabled'] : []),
+                      ...(forumSendBtn?.disabled ? ['forum_send_button_disabled'] : []),
+                    ],
+                  },
                 }
               }),
             });
@@ -18204,6 +18219,48 @@
                   window.bootstrap.Modal.getOrCreateInstance(modalEl).show();
                 }
                 reply += '\n\nSaya sudah siapkan form tiket bantuan. Silakan cek data lalu kirim ya.';
+              }
+
+              if (data.action === 'submit_forum_appeal') {
+                const uid = currentUser?.uid || '';
+                if (!uid) {
+                  reply += '\n\nUntuk kirim appeal, login Google dulu ya.';
+                } else {
+                  const disabledFeatures = [
+                    ...(getForumViolationCount?.() >= FORUM_VIOLATION_LIMIT ? ['forum_chat_input_disabled'] : []),
+                    ...(forumSendBtn?.disabled ? ['forum_send_button_disabled'] : []),
+                  ];
+                  try {
+                    const appealResp = await fetch('/api/forum/appeal', {
+                      method: 'POST',
+                      headers: { 'Content-Type': 'application/json' },
+                      body: JSON.stringify({
+                        userId: uid,
+                        name: currentUser?.displayName || 'Warga',
+                        email: currentUser?.email || '',
+                        room: activeForumRoom || 'umum',
+                        socketId: ensureForumSocket?.()?.id || '',
+                        reason: data?.params?.reason || text,
+                        violationCount: Number(getForumViolationCount?.() || 0),
+                        disabledFeatures,
+                        googleAccount: {
+                          provider: 'google',
+                          uid: uid,
+                          email: currentUser?.email || '',
+                        },
+                      }),
+                    });
+                    const appealData = await appealResp.json().catch(() => ({}));
+                    if (appealResp.ok && appealData?.appealId) {
+                      reply += `\n\n${appealData.message || `✅ Appeal ${appealData.appealId} sudah masuk dashboard admin.`}`;
+                    } else {
+                      reply += `\n\n❌ Gagal kirim appeal: ${appealData?.message || appealData?.error || 'unknown_error'}`;
+                    }
+                  } catch (appealErr) {
+                    reply += '\n\n❌ Gagal kirim appeal ke admin dashboard.';
+                    console.error('Gagal submit appeal AI Navigator', appealErr);
+                  }
+                }
               }
             }
           } catch (err) {


### PR DESCRIPTION
### Motivation

- Provide a reliable appeal flow so users can submit forum appeals (from AI Navigator or socket) that are tracked and reviewed by admins. 
- Surface appeal + moderation telemetry in the admin dashboard so operators can act quickly and see which features were disabled per-account. 

### Description

- Backend: add a normalized appeal store `forumAppeals`, helper `submitForumAppeal`, and email/ activity-log + realtime notifications via socket (`admin:appealCreated`, `admin:appealUpdated`).
- API: add `POST /api/forum/appeal` for AI Navigator submissions and admin endpoints `GET /api/admin/appeals` and `PATCH /api/admin/appeals/:appealId` to list and update appeals. 
- AI Navigator: detect appeal intent in `buildAssistantResponse` and return action `submit_forum_appeal`; frontend sends richer `clientState.forum` (including `violationCount`, `socketId`, `disabledFeatures`) and will POST to `/api/forum/appeal` when the assistant requests it. 
- Admin UI: add a "Forum Appeal (Prioritas)" panel in `public-ui/admin-dashboard.html` with summary, table, Accept/Reject controls, refresh, and live updates from socket; `GET /api/admin/stats` now includes `appeals` and `moderation` telemetry (counts, blocked users, disabled-feature aggregation). 

### Testing

- Ran `node --check index.js` which completed successfully. 
- Ran `node --check support_store.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6664db540832f95ba99de77db9d91)