### PR TITLE
Fix AI Navigator slash-command routing and Groq API key fallback

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,13 @@ const TURNSTILE_STRICT = /^(1|true|yes|on)$/i.test(String(process.env.TURNSTILE_
 const isTurnstileConfigured = Boolean(TURNSTILE_SECRET_KEY && TURNSTILE_SITE_KEY);
 const YOUTUBE_API_KEY = (process.env.YOUTUBE_API_KEY || "").trim();
 const isYoutubeApiConfigured = Boolean(YOUTUBE_API_KEY);
-const GROQ_API_KEY = (process.env.GROQ_API_KEY || "").trim();
+const GROQ_API_KEY = [
+  process.env.GROQ_API_KEY,
+  process.env.GROQ_APIKEY,
+  process.env.GROQ_KEY,
+  process.env.GROK_API_KEY,
+  process.env.AI_GROQ_API_KEY,
+].map((value) => String(value || "").trim()).find(Boolean) || "";
 const GROQ_MODEL = process.env.GROQ_MODEL || "llama-3.3-70b-versatile";
 const isGroqConfigured = Boolean(GROQ_API_KEY);
 const COOKIES_PATH = join(process.cwd(), "cookies.txt");
@@ -700,8 +706,7 @@ Jika percakapan biasa/edukasi/diagnosa:
         model: GROQ_MODEL,
         messages: messages,
         temperature: 0.7,
-        max_tokens: 500,
-        response_format: { type: "json_object" }
+        max_tokens: 500
       }),
     });
 

--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -18119,27 +18119,33 @@
 
         const handleAssistantCommand = (command) => {
           const normalized = command.trim().toLowerCase();
-          if (!normalized.startsWith('/')) return '';
+          if (!normalized.startsWith('/')) return { handled: false };
           if (normalized.includes('/faq')) {
             setActiveSection('faq');
             closeAssistantPanel();
-            return 'Membuka halaman Pertanyaan Umum (FAQ)...';
+            return { handled: true, reply: 'Membuka halaman Pertanyaan Umum (FAQ)...' };
           }
           if (normalized.includes('/walkthrough')) {
             closeAssistantPanel();
             narrateGuide(); // Assuming this triggers the guide
-            return 'Memulai panduan interaktif website...';
+            return { handled: true, reply: 'Memulai panduan interaktif website...' };
           }
           if (normalized.includes('/donasi')) {
             setActiveSection('saweria');
             closeAssistantPanel();
-            return 'Membuka halaman donasi Saweria. Terima kasih atas dukunganmu!';
+            return { handled: true, reply: 'Membuka halaman donasi Saweria. Terima kasih atas dukunganmu!' };
           }
           if (normalized.includes('/ai')) {
             // Stay here
-            return 'AI Navigator siap membantu! Tanyakan apa saja tentang fitur website ini.';
+            return { handled: true, reply: 'AI Navigator siap membantu! Tanyakan apa saja tentang fitur website ini.' };
           }
-          return 'Perintah tidak dikenal. Gunakan menu slash command (/) untuk melihat daftar perintah.';
+          if (normalized.includes('/appeal') || normalized.includes('/banding')) {
+            return { handled: false, forwardText: 'Saya mau appeal forum diblokir. Tolong bantu kirim appeal ke admin.' };
+          }
+          return {
+            handled: false,
+            forwardText: normalized.slice(1).trim() || command.trim(),
+          };
         };
 
         const respondWithAssistant = async (text) => {
@@ -18282,16 +18288,17 @@
           addAssistantMessage(value, 'user');
           state.assistantHistory.push({ role: 'user', text: value });
           assistantInput.value = '';
-          const commandReply = handleAssistantCommand(value);
-          if (commandReply) {
-            addAssistantMessage(commandReply, 'bot', { animate: true });
-            state.assistantHistory.push({ role: 'bot', text: commandReply });
+          const commandResult = handleAssistantCommand(value);
+          if (commandResult?.handled && commandResult.reply) {
+            addAssistantMessage(commandResult.reply, 'bot', { animate: true });
+            state.assistantHistory.push({ role: 'bot', text: commandResult.reply });
             persistState();
             incrementPoints(10, 'Perintah cepat AI', { badge: 'navigator' });
             updateMascotMood('ai');
             return;
           }
-          respondWithAssistant(value);
+          const textToSend = commandResult?.forwardText || value;
+          respondWithAssistant(textToSend);
         }
 
         const ensureAssistantWelcome = () => {


### PR DESCRIPTION
### Motivation
- The AI Navigator UI intercepted slash-commands and returned a static "unknown command" reply, preventing many intents (like appeals) from reaching the backend AI. 
- The backend considered Groq unconfigured if the API key used a different environment variable name, causing the system to always fall back to local responses. 
- Forcing `response_format: json_object` in the Groq request caused compatibility issues with some models/runtimes and could trigger fallback behavior.

### Description
- Added multi-name Groq key resolution in `index.js` by checking `GROQ_API_KEY`, `GROQ_APIKEY`, `GROQ_KEY`, `GROK_API_KEY`, and `AI_GROQ_API_KEY` and picking the first non-empty value. 
- Removed the forced `response_format: { type: "json_object" }` field from the Groq request payload to improve model/runtime compatibility. 
- Reworked the assistant command handler in `public-ui/index.html` so `handleAssistantCommand` returns a `{ handled, reply, forwardText }` object instead of a plain string, and added explicit handling to map `/appeal` and `/banding` into a forwarded appeal intent. 
- Updated `sendAssistantMessage` to forward unhandled slash input (`forwardText`) to the backend via `/api/assistant-chat` so unknown slash-commands are processed by the AI instead of being blocked locally.

### Testing
- Ran syntax check with `node --check index.js`, which completed successfully. 
- Ran the assistant integration script `node test-assistant.js`; the script exercised the assistant flow and produced expected fallback replies when Groq was not configured. 
- `test-assistant.js` run showed Groq reported as unconfigured (expected in this environment without secrets) and later the test environment exited due to a missing `yt-dlp` binary (`spawn yt-dlp ENOENT`), which is unrelated to the changes here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d67a9445fc832faffe0fc8c2b65e78)