### PR TITLE
Forum appeal workflow, session replay & admin UI; GROQ key fallback and client control_state

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,9 +94,13 @@ const TURNSTILE_STRICT = /^(1|true|yes|on)$/i.test(String(process.env.TURNSTILE_
 const isTurnstileConfigured = Boolean(TURNSTILE_SECRET_KEY && TURNSTILE_SITE_KEY);
 const YOUTUBE_API_KEY = (process.env.YOUTUBE_API_KEY || "").trim();
 const isYoutubeApiConfigured = Boolean(YOUTUBE_API_KEY);
-const GROQ_API_KEY = (process.env.GROQ_API_KEY || "").trim();
+const GROQ_API_KEYS = [
+  process.env.GROQ_API_KEY,
+  process.env.GROQ_API_KEY_FALLBACK,
+].map((x) => String(x || "").trim()).filter(Boolean);
+const GROQ_API_KEY = GROQ_API_KEYS[0] || "";
 const GROQ_MODEL = process.env.GROQ_MODEL || "llama-3.3-70b-versatile";
-const isGroqConfigured = Boolean(GROQ_API_KEY);
+const isGroqConfigured = GROQ_API_KEYS.length > 0;
 const COOKIES_PATH = join(process.cwd(), "cookies.txt");
 const SAWERIA_STREAM_KEY = (process.env.SAWERIA_STREAM_KEY || "").trim();
 
@@ -689,39 +693,45 @@ Jika percakapan biasa/edukasi/diagnosa:
     { role: "user", content: prompt }
   ];
 
-  try {
-    const response = await safeFetch("https://api.groq.com/openai/v1/chat/completions", {
-      method: "POST",
-      headers: {
-        "Authorization": "Bearer " + GROQ_API_KEY,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        model: GROQ_MODEL,
-        messages: messages,
-        temperature: 0.7,
-        max_tokens: 500,
-        response_format: { type: "json_object" }
-      }),
-    });
-
-    if (!response.ok) {
-      const error = await response.text();
-      throw new Error(`Groq API error: ${response.status} - ${error}`);
-    }
-
-    const data = await response.json();
-    const content = data.choices?.[0]?.message?.content || "{}";
-
+  let lastError = null;
+  for (let idx = 0; idx < GROQ_API_KEYS.length; idx += 1) {
+    const apiKey = GROQ_API_KEYS[idx];
     try {
-      return JSON.parse(content);
-    } catch (e) {
-      return { reply: content };
+      const response = await safeFetch("https://api.groq.com/openai/v1/chat/completions", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model: GROQ_MODEL,
+          messages,
+          temperature: 0.7,
+          max_tokens: 500,
+          response_format: { type: "json_object" }
+        }),
+      });
+
+      if (!response.ok) {
+        const error = await response.text();
+        throw new Error(`Groq API error: ${response.status} - ${error}`);
+      }
+
+      const data = await response.json();
+      const content = data.choices?.[0]?.message?.content || "{}";
+
+      try {
+        return JSON.parse(content);
+      } catch {
+        return { reply: content };
+      }
+    } catch (error) {
+      lastError = error;
+      const usingFallback = idx > 0;
+      console.error(`[Groq API] Error${usingFallback ? " (fallback key)" : ""}:`, error?.message || error);
     }
-  } catch (error) {
-    console.error("[Groq API] Error:", error);
-    throw error;
   }
+  throw lastError || new Error("Groq API request failed");
 };
 
 let turnstileWarningLogged = false;
@@ -3677,6 +3687,7 @@ const ASSISTANT_TOPICS = [
 
 const buildAssistantResponse = async (prompt, history = [], clientState = {}) => {
   const raw = typeof prompt === "string" ? prompt.trim() : String(prompt ?? "").trim();
+  const lowerRaw = raw.toLowerCase();
   if (!raw) {
     return {
       reply: "Hai! Mau bantuan convert video?",
@@ -3696,6 +3707,43 @@ const buildAssistantResponse = async (prompt, history = [], clientState = {}) =>
     return {
       reply: "**FAQ**: **M4A** tercepat, **MP3** universal, **FLAC** studio.",
       suggestions: ["Format", "Trim", "Cookies"],
+    };
+  }
+
+  if (/^\/?appeal(\s+.*)?$/i.test(raw)) {
+    const reason = raw.replace(/^\/?appeal\s*/i, "").trim() || "Saya mau appeal ban forum.";
+    return {
+      reply: "Sip, aku bantu kirim appeal kamu ke admin dashboard sekarang.",
+      suggestions: ["Cek status appeal", "Tambahkan alasan detail", "Buka tiket bantuan"],
+      action: "submit_forum_appeal",
+      params: { reason },
+    };
+  }
+
+  if (
+    /(appeal|banding|diban|di ban|keban|kena ban|forum diblokir|forum dikunci)/i.test(lowerRaw) ||
+    /(saya mau appeal|mau appeal|ajukan appeal)/i.test(lowerRaw)
+  ) {
+    const forumState = clientState?.forum || {};
+    const violationCount = Number(forumState?.violationCount || 0);
+    const disabledFeatures = Array.isArray(forumState?.disabledFeatures) ? forumState.disabledFeatures : [];
+    const hasForumBlockSignal = violationCount >= 5 || disabledFeatures.length > 0 || Boolean(forumState?.forumDisabled);
+    return {
+      reply: hasForumBlockSignal
+        ? "Siap, aku proses appeal kamu sekarang dan kirim ke admin dashboard. Mohon tunggu, aku akan sertakan data akun, socket, dan fitur yang terblokir."
+        : "Siap, aku bantu kirim appeal. Kalau forum kamu memang diblokir, appeal akan langsung masuk ke admin dashboard untuk direview.",
+      suggestions: ["Tulis alasan singkat", "Cek status appeal", "Buat tiket tambahan"],
+      action: "submit_forum_appeal",
+      params: {
+        reason: raw,
+      },
+    };
+  }
+
+  if (clientState?.forum?.forumDisabled && /(forum|chat|tidak bisa chat|gabisa chat|ga bisa chat)/i.test(lowerRaw)) {
+    return {
+      reply: "Kayaknya akun kamu memang lagi keblokir buat chat forum. Coba ketik **/appeal alasan kamu** biar langsung aku kirim ke admin dashboard.",
+      suggestions: ["/appeal saya tidak sengaja", "Buka tiket bantuan", "Cek status forum"],
     };
   }
 
@@ -3795,7 +3843,6 @@ Kontak darurat: forumwargaytmp3@gmail.com (atau tombol Email Bantuan di footer, 
       "halo": "**Halo!** Ready to convert! **Kirim URLnya!**"
     };
 
-    const lowerRaw = raw.toLowerCase();
     let reply = "**Hai!** Mau convert video? **Kirim URLnya!**";
 
     for (const [key, value] of Object.entries(fallbackResponses)) {
@@ -8220,6 +8267,7 @@ const controlState = {
 };
 const retentionUsers = new Map();
 const apiRouteStats = new Map();
+const forumAppeals = new Map();
 const abMetrics = {
   A: { started: 0, success: 0 },
   B: { started: 0, success: 0 },
@@ -8250,6 +8298,76 @@ const INDONESIAN_BADWORDS = [
 
 
 const SUPPORT_CONTACT_EMAIL = process.env.SUPPORT_CONTACT_EMAIL || "forumwargaytmp3@gmail.com";
+
+const buildAppealId = () => `APL-${Date.now().toString(36).toUpperCase().slice(-8)}`;
+
+const submitForumAppeal = async ({
+  source = "unknown",
+  userId = "",
+  name = "Warga",
+  email = "",
+  room = "umum",
+  reason = "",
+  socketId = "",
+  disabledFeatures = [],
+  metadata = {},
+} = {}) => {
+  const appealId = buildAppealId();
+  const submittedAt = new Date().toISOString();
+  const normalizedDisabled = Array.isArray(disabledFeatures)
+    ? disabledFeatures.map((x) => String(x || "").trim()).filter(Boolean).slice(0, 12)
+    : [];
+  const appeal = {
+    appealId,
+    source,
+    userId: String(userId || "").slice(0, 120),
+    name: String(name || "Warga").slice(0, 120),
+    email: String(email || "").slice(0, 240),
+    room: String(room || "umum").slice(0, 60),
+    reason: String(reason || "").slice(0, 2400),
+    socketId: String(socketId || "").slice(0, 120),
+    disabledFeatures: normalizedDisabled,
+    metadata: metadata && typeof metadata === "object" ? metadata : {},
+    status: "pending",
+    statusLabel: "Pending",
+    submittedAt,
+    updatedAt: submittedAt,
+    reviewedAt: null,
+    reviewedBy: "",
+    reviewNote: "",
+  };
+  forumAppeals.set(appealId, appeal);
+  pushActivityLog("forum_appeal_submitted", `Forum appeal ${appealId} dibuat`, {
+    appealId,
+    userId: appeal.userId,
+    source,
+  });
+  io.emit("admin:appealCreated", {
+    appealId,
+    submittedAt,
+    userId: appeal.userId,
+    name: appeal.name,
+    status: appeal.status,
+    source,
+  });
+
+  const appealLines = [
+    "=== Forum Appeal Request ===",
+    `Appeal ID : ${appeal.appealId}`,
+    `Source    : ${appeal.source}`,
+    `User ID   : ${appeal.userId || "-"}`,
+    `Name      : ${appeal.name || "-"}`,
+    `Email     : ${appeal.email || "-"}`,
+    `Room      : ${appeal.room || "-"}`,
+    `Socket ID : ${appeal.socketId || "-"}`,
+    `Disabled  : ${appeal.disabledFeatures.join(", ") || "-"}`,
+    `Reason    : ${appeal.reason || "-"}`,
+    `Time      : ${appeal.submittedAt}`,
+    "SLA       : 2x24 jam",
+  ];
+  await sendSupportEmail({ subject: `[Forum Appeal] ${appeal.appealId}`, lines: appealLines });
+  return appeal;
+};
 
 const sendSupportEmail = async ({ subject, lines = [], html = null, to = SUPPORT_CONTACT_EMAIL }) => {
   const transport = getMailTransport();
@@ -8509,6 +8627,53 @@ app.post('/api/forum/moderation-report', async (req, res) => {
   }
 });
 
+app.post("/api/forum/appeal", express.json({ limit: "512kb" }), async (req, res) => {
+  try {
+    const body = req.body || {};
+    const userId = String(body.userId || "").trim();
+    const reason = String(body.reason || body.message || "").trim();
+    if (!userId) return res.status(400).json({ ok: false, error: "user_id_required" });
+    if (!reason) return res.status(400).json({ ok: false, error: "reason_required" });
+
+    const violationRec = userViolations.get(userId);
+    const blockedByServer = Boolean(violationRec?.banned);
+    const disabledFeatures = Array.isArray(body.disabledFeatures) ? body.disabledFeatures : [];
+    const blockedByClient = disabledFeatures.length > 0 || Number(body.violationCount || 0) >= 5;
+
+    const blockedSignalDetected = blockedByServer || blockedByClient;
+
+    const appeal = await submitForumAppeal({
+      source: "ai_navigator",
+      userId,
+      name: body.name || "Warga",
+      email: body.email || "",
+      room: body.room || "umum",
+      reason,
+      socketId: body.socketId || "",
+      disabledFeatures,
+      metadata: {
+        violationCount: Number(body.violationCount || 0),
+        googleAccount: body.googleAccount || null,
+        blockedByServer,
+        blockedByClient,
+        blockedSignalDetected,
+      },
+    });
+    return res.json({
+      ok: true,
+      appealId: appeal.appealId,
+      status: appeal.status,
+      submittedAt: appeal.submittedAt,
+      message: blockedSignalDetected
+        ? `✅ Appeal ${appeal.appealId} berhasil dikirim ke admin dashboard.`
+        : `✅ Appeal ${appeal.appealId} tetap dikirim ke admin dashboard (status block belum terverifikasi otomatis).`,
+    });
+  } catch (e) {
+    console.error("[/api/forum/appeal error]", e);
+    return res.status(500).json({ ok: false, error: e?.message || "appeal_failed" });
+  }
+});
+
 app.get("/api/ticket/:ticketId", (req, res) => {
   const ticketId = String(req.params.ticketId || "").trim().toUpperCase();
   if (!ticketId) return res.status(400).json({ ok: false, error: "ticket_id_invalid" });
@@ -8554,6 +8719,66 @@ app.get("/api/admin/tickets", (req, res) => {
   return res.json({ ok: true, tickets: items });
 });
 
+app.get("/api/admin/appeals", (req, res) => {
+  if (!isAdminBearerValid(req)) return res.status(401).json({ ok: false, error: "unauthorized" });
+  const appeals = Array.from(forumAppeals.values())
+    .sort((a, b) => String(b.submittedAt || "").localeCompare(String(a.submittedAt || "")));
+  return res.json({ ok: true, appeals });
+});
+
+app.patch("/api/admin/appeals/:appealId", express.json({ limit: "256kb" }), (req, res) => {
+  if (!isAdminBearerValid(req)) return res.status(401).json({ ok: false, error: "unauthorized" });
+  const appealId = String(req.params.appealId || "").trim().toUpperCase();
+  const appeal = forumAppeals.get(appealId);
+  if (!appeal) return res.status(404).json({ ok: false, error: "appeal_not_found" });
+  const status = String(req.body?.status || "").trim().toLowerCase();
+  if (!["accepted", "rejected", "pending"].includes(status)) {
+    return res.status(400).json({ ok: false, error: "invalid_status" });
+  }
+  const statusLabelMap = { accepted: "Diterima", rejected: "Ditolak", pending: "Pending" };
+  appeal.status = status;
+  appeal.statusLabel = statusLabelMap[status] || status;
+  appeal.reviewNote = String(req.body?.reviewNote || "").slice(0, 1200);
+  appeal.reviewedBy = String(req.body?.reviewedBy || "admin").slice(0, 120);
+  appeal.reviewedAt = status === "pending" ? null : new Date().toISOString();
+  appeal.updatedAt = new Date().toISOString();
+  forumAppeals.set(appealId, appeal);
+  pushActivityLog("forum_appeal_updated", `Appeal ${appealId} -> ${appeal.statusLabel}`, {
+    appealId,
+    status: appeal.status,
+  });
+  io.emit("admin:appealUpdated", {
+    appealId,
+    status: appeal.status,
+    statusLabel: appeal.statusLabel,
+  });
+  return res.json({ ok: true, appeal });
+});
+
+app.get("/api/admin/session-replay/:socketId", (req, res) => {
+  if (!isAdminBearerValid(req)) return res.status(401).json({ ok: false, error: "unauthorized" });
+  const socketId = String(req.params.socketId || "").trim();
+  if (!socketId) return res.status(400).json({ ok: false, error: "socket_id_required" });
+  const live = activeUsers.get(socketId);
+  if (live) upsertSessionReplay(socketId, live);
+  const replay = sessionReplayStore.get(socketId);
+  if (!replay) return res.status(404).json({ ok: false, error: "session_not_found" });
+  return res.json({
+    ok: true,
+    replay: {
+      socketId: replay.socketId,
+      connectedAt: replay.connectedAt || null,
+      disconnectedAt: replay.disconnectedAt || null,
+      page: replay.page || "unknown",
+      room: replay.room || null,
+      status: replay.status || "idle",
+      userAgent: replay.userAgent || "",
+      geo: replay.geo || { country: "unknown", city: "unknown" },
+      actions: Array.isArray(replay.actions) ? replay.actions : [],
+    },
+  });
+});
+
 app.get("/api/admin/stats", (req, res) => {
   if (!isAdminBearerValid(req)) return res.status(401).json({ ok: false, error: "unauthorized" });
   const now = new Date();
@@ -8596,6 +8821,21 @@ app.get("/api/admin/stats", (req, res) => {
   })).sort((a, b) => b.hits - a.hits).slice(0, 20);
   const returningUsers = Array.from(retentionUsers.values()).filter((u) => Number(u.sessions || 0) > 1).length;
   const newUsers = Math.max(0, retentionUsers.size - returningUsers);
+  const appeals = Array.from(forumAppeals.values()).sort((a, b) => String(b.submittedAt || "").localeCompare(String(a.submittedAt || "")));
+  const appealsByStatus = appeals.reduce((acc, item) => {
+    const key = String(item?.status || "pending");
+    acc[key] = (acc[key] || 0) + 1;
+    return acc;
+  }, {});
+  const blockedForumUsers = Array.from(userViolations.values()).filter((x) => x?.banned).length;
+  const disabledFeatureUsage = {};
+  appeals.forEach((a) => {
+    (a.disabledFeatures || []).forEach((f) => {
+      const key = String(f || "").trim();
+      if (!key) return;
+      disabledFeatureUsage[key] = (disabledFeatureUsage[key] || 0) + 1;
+    });
+  });
   const successRate = conversionMetrics.started ? (conversionMetrics.success / conversionMetrics.started) * 100 : 0;
   const predictedNextHourUsers = Number(((conversionMetrics.entered / Math.max(1, process.uptime() / 3600))).toFixed(0));
   const smartInsights = [];
@@ -8679,6 +8919,16 @@ app.get("/api/admin/stats", (req, res) => {
       totalUsers: retentionUsers.size,
       newUsers,
       returningUsers,
+    },
+    appeals: {
+      total: appeals.length,
+      byStatus: appealsByStatus,
+      all: appeals.slice(0, 200),
+    },
+    moderation: {
+      blockedForumUsers,
+      disabledFeatureUsage,
+      storedSessionReplay: sessionReplayStore.size,
     },
     abTesting: abMetrics,
     smartInsights,
@@ -8819,6 +9069,7 @@ app.post("/api/admin/control", express.json({ limit: "128kb" }), (req, res) => {
   }
   pushActivityLog("admin_control", `Control action: ${action}`, { action });
   io.emit("admin:controlUpdated", { ...controlState });
+  io.emit("control_state", { ...controlState, updatedAt: new Date().toISOString() });
   emitDashboardStats();
   return res.json({ ok: true, control: { ...controlState } });
 });
@@ -8851,6 +9102,8 @@ const io = new SocketIOServer(httpServer, {
 const roomUsers = new Map();
 const socketState = new Map();
 const activeUsers = new Map();
+const sessionReplayStore = new Map();
+const MAX_SESSION_REPLAY = 300;
 
 const getLiveBreakdown = (field) => {
   const result = {};
@@ -8880,12 +9133,41 @@ const getLiveUsers = () => Array.from(activeUsers.entries()).map(([socketId, use
   journey: Array.isArray(user.journey) ? user.journey.join(" → ") : "",
   actions: Array.isArray(user.actionTrail) ? user.actionTrail : [],
   clientId: user.clientId || "",
+  userId: user.userId || "",
+  userEmail: user.userEmail || "",
   abVariant: user.abVariant || "A",
   geo: user.geo || { country: "unknown", city: "unknown" },
   userAgent: user.userAgent || "",
   connectedAt: user.connectedAt || null,
   lastSeenAt: user.lastSeenAt || null,
 }));
+
+const upsertSessionReplay = (socketId, user = null, extras = {}) => {
+  if (!socketId) return;
+  const prev = sessionReplayStore.get(socketId) || {
+    socketId,
+    connectedAt: new Date().toISOString(),
+    disconnectedAt: null,
+    page: "unknown",
+    room: null,
+    status: "idle",
+    userAgent: "",
+    geo: { country: "unknown", city: "unknown" },
+    actions: [],
+  };
+  const next = {
+    ...prev,
+    ...(user || {}),
+    ...extras,
+    socketId,
+    actions: Array.isArray(user?.actionTrail) ? user.actionTrail.slice(-120) : (prev.actions || []),
+  };
+  sessionReplayStore.set(socketId, next);
+  if (sessionReplayStore.size > MAX_SESSION_REPLAY) {
+    const oldestKey = sessionReplayStore.keys().next().value;
+    if (oldestKey) sessionReplayStore.delete(oldestKey);
+  }
+};
 
 const emitDashboardStats = () => {
   io.emit("dashboard_stats", {
@@ -8912,6 +9194,7 @@ const broadcastRoomUsers = (room) => {
 };
 
 io.on("connection", (socket) => {
+  socket.emit("control_state", { ...controlState, updatedAt: new Date().toISOString() });
   activeUsers.set(socket.id, {
     page: "unknown",
     room: null,
@@ -8920,6 +9203,8 @@ io.on("connection", (socket) => {
     actionTrail: [],
     convertStartedAt: null,
     clientId: "",
+    userId: "",
+    userEmail: "",
     abVariant: "A",
     geo: {
       country: String(socket.handshake?.headers?.["cf-ipcountry"] || socket.handshake?.headers?.["x-vercel-ip-country"] || "unknown"),
@@ -8929,6 +9214,7 @@ io.on("connection", (socket) => {
     connectedAt: new Date().toISOString(),
     lastSeenAt: new Date().toISOString(),
   });
+  upsertSessionReplay(socket.id, activeUsers.get(socket.id));
   conversionMetrics.entered += 1;
   pushActivityLog("user_connected", `Socket ${socket.id} connected`, { socketId: socket.id });
   emitDashboardStats();
@@ -8938,8 +9224,12 @@ io.on("connection", (socket) => {
     const rec = activeUsers.get(socket.id);
     if (!rec) return;
     const clientId = String(payload?.clientId || rec.clientId || "").slice(0, 120);
+    const userId = String(payload?.userId || rec.userId || "").slice(0, 180);
+    const userEmail = String(payload?.userEmail || rec.userEmail || "").slice(0, 240);
     const abVariant = String(payload?.abVariant || rec.abVariant || "A").toUpperCase() === "B" ? "B" : "A";
     rec.clientId = clientId;
+    rec.userId = userId;
+    rec.userEmail = userEmail;
     rec.abVariant = abVariant;
     if (clientId) {
       const retentionRec = retentionUsers.get(clientId) || { sessions: 0, lastSeenAt: null };
@@ -8955,6 +9245,7 @@ io.on("connection", (socket) => {
     if (rec.journey.length > 12) rec.journey = rec.journey.slice(-12);
     rec.lastSeenAt = new Date().toISOString();
     activeUsers.set(socket.id, rec);
+    upsertSessionReplay(socket.id, rec);
     emitDashboardStats();
   });
 
@@ -8973,6 +9264,7 @@ io.on("connection", (socket) => {
     if (rec.actionTrail.length > 40) rec.actionTrail = rec.actionTrail.slice(-40);
     rec.lastSeenAt = new Date().toISOString();
     activeUsers.set(socket.id, rec);
+    upsertSessionReplay(socket.id, rec);
     pushActivityLog("user_action", `${socket.id}: ${action}`, { socketId: socket.id, action, detail });
     emitDashboardStats();
   });
@@ -8997,6 +9289,7 @@ io.on("connection", (socket) => {
     controlState.waiting = Math.max(0, controlState.queueLength - controlState.processing);
     rec.lastSeenAt = new Date().toISOString();
     activeUsers.set(socket.id, rec);
+    upsertSessionReplay(socket.id, rec);
     emitDashboardStats();
   });
 
@@ -9019,6 +9312,7 @@ io.on("connection", (socket) => {
     pushActivityLog("conversion_success", `Conversion success from ${socket.id}`, { socketId: socket.id });
     rec.lastSeenAt = new Date().toISOString();
     activeUsers.set(socket.id, rec);
+    upsertSessionReplay(socket.id, rec);
     emitDashboardStats();
   });
 
@@ -9028,6 +9322,7 @@ io.on("connection", (socket) => {
     rec.status = "idle";
     rec.lastSeenAt = new Date().toISOString();
     activeUsers.set(socket.id, rec);
+    upsertSessionReplay(socket.id, rec);
     emitDashboardStats();
   });
 
@@ -9045,6 +9340,7 @@ io.on("connection", (socket) => {
       rec.journey.push(`convert:error:${reason}`);
       rec.lastSeenAt = new Date().toISOString();
       activeUsers.set(socket.id, rec);
+      upsertSessionReplay(socket.id, rec);
     }
     pushActivityLog("conversion_error", `Conversion error ${reason}`, { socketId: socket.id, reason });
     emitDashboardStats();
@@ -9113,22 +9409,21 @@ io.on("connection", (socket) => {
     if (!from) return;
     const rec = userViolations.get(from.userId);
     if (rec?.banned) {
-      const appealId = 'APL-' + Date.now().toString(36).toUpperCase().slice(-8);
-      const submittedAt = new Date().toISOString();
-      console.warn(`[Forum Appeal] userId=${from.userId} name=${from.name} appealId=${appealId} submittedAt=${submittedAt}`);
-      const appealLines = [
-        '=== Forum Appeal Request ===',
-        `Appeal ID : ${appealId}`,
-        `User ID   : ${from.userId}`,
-        `Name      : ${from.name}`,
-        `Room      : ${from.room || 'umum'}`,
-        `Time      : ${submittedAt}`,
-        'SLA       : 2x24 jam',
-      ];
-      await sendSupportEmail({ subject: `[Forum Appeal] ${appealId}`, lines: appealLines });
+      const appeal = await submitForumAppeal({
+        source: "forum_socket",
+        userId: from.userId,
+        name: from.name,
+        room: from.room || "umum",
+        reason: String(payload?.reason || "Appeal via forum socket"),
+        socketId: socket.id,
+        metadata: {
+          bannedByServer: true,
+          violationCount: Number(rec?.count || 0),
+        },
+      });
       socket.emit("forum:appealSubmitted", {
-        appealId,
-        message: `✅ Appeal kamu (${appealId}) telah diterima! Tim akan mereview dalam 2x24 jam. Notifikasi juga dikirim ke ${SUPPORT_CONTACT_EMAIL}.`
+        appealId: appeal.appealId,
+        message: `✅ Appeal kamu (${appeal.appealId}) telah diterima! Tim akan mereview dalam 2x24 jam. Notifikasi juga dikirim ke ${SUPPORT_CONTACT_EMAIL}.`
       });
     }
   });
@@ -9154,6 +9449,7 @@ io.on("connection", (socket) => {
       active.room = room;
       active.lastSeenAt = new Date().toISOString();
       activeUsers.set(socket.id, active);
+      upsertSessionReplay(socket.id, active);
     }
     const map = getOrCreateRoomMap(room);
     map.set(userId, { userId, name, socketId: socket.id });
@@ -9175,6 +9471,7 @@ io.on("connection", (socket) => {
       active.room = null;
       active.lastSeenAt = new Date().toISOString();
       activeUsers.set(socket.id, active);
+      upsertSessionReplay(socket.id, active);
     }
     broadcastRoomUsers(prev.room);
     emitDashboardStats();
@@ -9265,6 +9562,7 @@ io.on("connection", (socket) => {
       broadcastRoomUsers(prev.room);
     }
     activeUsers.delete(socket.id);
+    upsertSessionReplay(socket.id, null, { disconnectedAt: new Date().toISOString() });
     pushActivityLog("user_disconnected", `Socket ${socket.id} disconnected`, { socketId: socket.id });
     emitDashboardStats();
   });

--- a/public-ui/admin-dashboard.html
+++ b/public-ui/admin-dashboard.html
@@ -170,7 +170,7 @@
     <section class="rounded-2xl border border-slate-800 bg-slate-900 p-4">
       <h2 class="font-bold mb-2">🧍 Live User Table + Journey</h2>
       <div class="overflow-auto rounded-xl border border-slate-800">
-        <table class="min-w-full text-xs"><thead class="bg-slate-800/80 text-slate-300"><tr><th class="text-left p-2">Socket</th><th class="text-left p-2">Page</th><th class="text-left p-2">Room</th><th class="text-left p-2">Status</th><th class="text-left p-2">Duration</th><th class="text-left p-2">Journey</th><th class="text-left p-2">Last Action</th></tr></thead><tbody id="liveUserRows"></tbody></table>
+        <table class="min-w-full text-xs"><thead class="bg-slate-800/80 text-slate-300"><tr><th class="text-left p-2">Socket</th><th class="text-left p-2">User</th><th class="text-left p-2">Page</th><th class="text-left p-2">Room</th><th class="text-left p-2">Status</th><th class="text-left p-2">Duration</th><th class="text-left p-2">Journey</th><th class="text-left p-2">Last Action</th></tr></thead><tbody id="liveUserRows"></tbody></table>
       </div>
       <div class="mt-3 rounded-xl border border-slate-800 bg-slate-950 p-2">
         <div class="text-xs text-slate-400 mb-1">User Action Stream</div>
@@ -209,6 +209,24 @@
       <h2 class="font-bold mb-2">🧾 Activity Log (Audit Trail)</h2>
       <ul id="activityLogs" class="max-h-48 overflow-auto text-xs space-y-1"></ul>
     </section>
+
+    <section class="rounded-2xl border border-slate-800 bg-slate-900 p-4">
+      <div class="flex items-center justify-between gap-2 mb-2">
+        <h2 class="font-bold">⚖️ Forum Appeal (Prioritas)</h2>
+        <button id="refreshAppealsBtn" class="px-2 py-1 rounded bg-indigo-600 text-xs">Refresh Appeal</button>
+      </div>
+      <div class="text-xs text-slate-400 mb-2">Appeal dari AI Navigator/forum akan masuk ke sini dan bisa di-accept/reject.</div>
+      <div id="appealSummary" class="text-sm mb-2">Pending: 0 • Diterima: 0 • Ditolak: 0</div>
+      <div class="overflow-auto rounded-xl border border-slate-800">
+        <table class="min-w-full text-xs">
+          <thead class="bg-slate-800/80 text-slate-300">
+            <tr><th class="text-left p-2">Appeal ID</th><th class="text-left p-2">User</th><th class="text-left p-2">Socket</th><th class="text-left p-2">Fitur Disabled</th><th class="text-left p-2">Reason</th><th class="text-left p-2">Status</th><th class="text-left p-2">Aksi</th></tr>
+          </thead>
+          <tbody id="appealRows"></tbody>
+        </table>
+      </div>
+      <div class="mt-2 text-xs text-slate-400" id="disabledFeatureStats">-</div>
+    </section>
   </main>
 
 <script>
@@ -219,7 +237,7 @@ const getToken=()=> (localStorage.getItem(TOKEN_KEY)||'').trim();
 const setToken=(v)=> localStorage.setItem(TOKEN_KEY,v||'');
 const formatBytes=(n)=>`${(Number(n||0)/(1024*1024)).toFixed(2)} MB`;
 const formatUptime=(sec=0)=>`${Math.floor(sec/3600)}j ${Math.floor((sec%3600)/60)}m ${Math.floor(sec%60)}d`;
-let state={allTickets:[],filteredTickets:[],currentTicket:null,unread:0,lineChart:null,pieChart:null,alerts:[],lastSnapshot:null,latestUsers:[]};
+let state={allTickets:[],filteredTickets:[],currentTicket:null,unread:0,lineChart:null,pieChart:null,alerts:[],lastSnapshot:null,latestUsers:[],appeals:[]};
 let socket=null;
 
 const toast=(m,type='info')=>{const n=document.createElement('div');n.className=`px-3 py-2 rounded-lg border text-sm shadow ${type==='error'?'bg-rose-950 border-rose-700':type==='warn'?'bg-amber-950 border-amber-700':'bg-slate-900 border-slate-700'}`;n.textContent=m;el('toastWrap').appendChild(n);setTimeout(()=>n.remove(),3800);};
@@ -261,7 +279,7 @@ function renderLive(data){
   el('roomStats').innerHTML=Object.entries(data.live?.roomStats||{}).map(([k,v])=>`<li>${k}: <b>${v}</b></li>`).join('')||'<li>-</li>';
   const users=data.live?.users||[];
   state.latestUsers = users;
-  el('liveUserRows').innerHTML=users.map((u)=>{const lastAction=Array.isArray(u.actions)&&u.actions.length?u.actions[u.actions.length-1]:null;return `<tr class="border-t border-slate-800"><td class="p-2">${u.socketId}</td><td class="p-2">${u.page||'-'}</td><td class="p-2">${u.room||'-'}</td><td class="p-2">${u.status||'-'}</td><td class="p-2">${u.durationSeconds||0}s</td><td class="p-2">${(u.journey||'-').replace(/</g,'&lt;')}</td><td class="p-2">${lastAction ? `${lastAction.action} (${new Date(lastAction.at).toLocaleTimeString()})` : '-'}</td></tr>`;}).join('')||'<tr><td class="p-2" colspan="7">Tidak ada user.</td></tr>';
+  el('liveUserRows').innerHTML=users.map((u)=>{const lastAction=Array.isArray(u.actions)&&u.actions.length?u.actions[u.actions.length-1]:null;const userLabel=(u.userId||u.userEmail||'-').replace(/</g,'&lt;');return `<tr class="border-t border-slate-800"><td class="p-2">${u.socketId}</td><td class="p-2">${userLabel}</td><td class="p-2">${u.page||'-'}</td><td class="p-2">${u.room||'-'}</td><td class="p-2">${u.status||'-'}</td><td class="p-2">${u.durationSeconds||0}s</td><td class="p-2">${(u.journey||'-').replace(/</g,'&lt;')}</td><td class="p-2">${lastAction ? `${lastAction.action} (${new Date(lastAction.at).toLocaleTimeString()})` : '-'}</td></tr>`;}).join('')||'<tr><td class="p-2" colspan="8">Tidak ada user.</td></tr>';
   const allActions=users.flatMap((u)=>Array.isArray(u.actions)?u.actions.map((a)=>({socketId:u.socketId,...a})):[]).sort((a,b)=>new Date(b.at)-new Date(a.at)).slice(0,40);
   el('userActionStream').innerHTML=allActions.map((a)=>`<li class="border border-slate-800 rounded p-1">${a.socketId.slice(0,8)} • ${a.action}${a.detail?` — ${a.detail}`:''}<div class="text-[10px] text-slate-500">${fmt.format(new Date(a.at))}</div></li>`).join('')||'<li class="text-slate-500">Belum ada action.</li>';
 }
@@ -287,11 +305,16 @@ function renderAdvanced(data){
   el('geoStats').innerHTML=Object.entries(geoCounts).map(([k,v])=>`<li>${k}: <b>${v}</b></li>`).join('')||'<li>-</li>';
   el('apiStats').innerHTML=(data.apiMonitoring||[]).map((a)=>`<li class="border border-slate-800 rounded p-1">${a.route}<br>hits:${a.hits} • err:${a.errors} • avg:${a.avgMs}ms</li>`).join('')||'<li>-</li>';
   el('activityLogs').innerHTML=(data.activityLogs||[]).map((l)=>`<li class="rounded border border-slate-800 bg-slate-950 p-2">${l.type}: ${l.message}<div class="text-[10px] text-slate-400">${fmt.format(new Date(l.at))}</div></li>`).join('')||'<li>-</li>';
+  const disabledStats=data.moderation?.disabledFeatureUsage||{};
+  const disabledText=Object.entries(disabledStats).map(([k,v])=>`${k}:${v}`).join(' • ');
+  el('disabledFeatureStats').textContent=`Blocked user: ${data.moderation?.blockedForumUsers||0} • Session replay stored: ${data.moderation?.storedSessionReplay||0} • Disabled feature usage: ${disabledText||'-'}`;
   el('toggleConvertBtn').textContent=(data.control?.convertEnabled ? 'Disable Convert Sementara' : 'Enable Convert Lagi');
   evaluateAlerts(data);
 }
 
-async function loadStats(){const token=getToken();if(!token)return;const res=await fetch('/api/admin/stats',{headers:{Authorization:`Bearer ${token}`}});const data=await res.json().catch(()=>({}));if(!res.ok||!data.ok){el('authState').textContent='Token invalid';return;}el('authState').textContent=`Aktif • ${fmt.format(new Date(data.timestamp))}`;state.allTickets=data.tickets?.all||[];renderMetrics(data);updateCharts(data);renderLive(data);renderAdvanced(data);applyFilters();}
+function renderAppeals(){const items=state.appeals||[];const by={pending:0,accepted:0,rejected:0};items.forEach((a)=>{if(by[a.status]!==undefined)by[a.status]+=1;});el('appealSummary').textContent=`Pending: ${by.pending||0} • Diterima: ${by.accepted||0} • Ditolak: ${by.rejected||0}`;el('appealRows').innerHTML=items.map((a)=>`<tr class="border-t border-slate-800"><td class="p-2 font-semibold">${a.appealId}</td><td class="p-2">${(a.name||'-').replace(/</g,'&lt;')}<div class="text-[10px] text-slate-400">${(a.userId||'-').replace(/</g,'&lt;')}</div></td><td class="p-2">${(a.socketId||'-').replace(/</g,'&lt;')}</td><td class="p-2">${(a.disabledFeatures||[]).join(', ')||'-'}</td><td class="p-2">${(a.reason||'-').replace(/</g,'&lt;')}</td><td class="p-2">${a.statusLabel||a.status||'-'}</td><td class="p-2"><div class="flex gap-1"><button data-appeal="${a.appealId}" data-status="accepted" class="px-2 py-1 rounded bg-emerald-600 text-[10px]">Accept</button><button data-appeal="${a.appealId}" data-status="rejected" class="px-2 py-1 rounded bg-rose-600 text-[10px]">Reject</button></div></td></tr>`).join('')||'<tr><td class="p-2 text-slate-400" colspan="7">Belum ada appeal masuk.</td></tr>';}
+
+async function loadStats(){const token=getToken();if(!token)return;const res=await fetch('/api/admin/stats',{headers:{Authorization:`Bearer ${token}`}});const data=await res.json().catch(()=>({}));if(!res.ok||!data.ok){el('authState').textContent='Token invalid';return;}el('authState').textContent=`Aktif • ${fmt.format(new Date(data.timestamp))}`;state.allTickets=data.tickets?.all||[];state.appeals=data.appeals?.all||[];renderMetrics(data);updateCharts(data);renderLive(data);renderAdvanced(data);renderAppeals();applyFilters();}
 
 function renderChatHistory(items){el('chatHistory').innerHTML=items.map((c)=>`<div class="text-xs rounded p-2 ${c.sender==='admin'?'bg-indigo-900/50 border border-indigo-700':'bg-slate-900 border border-slate-700'}"><div class="text-slate-400 mb-1">${c.sender||'system'} • ${c.at?fmt.format(new Date(c.at)):'-'}</div><div>${(c.message||'').replace(/</g,'&lt;')}</div></div>`).join('')||'<div class="text-slate-500 text-xs">Belum ada chat.</div>';const adminCount=items.filter((x)=>x?.sender==='admin').length;const remain=Math.max(0,3-adminCount);el('chatLimitHint').textContent=`Sisa chat admin: ${remain}`;el('chatInput').disabled=remain<=0;el('chatHistory').scrollTop=el('chatHistory').scrollHeight;}
 
@@ -301,16 +324,18 @@ async function sendChat(evt){evt.preventDefault();if(!state.currentTicket)return
 
 function exportExcel(){const rows=state.filteredTickets.map((t)=>({ID:t.ticketId,Nama:t.name,Email:t.email,Kategori:t.category,Status:t.statusLabel||t.status,SubmittedAt:t.submittedAt}));const ws=XLSX.utils.json_to_sheet(rows);const wb=XLSX.utils.book_new();XLSX.utils.book_append_sheet(wb,ws,'Tickets');XLSX.writeFile(wb,`tickets-${Date.now()}.xlsx`);}
 
-function initSocket(){if(socket)return;socket=io({transports:['websocket','polling']});socket.on('connect',()=>socket.emit('page_change',{page:'/admin/dashboard'}));socket.on('dashboard_stats',(payload)=>renderLive({live:{...payload,conversion:payload.conversion||{}}}));socket.on('admin:newTicket',(payload)=>{setBadge(state.unread+1);toast(`Ticket baru: ${payload.ticketId}`);playNotif();loadStats().catch(()=>{});});socket.on('admin:ticketUpdated',()=>loadStats().catch(()=>{}));socket.on('admin:ticketChat',(payload)=>{if(state.currentTicket?.ticketId===payload.ticketId){state.currentTicket.chatHistory=[...(state.currentTicket.chatHistory||[]),payload.chat];renderChatHistory(state.currentTicket.chatHistory||[]);}toast(`Chat baru di ${payload.ticketId}`);playNotif();});socket.on('admin:controlUpdated',()=>loadStats().catch(()=>{}));}
+function initSocket(){if(socket)return;socket=io({transports:['websocket','polling']});socket.on('connect',()=>socket.emit('page_change',{page:'/admin/dashboard'}));socket.on('dashboard_stats',(payload)=>renderLive({live:{...payload,conversion:payload.conversion||{}}}));socket.on('admin:newTicket',(payload)=>{setBadge(state.unread+1);toast(`Ticket baru: ${payload.ticketId}`);playNotif();loadStats().catch(()=>{});});socket.on('admin:ticketUpdated',()=>loadStats().catch(()=>{}));socket.on('admin:ticketChat',(payload)=>{if(state.currentTicket?.ticketId===payload.ticketId){state.currentTicket.chatHistory=[...(state.currentTicket.chatHistory||[]),payload.chat];renderChatHistory(state.currentTicket.chatHistory||[]);}toast(`Chat baru di ${payload.ticketId}`);playNotif();});socket.on('admin:controlUpdated',()=>loadStats().catch(()=>{}));socket.on('admin:appealCreated',(payload)=>{toast(`Appeal baru: ${payload.appealId}`);playNotif();loadStats().catch(()=>{});});socket.on('admin:appealUpdated',()=>loadStats().catch(()=>{}));}
 
 async function control(action,extra={}){const token=getToken();const r=await fetch('/api/admin/control',{method:'POST',headers:{'Content-Type':'application/json',Authorization:`Bearer ${token}`},body:JSON.stringify({action,...extra})});const d=await r.json().catch(()=>({}));if(!r.ok||!d.ok)return toast(d.error||'Control gagal','error');toast(`Action ${action} berhasil`);loadStats().catch(()=>{});}
+async function updateAppeal(appealId,status){const token=getToken();const r=await fetch(`/api/admin/appeals/${encodeURIComponent(appealId)}`,{method:'PATCH',headers:{'Content-Type':'application/json',Authorization:`Bearer ${token}`},body:JSON.stringify({status,reviewedBy:'admin_dashboard'})});const d=await r.json().catch(()=>({}));if(!r.ok||!d.ok)return toast(d.error||'Update appeal gagal','error');toast(`Appeal ${appealId} -> ${status}`);loadStats().catch(()=>{});}
 
 async function login(evt){evt.preventDefault();const res=await fetch('/admin/login',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({username:el('username').value,password:el('password').value})});const data=await res.json().catch(()=>({}));if(!res.ok||!data.ok||!data.token)return toast('Login gagal','error');setToken(data.token);el('authState').textContent='Login aktif';toast('Login berhasil');await loadStats();initSocket();}
 
 el('loginForm').addEventListener('submit',login);el('refreshBtn').addEventListener('click',()=>loadStats().catch(()=>{}));el('closeDetailBtn').addEventListener('click',()=>el('detailPanel').classList.add('hidden'));el('chatForm').addEventListener('submit',sendChat);el('exportBtn').addEventListener('click',exportExcel);['searchId','filterStatus','filterCategory','filterDate'].forEach((id)=>el(id).addEventListener('input',applyFilters));el('ticketRows').addEventListener('click',(evt)=>{const btn=evt.target.closest('button[data-open]');if(!btn)return;openDetail(btn.getAttribute('data-open'));});el('adminTicketsBtn').addEventListener('click',()=>setBadge(0));
 el('toggleConvertBtn').addEventListener('click',()=>control('toggle_convert'));el('clearQueueBtn').addEventListener('click',()=>control('clear_queue'));el('kickUserBtn').addEventListener('click',()=>control('kick_user',{socketId:el('kickSocketId').value.trim()}));
+el('refreshAppealsBtn').addEventListener('click',()=>loadStats().catch(()=>{}));el('appealRows').addEventListener('click',(evt)=>{const btn=evt.target.closest('button[data-appeal]');if(!btn)return;updateAppeal(btn.getAttribute('data-appeal'),btn.getAttribute('data-status'));});
 el('themeBtn').addEventListener('click',()=>{document.body.classList.toggle('bg-slate-950');document.body.classList.toggle('bg-slate-100');document.body.classList.toggle('text-slate-100');document.body.classList.toggle('text-slate-900');});
-el('replayBtn').addEventListener('click',()=>{const sid=el('replaySocketId').value.trim();const user=state.latestUsers.find((u)=>u.socketId===sid);const timeline=Array.isArray(user?.actions)?user.actions:[];el('replayTimeline').innerHTML=timeline.map((a)=>`<li class=\"border border-slate-800 rounded p-1\">${a.action}${a.detail?` — ${a.detail}`:''}<div class=\"text-[10px] text-slate-500\">${fmt.format(new Date(a.at))}</div></li>`).join('')||'<li class=\"text-slate-500\">Timeline kosong / socket tidak ditemukan.</li>';});
+el('replayBtn').addEventListener('click',async()=>{const sid=el('replaySocketId').value.trim();if(!sid)return toast('Isi socket id dulu','warn');let timeline=[];const user=state.latestUsers.find((u)=>u.socketId===sid);if(Array.isArray(user?.actions)&&user.actions.length)timeline=user.actions;else{try{const token=getToken();const r=await fetch(`/api/admin/session-replay/${encodeURIComponent(sid)}`,{headers:{Authorization:`Bearer ${token}`}});const d=await r.json().catch(()=>({}));if(r.ok&&d.ok&&Array.isArray(d.replay?.actions))timeline=d.replay.actions;}catch{}}el('replayTimeline').innerHTML=timeline.map((a)=>`<li class=\"border border-slate-800 rounded p-1\">${a.action}${a.detail?` — ${a.detail}`:''}<div class=\"text-[10px] text-slate-500\">${fmt.format(new Date(a.at))}</div></li>`).join('')||'<li class=\"text-slate-500\">Timeline kosong / socket tidak ditemukan.</li>';});
 el('exportPngBtn').addEventListener('click',async()=>{const canvas=await html2canvas(document.querySelector('main'));const a=document.createElement('a');a.href=canvas.toDataURL('image/png');a.download=`dashboard-${Date.now()}.png`;a.click();});
 el('exportPdfBtn').addEventListener('click',async()=>{const canvas=await html2canvas(document.querySelector('main'));const img=canvas.toDataURL('image/png');const { jsPDF }=window.jspdf;const pdf=new jsPDF('p','pt','a4');const w=pdf.internal.pageSize.getWidth();const h=(canvas.height/canvas.width)*w;pdf.addImage(img,'PNG',0,0,w,h);pdf.save(`dashboard-${Date.now()}.pdf`);});
 

--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -18139,6 +18139,9 @@
             // Stay here
             return 'AI Navigator siap membantu! Tanyakan apa saja tentang fitur website ini.';
           }
+          if (normalized.startsWith('/appeal')) {
+            return '__APPEAL_COMMAND__';
+          }
           return 'Perintah tidak dikenal. Gunakan menu slash command (/) untuk melihat daftar perintah.';
         };
 
@@ -18159,7 +18162,22 @@
                 clientState: {
                   preferences: state.preferences,
                   experience: state.experience,
-                  mode: localStorage.getItem('ytmp3_mode_pref') || 'advanced'
+                  mode: localStorage.getItem('ytmp3_mode_pref') || 'advanced',
+                  auth: {
+                    uid: currentUser?.uid || '',
+                    email: currentUser?.email || '',
+                    name: currentUser?.displayName || 'Warga',
+                  },
+                  forum: {
+                    room: activeForumRoom || 'umum',
+                    socketId: ensureForumSocket?.()?.id || '',
+                    violationCount: Number(getForumViolationCount?.() || 0),
+                    forumDisabled: Boolean(getForumViolationCount?.() >= FORUM_VIOLATION_LIMIT),
+                    disabledFeatures: [
+                      ...(getForumViolationCount?.() >= FORUM_VIOLATION_LIMIT ? ['forum_chat_input_disabled'] : []),
+                      ...(forumSendBtn?.disabled ? ['forum_send_button_disabled'] : []),
+                    ],
+                  },
                 }
               }),
             });
@@ -18205,6 +18223,48 @@
                 }
                 reply += '\n\nSaya sudah siapkan form tiket bantuan. Silakan cek data lalu kirim ya.';
               }
+
+              if (data.action === 'submit_forum_appeal') {
+                const uid = currentUser?.uid || '';
+                if (!uid) {
+                  reply += '\n\nUntuk kirim appeal, login Google dulu ya.';
+                } else {
+                  const disabledFeatures = [
+                    ...(getForumViolationCount?.() >= FORUM_VIOLATION_LIMIT ? ['forum_chat_input_disabled'] : []),
+                    ...(forumSendBtn?.disabled ? ['forum_send_button_disabled'] : []),
+                  ];
+                  try {
+                    const appealResp = await fetch('/api/forum/appeal', {
+                      method: 'POST',
+                      headers: { 'Content-Type': 'application/json' },
+                      body: JSON.stringify({
+                        userId: uid,
+                        name: currentUser?.displayName || 'Warga',
+                        email: currentUser?.email || '',
+                        room: activeForumRoom || 'umum',
+                        socketId: ensureForumSocket?.()?.id || '',
+                        reason: data?.params?.reason || text,
+                        violationCount: Number(getForumViolationCount?.() || 0),
+                        disabledFeatures,
+                        googleAccount: {
+                          provider: 'google',
+                          uid: uid,
+                          email: currentUser?.email || '',
+                        },
+                      }),
+                    });
+                    const appealData = await appealResp.json().catch(() => ({}));
+                    if (appealResp.ok && appealData?.appealId) {
+                      reply += `\n\n${appealData.message || `✅ Appeal ${appealData.appealId} sudah masuk dashboard admin.`}`;
+                    } else {
+                      reply += `\n\n❌ Gagal kirim appeal: ${appealData?.message || appealData?.error || 'unknown_error'}`;
+                    }
+                  } catch (appealErr) {
+                    reply += '\n\n❌ Gagal kirim appeal ke admin dashboard.';
+                    console.error('Gagal submit appeal AI Navigator', appealErr);
+                  }
+                }
+              }
             }
           } catch (err) {
             console.error('Gagal mengambil jawaban AI', err);
@@ -18226,6 +18286,12 @@
           state.assistantHistory.push({ role: 'user', text: value });
           assistantInput.value = '';
           const commandReply = handleAssistantCommand(value);
+          if (commandReply === '__APPEAL_COMMAND__') {
+            const reason = value.replace(/^\/appeal\s*/i, '').trim();
+            const prompt = reason ? `/appeal ${reason}` : '/appeal saya tidak sengaja dan ingin kembali chat di forum';
+            respondWithAssistant(prompt);
+            return;
+          }
           if (commandReply) {
             addAssistantMessage(commandReply, 'bot', { animate: true });
             state.assistantHistory.push({ role: 'bot', text: commandReply });
@@ -18241,6 +18307,11 @@
           if (!assistantMessages) return;
           if (!state.assistantHistory.length) {
             addAssistantMessage('Navigator YTConv siap bantu seperti customer service. Tanyakan apa saja dengan bahasa kamu, nanti aku kasih alur langkah yang jelas.', 'bot');
+            try {
+              if (typeof getForumViolationCount === 'function' && getForumViolationCount() >= FORUM_VIOLATION_LIMIT) {
+                addAssistantMessage('Aku deteksi akun kamu lagi dibatasi di forum. Ketik **/appeal alasan kamu** supaya langsung aku kirim ke admin dashboard.', 'bot');
+              }
+            } catch { }
           } else {
             state.assistantHistory.forEach((msg) => addAssistantMessage(msg.text, msg.role));
           }
@@ -23784,6 +23855,10 @@
         }
 
         async function doConvert(target, autoDownload = false) {
+          if (window.__adminConvertDisabled) {
+            setToast('Convert sedang dinonaktifkan admin. Coba lagi nanti ya.', 'warning');
+            return;
+          }
           // Request notification permission if default
           if ('Notification' in window && Notification.permission === 'default') {
             try { Notification.requestPermission(); } catch { }
@@ -25882,9 +25957,10 @@
           // Helper to set disabled state
           const set = (el, disabled) => {
             if (el) {
-              el.disabled = disabled;
+              const adminLocked = Boolean(window.__adminConvertDisabled) && (el.id === 'convertBtn' || el.id === 'basic-convert-btn' || el.id === 'gaptek-convert-btn');
+              el.disabled = disabled || adminLocked;
               // Add/remove visual hint for disabled state if needed, but 'disabled' attribute is usually enough for Bootstrap
-              if (disabled) {
+              if (disabled || adminLocked) {
                 el.classList.add('opacity-50');
               } else {
                 el.classList.remove('opacity-50');
@@ -25902,9 +25978,11 @@
 
               // Restore Convert Button Text
               if (convertBtn) {
-                convertBtn.innerHTML = '<i class="bi bi-magic"></i> <span data-i18n="buttonConvert">Convert</span>';
+                convertBtn.innerHTML = window.__adminConvertDisabled
+                  ? '<i class="bi bi-shield-lock"></i> <span>Convert Disabled Admin</span>'
+                  : '<i class="bi bi-magic"></i> <span data-i18n="buttonConvert">Convert</span>';
                 // Ensure it pulsates or highlights as the primary action
-                convertBtn.classList.add('pulse-animation');
+                convertBtn.classList.toggle('pulse-animation', !window.__adminConvertDisabled);
               }
               break;
 
@@ -27269,7 +27347,13 @@
             })();
             const reportPageChange = () => {
               try {
-                forumSocket?.emit('page_change', { page: window.location.pathname || '/', clientId: telemetryClientId, abVariant });
+                forumSocket?.emit('page_change', {
+                  page: window.location.pathname || '/',
+                  clientId: telemetryClientId,
+                  abVariant,
+                  userId: currentUser?.uid || '',
+                  userEmail: currentUser?.email || '',
+                });
               } catch { }
             };
             const reportUserAction = (action, detail = '') => {
@@ -27350,6 +27434,33 @@
             forumSocket.on('conversion_blocked', (payload) => {
               if (typeof setToast === 'function') setToast(payload?.message || 'Konversi dinonaktifkan sementara oleh admin.', 'warning');
               window.manageCTAState?.('idle');
+            });
+            forumSocket.on('control_state', (payload) => {
+              const disabled = payload?.convertEnabled === false;
+              window.__adminConvertDisabled = disabled;
+              const convertBtn = document.getElementById('convertBtn');
+              const basicBtn = document.getElementById('basic-convert-btn');
+              const gaptekBtn = document.getElementById('gaptek-convert-btn');
+              [convertBtn, basicBtn, gaptekBtn].forEach((btn) => {
+                if (!btn) return;
+                btn.disabled = disabled;
+                btn.classList.toggle('opacity-50', disabled);
+                btn.title = disabled ? 'Convert dinonaktifkan admin sementara' : '';
+              });
+              const badgeId = 'adminConvertStateBadge';
+              let badge = document.getElementById(badgeId);
+              if (!badge) {
+                badge = document.createElement('div');
+                badge.id = badgeId;
+                badge.className = 'small mt-2';
+                const target = document.getElementById('convertBtn')?.parentElement;
+                if (target) target.appendChild(badge);
+              }
+              if (badge) {
+                badge.textContent = disabled ? '🚫 Convert dinonaktifkan sementara oleh admin.' : '✅ Convert aktif normal.';
+                badge.classList.toggle('text-danger', disabled);
+                badge.classList.toggle('text-success', !disabled);
+              }
             });
             window.addEventListener('popstate', reportPageChange);
             window.addEventListener('hashchange', reportPageChange);


### PR DESCRIPTION
### Motivation
- Provide a structured forum appeal pipeline so users can submit appeals and admins can review them from the dashboard. 
- Improve resilience of Groq API usage by supporting multiple API keys and fallback attempts. 
- Add session replay and richer live telemetry to help admins investigate user sessions and moderation cases. 

### Description
- Implemented GROQ API key fallback by reading `GROQ_API_KEY` and `GROQ_API_KEY_FALLBACK` into `GROQ_API_KEYS` and iterating keys when calling `callGroqAPI`. 
- Added forum appeal model and flow: `forumAppeals` store, `buildAppealId`, `submitForumAppeal` helper, and `sendSupportEmail` integration to notify support. 
- Exposed REST endpoints: `POST /api/forum/appeal`, `GET /api/admin/appeals`, and `PATCH /api/admin/appeals/:appealId` for creating and managing appeals; and `GET /api/admin/session-replay/:socketId` to fetch stored session replay. 
- Socket/server instrumentation: track `userId`/`userEmail` in `activeUsers`, maintain `sessionReplayStore` with `upsertSessionReplay`, emit `admin:appealCreated`/`admin:appealUpdated` events, and emit `control_state` for admin-driven UI control. 
- Assistant & public UI changes: detect `/appeal` command and appeal-related messages in AI assistant, include forum state in `clientState` payload to AI, submit appeals from client-side assistant to `POST /api/forum/appeal`, and add UI affordances in `admin-dashboard.html` and `public-ui/index.html` for appeals, session replay, and admin convert-disable state handling. 
- Misc: replaced some console/error handling to aggregate `lastError` for Groq fallback, enhanced moderation socket appeal path to use `submitForumAppeal`, and added push activity logs for appeals. 

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6664db540832f95ba99de77db9d91)