### PR TITLE
Fix AI Navigator not reaching Groq and improve assistant-chat fallback

### DIFF
--- a/index.js
+++ b/index.js
@@ -8712,7 +8712,7 @@ app.post("/api/forum/appeal", express.json({ limit: "512kb" }), async (req, res)
     const blockedSignalDetected = moderationState.blockedSignalDetected;
 
     const appeal = await submitForumAppeal({
-      source: "ai_navigator",
+      source: String(body.source || "ai_navigator").slice(0, 60),
       userId,
       name: body.name || "Warga",
       email: body.email || "",
@@ -9583,24 +9583,25 @@ io.on("connection", (socket) => {
     if (!from) return;
     const rec = userViolations.get(from.userId);
     const blockState = isForumUserBlocked({ userId: from.userId, violationCount: Number(rec?.count || 0) });
-    if (blockState.blocked) {
-      const appeal = await submitForumAppeal({
-        source: "forum_socket",
-        userId: from.userId,
-        name: from.name,
-        room: from.room || "umum",
-        reason: String(payload?.reason || "Appeal via forum socket"),
-        socketId: socket.id,
-        metadata: {
-          bannedByServer: true,
-          violationCount: Number(rec?.count || 0),
-        },
-      });
-      socket.emit("forum:appealSubmitted", {
-        appealId: appeal.appealId,
-        message: `✅ Appeal kamu (${appeal.appealId}) telah diterima! Tim akan mereview dalam 2x24 jam. Notifikasi juga dikirim ke ${SUPPORT_CONTACT_EMAIL}.`
-      });
-    }
+    const reason = String(payload?.reason || "").trim() || "Appeal via forum socket";
+    const appeal = await submitForumAppeal({
+      source: "forum_socket",
+      userId: from.userId,
+      name: from.name,
+      room: from.room || "umum",
+      reason,
+      socketId: socket.id,
+      metadata: {
+        blocked: blockState.blocked,
+        blockedByServer: blockState.blockedByServer,
+        blockedByClient: blockState.blockedByClient,
+        violationCount: Number(rec?.count || 0),
+      },
+    });
+    socket.emit("forum:appealSubmitted", {
+      appealId: appeal.appealId,
+      message: `✅ Appeal kamu (${appeal.appealId}) telah diterima! Tim akan mereview dalam 2x24 jam. Notifikasi juga dikirim ke ${SUPPORT_CONTACT_EMAIL}.`
+    });
   });
 
   socket.on("forum:join", (payload) => {

--- a/index.js
+++ b/index.js
@@ -8304,6 +8304,7 @@ const controlState = {
 const retentionUsers = new Map();
 const apiRouteStats = new Map();
 const forumAppeals = new Map();
+const forumUnblockedUsers = new Map();
 const abMetrics = {
   A: { started: 0, success: 0 },
   B: { started: 0, success: 0 },
@@ -8336,6 +8337,35 @@ const INDONESIAN_BADWORDS = [
 const SUPPORT_CONTACT_EMAIL = process.env.SUPPORT_CONTACT_EMAIL || "forumwargaytmp3@gmail.com";
 
 const buildAppealId = () => `APL-${Date.now().toString(36).toUpperCase().slice(-8)}`;
+
+const isForumUserBlocked = ({ userId = "", violationCount = 0, disabledFeatures = [] } = {}) => {
+  const normalizedUserId = String(userId || "").trim();
+  const override = normalizedUserId ? forumUnblockedUsers.get(normalizedUserId) : null;
+  if (override) {
+    return {
+      blocked: false,
+      blockedByServer: false,
+      blockedByClient: false,
+      blockedSignalDetected: false,
+      unblockedByAppeal: true,
+      override,
+      violationCount: 0,
+    };
+  }
+  const violationRec = normalizedUserId ? userViolations.get(normalizedUserId) : null;
+  const blockedByServer = Boolean(violationRec?.banned);
+  const normalizedDisabled = Array.isArray(disabledFeatures) ? disabledFeatures : [];
+  const blockedByClient = normalizedDisabled.length > 0 || Number(violationCount || 0) >= 5;
+  return {
+    blocked: blockedByServer || blockedByClient,
+    blockedByServer,
+    blockedByClient,
+    blockedSignalDetected: blockedByServer || blockedByClient,
+    unblockedByAppeal: false,
+    override: null,
+    violationCount: Number(violationRec?.count || violationCount || 0),
+  };
+};
 
 const submitForumAppeal = async ({
   source = "unknown",
@@ -8671,12 +8701,15 @@ app.post("/api/forum/appeal", express.json({ limit: "512kb" }), async (req, res)
     if (!userId) return res.status(400).json({ ok: false, error: "user_id_required" });
     if (!reason) return res.status(400).json({ ok: false, error: "reason_required" });
 
-    const violationRec = userViolations.get(userId);
-    const blockedByServer = Boolean(violationRec?.banned);
     const disabledFeatures = Array.isArray(body.disabledFeatures) ? body.disabledFeatures : [];
-    const blockedByClient = disabledFeatures.length > 0 || Number(body.violationCount || 0) >= 5;
-
-    const blockedSignalDetected = blockedByServer || blockedByClient;
+    const moderationState = isForumUserBlocked({
+      userId,
+      violationCount: Number(body.violationCount || 0),
+      disabledFeatures,
+    });
+    const blockedByServer = moderationState.blockedByServer;
+    const blockedByClient = moderationState.blockedByClient;
+    const blockedSignalDetected = moderationState.blockedSignalDetected;
 
     const appeal = await submitForumAppeal({
       source: "ai_navigator",
@@ -8708,6 +8741,22 @@ app.post("/api/forum/appeal", express.json({ limit: "512kb" }), async (req, res)
     console.error("[/api/forum/appeal error]", e);
     return res.status(500).json({ ok: false, error: e?.message || "appeal_failed" });
   }
+});
+
+app.get("/api/forum/status", (req, res) => {
+  const userId = String(req.query?.userId || "").trim();
+  if (!userId) return res.status(400).json({ ok: false, error: "user_id_required" });
+  const state = isForumUserBlocked({ userId });
+  return res.json({
+    ok: true,
+    userId,
+    blocked: state.blocked,
+    blockedByServer: state.blockedByServer,
+    blockedByClient: state.blockedByClient,
+    unblockedByAppeal: state.unblockedByAppeal,
+    violationCount: state.violationCount,
+    override: state.override || null,
+  });
 });
 
 app.get("/api/ticket/:ticketId", (req, res) => {
@@ -8778,6 +8827,24 @@ app.patch("/api/admin/appeals/:appealId", express.json({ limit: "256kb" }), (req
   appeal.reviewedBy = String(req.body?.reviewedBy || "admin").slice(0, 120);
   appeal.reviewedAt = status === "pending" ? null : new Date().toISOString();
   appeal.updatedAt = new Date().toISOString();
+  if (status === "accepted" && appeal.userId) {
+    forumUnblockedUsers.set(appeal.userId, {
+      appealId,
+      reviewedBy: appeal.reviewedBy,
+      reviewedAt: appeal.reviewedAt,
+    });
+    userViolations.set(appeal.userId, {
+      count: 0,
+      banned: false,
+      unbannedAt: Date.now(),
+      unbannedByAppeal: appealId,
+    });
+    io.emit("forum:userUnblocked", {
+      userId: appeal.userId,
+      appealId,
+      reviewedAt: appeal.reviewedAt,
+    });
+  }
   forumAppeals.set(appealId, appeal);
   pushActivityLog("forum_appeal_updated", `Appeal ${appealId} -> ${appeal.statusLabel}`, {
     appealId,
@@ -8787,6 +8854,7 @@ app.patch("/api/admin/appeals/:appealId", express.json({ limit: "256kb" }), (req
     appealId,
     status: appeal.status,
     statusLabel: appeal.statusLabel,
+    userId: appeal.userId || "",
   });
   return res.json({ ok: true, appeal });
 });
@@ -9466,7 +9534,8 @@ io.on("connection", (socket) => {
 
     // Check if user already banned
     const rec = userViolations.get(userId) || { count: 0, banned: false };
-    if (rec.banned) {
+    const blockState = isForumUserBlocked({ userId, violationCount: rec.count || 0 });
+    if (blockState.blocked) {
       socket.emit("forum:banned", {
         message: "Kamu telah diblokir dari forum karena 5 pelanggaran bahasa. Silakan ajukan appeal via AI Navigator / tiket bantuan.",
         appealUrl: "#"
@@ -9513,7 +9582,8 @@ io.on("connection", (socket) => {
     const from = socketState.get(socket.id);
     if (!from) return;
     const rec = userViolations.get(from.userId);
-    if (rec?.banned) {
+    const blockState = isForumUserBlocked({ userId: from.userId, violationCount: Number(rec?.count || 0) });
+    if (blockState.blocked) {
       const appeal = await submitForumAppeal({
         source: "forum_socket",
         userId: from.userId,

--- a/index.js
+++ b/index.js
@@ -103,11 +103,11 @@ const collectGroqKeys = () => {
 
   const keys = [];
   const seen = new Set();
-  const keyPattern = /gsk_[A-Za-z0-9]+/g;
+  const keyPattern = /gsk_[A-Za-z0-9_-]+/g;
 
   rawValues.forEach((raw) => {
     const direct = raw.trim();
-    if (/^gsk_[A-Za-z0-9]+$/.test(direct) && !seen.has(direct)) {
+    if (/^gsk_[A-Za-z0-9_-]+$/.test(direct) && !seen.has(direct)) {
       seen.add(direct);
       keys.push(direct);
     }
@@ -123,7 +123,7 @@ const collectGroqKeys = () => {
     raw
       .split(/[\n,;\s]+/)
       .map((token) => token.trim())
-      .filter((token) => /^gsk_[A-Za-z0-9]+$/.test(token))
+      .filter((token) => /^gsk_[A-Za-z0-9_-]+$/.test(token))
       .forEach((token) => {
         if (seen.has(token)) return;
         seen.add(token);
@@ -745,7 +745,6 @@ Jika percakapan biasa/edukasi/diagnosa:
           messages,
           temperature: 0.7,
           max_tokens: 500,
-          response_format: { type: "json_object" }
         }),
       });
 

--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -18196,35 +18196,53 @@
           let reply = '';
           try {
             const historyToSend = state.assistantHistory.slice(0, -1);
-
-            const response = await fetch(api('/api/assistant-chat'), {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({
-                prompt: text,
-                messages: historyToSend,
-                clientState: {
-                  preferences: state.preferences,
-                  experience: state.experience,
-                  mode: localStorage.getItem('ytmp3_mode_pref') || 'advanced',
-                  auth: {
-                    uid: currentUser?.uid || '',
-                    email: currentUser?.email || '',
-                    name: currentUser?.displayName || 'Warga',
-                  },
-                  forum: {
-                    room: activeForumRoom || 'umum',
-                    socketId: ensureForumSocket?.()?.id || '',
-                    violationCount: Number(getForumViolationCount?.() || 0),
-                    forumDisabled: Boolean(getForumViolationCount?.() >= FORUM_VIOLATION_LIMIT),
-                    disabledFeatures: [
-                      ...(getForumViolationCount?.() >= FORUM_VIOLATION_LIMIT ? ['forum_chat_input_disabled'] : []),
-                      ...(forumSendBtn?.disabled ? ['forum_send_button_disabled'] : []),
-                    ],
-                  },
+            const payload = {
+              prompt: text,
+              messages: historyToSend,
+              clientState: {
+                preferences: state.preferences,
+                experience: state.experience,
+                mode: localStorage.getItem('ytmp3_mode_pref') || 'advanced',
+                auth: {
+                  uid: currentUser?.uid || '',
+                  email: currentUser?.email || '',
+                  name: currentUser?.displayName || 'Warga',
+                },
+                forum: {
+                  room: activeForumRoom || 'umum',
+                  socketId: ensureForumSocket?.()?.id || '',
+                  violationCount: Number(getForumViolationCount?.() || 0),
+                  forumDisabled: Boolean(getForumViolationCount?.() >= FORUM_VIOLATION_LIMIT),
+                  disabledFeatures: [
+                    ...(getForumViolationCount?.() >= FORUM_VIOLATION_LIMIT ? ['forum_chat_input_disabled'] : []),
+                    ...(forumSendBtn?.disabled ? ['forum_send_button_disabled'] : []),
+                  ],
+                },
+              }
+            };
+            const primaryUrl = api('/api/assistant-chat');
+            const sameOriginUrl = '/api/assistant-chat';
+            const targets = [primaryUrl];
+            if (primaryUrl !== sameOriginUrl) targets.push(sameOriginUrl);
+            let response = null;
+            let responseErr = null;
+            for (const target of targets) {
+              try {
+                const candidate = await fetch(target, {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify(payload),
+                });
+                if (candidate.ok) {
+                  response = candidate;
+                  break;
                 }
-              }),
-            });
+                responseErr = new Error(`assistant_api_${candidate.status}`);
+              } catch (networkErr) {
+                responseErr = networkErr;
+              }
+            }
+            if (!response) throw responseErr || new Error('assistant_api_unreachable');
             if (response.ok) {
               const data = await response.json();
               reply = data?.reply || '';

--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -18167,9 +18167,21 @@
           if (!uid) {
             return { ok: false, error: 'Untuk kirim appeal, login Google dulu ya.' };
           }
+          const violationLimit = 5;
+          const getViolationCountSafe = () => {
+            try {
+              if (typeof window.getForumViolationCount === 'function') {
+                return Number(window.getForumViolationCount() || 0) || 0;
+              }
+              return 0;
+            } catch {
+              return 0;
+            }
+          };
+          const violationCount = getViolationCountSafe();
           const disabledFeatures = [
-            ...(getForumViolationCount?.() >= FORUM_VIOLATION_LIMIT ? ['forum_chat_input_disabled'] : []),
-            ...(forumSendBtn?.disabled ? ['forum_send_button_disabled'] : []),
+            ...(violationCount >= violationLimit ? ['forum_chat_input_disabled'] : []),
+            ...(document.getElementById('forumSendBtn')?.disabled ? ['forum_send_button_disabled'] : []),
           ];
           const appealResp = await fetch('/api/forum/appeal', {
             method: 'POST',
@@ -18179,9 +18191,9 @@
               name: currentUser?.displayName || 'Warga',
               email: currentUser?.email || '',
               room: activeForumRoom || 'umum',
-              socketId: ensureForumSocket?.()?.id || '',
+              socketId: '',
               reason: String(reasonText || '').trim() || 'Saya mau appeal forum',
-              violationCount: Number(getForumViolationCount?.() || 0),
+              violationCount,
               disabledFeatures,
               googleAccount: {
                 provider: 'google',
@@ -18203,6 +18215,19 @@
           let reply = '';
           try {
             const historyToSend = state.assistantHistory.slice(0, -1);
+            const violationLimit = 5;
+            const getViolationCountSafe = () => {
+              try {
+                if (typeof window.getForumViolationCount === 'function') {
+                  return Number(window.getForumViolationCount() || 0) || 0;
+                }
+                return 0;
+              } catch {
+                return 0;
+              }
+            };
+            const violationCount = getViolationCountSafe();
+            const forumSendDisabled = Boolean(document.getElementById('forumSendBtn')?.disabled);
             const payload = {
               prompt: text,
               messages: historyToSend,
@@ -18217,12 +18242,12 @@
                 },
                 forum: {
                   room: activeForumRoom || 'umum',
-                  socketId: ensureForumSocket?.()?.id || '',
-                  violationCount: Number(getForumViolationCount?.() || 0),
-                  forumDisabled: Boolean(getForumViolationCount?.() >= FORUM_VIOLATION_LIMIT),
+                  socketId: '',
+                  violationCount,
+                  forumDisabled: Boolean(violationCount >= violationLimit),
                   disabledFeatures: [
-                    ...(getForumViolationCount?.() >= FORUM_VIOLATION_LIMIT ? ['forum_chat_input_disabled'] : []),
-                    ...(forumSendBtn?.disabled ? ['forum_send_button_disabled'] : []),
+                    ...(violationCount >= violationLimit ? ['forum_chat_input_disabled'] : []),
+                    ...(forumSendDisabled ? ['forum_send_button_disabled'] : []),
                   ],
                 },
               }
@@ -29515,6 +29540,9 @@
           function setForumViolationCount(val) {
             try { localStorage.setItem(forumViolationKey(), String(Math.max(0, Number(val) || 0))); } catch { }
           }
+          try {
+            window.getForumViolationCount = getForumViolationCount;
+          } catch { }
 
           async function reportForumModeration(text, violationCount) {
             try {

--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -8299,6 +8299,12 @@
                 style="width: 45px; height: 45px;" type="button" id="forumSendBtn" disabled>
                 <i class="bi bi-send-fill fs-5 ms-1"></i>
               </button>
+              <button
+                class="btn btn-outline-warning rounded-pill ms-2 d-none"
+                type="button"
+                id="forumAppealBtn">
+                <i class="bi bi-envelope-paper-heart me-1"></i> Appeal Forum
+              </button>
             </div>
           </div>
         </div>
@@ -16130,6 +16136,7 @@
           const forumOverlay = document.getElementById('forumLoginOverlay');
           const forumInput = document.getElementById('forumInput');
           const forumSendBtn = document.getElementById('forumSendBtn');
+          const forumAppealBtn = document.getElementById('forumAppealBtn');
 
           if (forumOverlay) forumOverlay.hidden = !!user;
           if (forumInput) forumInput.disabled = !user;
@@ -18297,6 +18304,7 @@
             }
           } catch (err) {
             console.error('Gagal mengambil jawaban AI', err);
+            reply = '⚠️ AI Groq sedang gangguan. Coba lagi 5-10 detik, atau cek konfigurasi GROQ_API_KEY/GROQ_MODEL di server.';
             if (isAppealIntent(text)) {
               try {
                 const result = await submitForumAppeal(text);
@@ -26452,6 +26460,7 @@
           let isNearBottomState = true;
           let replyContext = null;
           let reportFiles = [];
+          let forumUnblockedByAppeal = false;
           let voiceState = {
             isRecording: false,
             mediaRecorder: null,
@@ -27418,6 +27427,14 @@
               if (!payload || payload.room !== activeForumRoom) return;
               forumPresenceUsers = Array.isArray(payload.users) ? payload.users : [];
               renderCallUserList();
+            });
+            forumSocket.on('forum:userUnblocked', (payload) => {
+              const targetUserId = String(payload?.userId || '');
+              if (!targetUserId || targetUserId !== String(currentUser?.uid || '')) return;
+              forumUnblockedByAppeal = true;
+              setForumViolationCount(0);
+              setToast('✅ Appeal diterima admin. Forum chat kamu sudah diaktifkan lagi.', 'success');
+              updateSendButtonState();
             });
             forumSocket.on('call:offer', (payload) => {
               if (!payload?.callId || !payload?.offer) return;
@@ -29599,18 +29616,28 @@
             if (!forumSendBtn) return;
             if (!currentUser) {
               forumSendBtn.disabled = true;
+              if (forumAppealBtn) forumAppealBtn.classList.add('d-none');
               return;
             }
             if (isLaporanRoom()) {
               forumSendBtn.disabled = true;
+              if (forumAppealBtn) forumAppealBtn.classList.add('d-none');
               return;
             }
             if (getForumViolationCount() >= FORUM_VIOLATION_LIMIT) {
-              forumSendBtn.disabled = true;
-              forumInput.disabled = true;
-              forumInput.placeholder = 'Akun forum dibatasi karena 5x pelanggaran. Ajukan appeal via AI Navigator / tiket email (respon 2x24 jam).';
-              return;
+              if (forumUnblockedByAppeal) {
+                setForumViolationCount(0);
+              } else {
+                forumSendBtn.disabled = true;
+                forumInput.disabled = true;
+                forumInput.placeholder = 'Akun forum dibatasi karena 5x pelanggaran. Ajukan appeal via AI Navigator / tiket email (respon 2x24 jam).';
+                if (forumAppealBtn) forumAppealBtn.classList.remove('d-none');
+                return;
+              }
             }
+            if (forumAppealBtn) forumAppealBtn.classList.add('d-none');
+            forumInput.disabled = false;
+            forumInput.placeholder = 'Ketik pesan...';
             if (voiceState.isRecording) {
               forumSendBtn.disabled = false;
               forumSendBtn.classList.remove('btn-primary');
@@ -29628,6 +29655,67 @@
             } else {
               forumSendBtn.innerHTML = '<i class="bi bi-mic-fill fs-4"></i>';
             }
+          }
+
+          async function syncForumModerationStatus() {
+            const uid = currentUser?.uid || '';
+            if (!uid) return;
+            try {
+              const r = await fetch(`/api/forum/status?userId=${encodeURIComponent(uid)}`);
+              const d = await r.json().catch(() => ({}));
+              if (!r.ok || !d?.ok) return;
+              forumUnblockedByAppeal = Boolean(d.unblockedByAppeal);
+              if (forumUnblockedByAppeal) {
+                setForumViolationCount(0);
+              }
+              updateSendButtonState();
+            } catch (err) {
+              console.warn('Gagal sinkron status forum', err);
+            }
+          }
+
+          async function submitForumAppealFromButton() {
+            if (!currentUser?.uid) {
+              setToast('Login Google dulu untuk kirim appeal.', 'warning');
+              return;
+            }
+            const reason = window.prompt('Tulis alasan appeal forum kamu:', 'Saya minta unban forum, akan patuh aturan dan tidak toxic lagi.');
+            if (reason === null) return;
+            const cleanReason = String(reason || '').trim();
+            if (!cleanReason) {
+              setToast('Alasan appeal tidak boleh kosong.', 'warning');
+              return;
+            }
+            forumAppealBtn?.setAttribute('disabled', '');
+            try {
+              const result = await submitForumAppeal(cleanReason);
+              if (!result?.ok) {
+                setToast(`Gagal kirim appeal: ${result?.error || 'unknown_error'}`, 'danger');
+                return;
+              }
+              setToast(result.message || 'Appeal berhasil dikirim ke admin dashboard.', 'success');
+            } catch (err) {
+              console.error('Gagal submit appeal dari tombol forum', err);
+              setToast('Gagal kirim appeal. Coba lagi sebentar.', 'danger');
+            } finally {
+              forumAppealBtn?.removeAttribute('disabled');
+            }
+          }
+
+          if (forumAppealBtn) {
+            forumAppealBtn.addEventListener('click', submitForumAppealFromButton);
+          }
+
+          if (forumModal) {
+            forumModal.addEventListener('shown.bs.modal', () => {
+              syncForumModerationStatus().catch(() => { });
+            });
+          }
+
+          if (typeof window !== 'undefined') {
+            window.addEventListener('focus', () => {
+              syncForumModerationStatus().catch(() => { });
+            });
           }
 
           if (forumSendBtn) {

--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -29716,15 +29716,45 @@
             }
             forumAppealBtn?.setAttribute('disabled', '');
             try {
-              const result = await submitForumAppeal(cleanReason);
-              if (!result?.ok) {
-                setToast(`Gagal kirim appeal: ${result?.error || 'unknown_error'}`, 'danger');
-                return;
+              const socketId = (() => {
+                try { return ensureForumSocket?.()?.id || ''; } catch { return ''; }
+              })();
+              const violationCount = Number(getForumViolationCount() || 0) || 0;
+              const disabledFeatures = [
+                ...(violationCount >= FORUM_VIOLATION_LIMIT ? ['forum_chat_input_disabled'] : []),
+                ...(forumSendBtn?.disabled ? ['forum_send_button_disabled'] : []),
+              ];
+              const resp = await fetch('/api/forum/appeal', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                  source: 'forum_button',
+                  userId: currentUser.uid,
+                  name: currentUser.displayName || 'Warga',
+                  email: currentUser.email || '',
+                  room: activeForumRoom || 'umum',
+                  socketId,
+                  reason: cleanReason,
+                  violationCount,
+                  disabledFeatures,
+                  googleAccount: {
+                    provider: 'google',
+                    uid: currentUser.uid,
+                    email: currentUser.email || '',
+                  },
+                }),
+              });
+              const data = await resp.json().catch(() => ({}));
+              if (!resp.ok || !data?.appealId) {
+                try {
+                  ensureForumSocket?.()?.emit?.('forum:appeal', { reason: cleanReason });
+                } catch { }
+                throw new Error(data?.message || data?.error || 'appeal_submit_failed');
               }
-              setToast(result.message || 'Appeal berhasil dikirim ke admin dashboard.', 'success');
+              setToast(data?.message || `Appeal ${data.appealId} berhasil dikirim ke admin dashboard.`, 'success');
             } catch (err) {
               console.error('Gagal submit appeal dari tombol forum', err);
-              setToast('Gagal kirim appeal. Coba lagi sebentar.', 'danger');
+              setToast(`Gagal kirim appeal: ${err?.message || 'unknown_error'}`, 'danger');
             } finally {
               forumAppealBtn?.removeAttribute('disabled');
             }


### PR DESCRIPTION
### Motivation
- AI Navigator responses were not reaching Groq in some deployments and appeal submissions could be masked when the AI endpoint failed, while environment GROQ keys could be missed due to a too-strict key pattern.

### Description
- Broadened Groq API key parsing in `collectGroqKeys` to accept keys containing `_` or `-` and more robustly extract keys from mixed env values (`index.js`).
- Removed the forced `response_format: { type: "json_object" }` field from the Groq chat completion request to avoid model/API incompatibility failures (`index.js`).
- Made the AI Navigator frontend (`respondWithAssistant` in `public-ui/index.html`) build a single payload, attempt the configured backend then a same-origin `/api/assistant-chat` fallback, and treat non-2xx responses as errors so failures are surfaced rather than silently falling back.

### Testing
- Ran `node --check index.js`, which succeeded.
- Ran `node --check public-ui/index.html`, which failed because Node cannot syntax-check `.html` files (this is an expected limitation of the check command and not an application runtime error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d67cdee848832fb33fc19831b8e363)