### PR TITLE
Add load-testing telemetry + admin monitor and fix forum moderation & AI ticket prefill

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,28 @@ Aplikasi web serbaguna untuk mengunduh audio atau video dari YouTube, Spotify, m
 - Kartu status tool yang memeriksa versi yt-dlp & ffmpeg terbaru sekaligus memberi badge peringatan bila sudah kedaluwarsa.
 - Auto metadata tagging & AI music tags untuk mengisi judul/artis/genre secara otomatis, lengkap dengan insight genre/mood di UI.
 
+## Load Testing (k6) + Monitoring Admin Dashboard
+
+Project ini sekarang punya script load test siap pakai di `load-tests/k6-admin-dashboard.js`. Setelah selesai jalan, script akan otomatis mengirim ringkasan hasil test ke backend (`/api/load-test/report`) agar muncul di **Admin Dashboard** bagian **Load Testing Monitor (k6)**.
+
+### Cara pakai cepat
+1. Set token pelaporan di server:
+   - `LOAD_TEST_REPORT_TOKEN=isi_token_aman`
+2. Jalankan server seperti biasa (`npm start`).
+3. Jalankan k6 dari terminal lain:
+
+```bash
+K6_BASE_URL=http://localhost:3000 \
+LOAD_TEST_REPORT_TOKEN=isi_token_aman \
+k6 run load-tests/k6-admin-dashboard.js
+```
+
+Variabel opsional:
+- `K6_VUS` (default `10`)
+- `K6_DURATION` (default `30s`)
+- `K6_SCENARIO` (default `baseline_mix`)
+- `K6_ENV` (contoh: `staging`, `production`)
+
 ## Antarmuka Next.js + Bootstrap
 Untuk antarmuka modern berbasis React, repositori ini menyertakan aplikasi [Next.js](./next-app) yang memanfaatkan komponen Bootstrap namun tetap memakai API backend yang sama. Antarmuka ini dapat dijalankan berdampingan dengan UI klasik tanpa memodifikasi fitur yang sudah ada.
 

--- a/index.html
+++ b/index.html
@@ -18032,25 +18032,12 @@
                 const ticketMsg = document.getElementById('emailMsg');
                 const ticketIdEl = document.getElementById('emailTicketId');
                 const categoryEl = document.getElementById('emailCategory');
-                const nameEl = document.getElementById('emailName');
-                const emailEl = document.getElementById('emailAddr');
-                const googleName = state?.currentUser?.displayName || '';
-                const googleEmail = state?.currentUser?.email || '';
                 if (ticketIdEl && !ticketIdEl.value) {
                   const seed = Date.now().toString(36).toUpperCase().slice(-8);
                   ticketIdEl.value = `TKT-${seed}`;
                 }
-                if (nameEl && !nameEl.value && googleName) {
-                  nameEl.value = googleName;
-                }
-                if (emailEl && !emailEl.value && googleEmail) {
-                  emailEl.value = googleEmail;
-                }
                 if (ticketMsg && data?.params?.context) {
-                  const userHeader = (googleName || googleEmail)
-                    ? `User Google: ${googleName || '-'} <${googleEmail || '-'}>\n`
-                    : '';
-                  ticketMsg.value = `${userHeader}Ringkasan dari AI Navigator:\n${data.params.context}\n\nDetail tambahan:`;
+                  ticketMsg.value = `Ringkasan dari AI Navigator:\n${data.params.context}\n\nDetail tambahan:`;
                 }
                 if (categoryEl && /forum|kasar|moderasi/i.test(String(data?.params?.context || ''))) {
                   categoryEl.value = 'forum';
@@ -28964,15 +28951,6 @@
           const FORUM_BADWORDS = ['anjing', 'bangsat', 'brengsek', 'goblok', 'tolol', 'kontol', 'memek', 'jancok', 'ngentot', 'bacot'];
           const FORUM_VIOLATION_LIMIT = 5;
           const forumViolationKey = () => `ytconv:forum:violations:${currentUser?.uid || 'guest'}`;
-          const normalizeForumText = (value) => String(value || '')
-            .toLowerCase()
-            .replace(/[@4]/g, 'a')
-            .replace(/[3]/g, 'e')
-            .replace(/[1!|]/g, 'i')
-            .replace(/[0]/g, 'o')
-            .replace(/[5$]/g, 's')
-            .replace(/[7]/g, 't')
-            .replace(/[^a-z0-9\s]/g, '');
 
           function getForumViolationCount() {
             try { return Number(localStorage.getItem(forumViolationKey()) || '0') || 0; } catch { return 0; }
@@ -29006,26 +28984,8 @@
             const text = forumInput.value.trim();
             if (!text && selectedFiles.length === 0) return;
             if (!currentUser) { setToast('Anda belum login!', 'warning'); return; }
-            if (getForumViolationCount() >= FORUM_VIOLATION_LIMIT) {
-              forumInput.disabled = true;
-              setToast('🚫 Akun kamu sudah dibatasi karena 5x pelanggaran. Ketik "saya mau appeal" di AI Navigator.', 'danger');
-              return;
-            }
 
-            try {
-              const forumStatusResp = await fetch(`/api/forum/status?userId=${encodeURIComponent(currentUser.uid)}`);
-              const forumStatusData = await forumStatusResp.json().catch(() => ({}));
-              if (forumStatusResp.ok && forumStatusData?.ok && forumStatusData.blocked) {
-                setForumViolationCount(Math.max(FORUM_VIOLATION_LIMIT, Number(forumStatusData.violationCount || 0) || FORUM_VIOLATION_LIMIT));
-                forumInput.disabled = true;
-                forumInput.placeholder = 'Akun dibatasi (5x pelanggaran). Ketik "saya mau appeal" di AI Navigator.';
-                updateSendButtonState();
-                setToast('🚫 Status akun forum kamu sedang dibatasi oleh sistem moderasi.', 'danger');
-                return;
-              }
-            } catch { }
-
-            const normalized = normalizeForumText(text);
+            const normalized = text.toLowerCase();
             const hasBadWord = FORUM_BADWORDS.some((w) => normalized.includes(w));
             if (hasBadWord) {
               const nextCount = getForumViolationCount() + 1;
@@ -29033,8 +28993,6 @@
               await reportForumModeration(text, nextCount);
               if (nextCount >= FORUM_VIOLATION_LIMIT) {
                 setToast('🚫 Kamu diblokir sementara setelah 5x pelanggaran. Buka AI Navigator lalu ketik "saya mau appeal" untuk mengajukan pemulihan.', 'danger');
-                forumInput.disabled = true;
-                forumInput.placeholder = 'Akun dibatasi (5x pelanggaran). Ketik "saya mau appeal" di AI Navigator.';
                 forumInput.value = '';
                 updateSendButtonState();
                 return;
@@ -29114,7 +29072,6 @@
               forumInput.placeholder = 'Akun dibatasi (5x pelanggaran). Ketik "saya mau appeal" di AI Navigator.';
               return;
             }
-            forumInput.disabled = false;
             if (voiceState.isRecording) {
               forumSendBtn.disabled = false;
               forumSendBtn.classList.remove('btn-primary');

--- a/index.html
+++ b/index.html
@@ -18032,12 +18032,25 @@
                 const ticketMsg = document.getElementById('emailMsg');
                 const ticketIdEl = document.getElementById('emailTicketId');
                 const categoryEl = document.getElementById('emailCategory');
+                const nameEl = document.getElementById('emailName');
+                const emailEl = document.getElementById('emailAddr');
+                const googleName = state?.currentUser?.displayName || '';
+                const googleEmail = state?.currentUser?.email || '';
                 if (ticketIdEl && !ticketIdEl.value) {
                   const seed = Date.now().toString(36).toUpperCase().slice(-8);
                   ticketIdEl.value = `TKT-${seed}`;
                 }
+                if (nameEl && !nameEl.value && googleName) {
+                  nameEl.value = googleName;
+                }
+                if (emailEl && !emailEl.value && googleEmail) {
+                  emailEl.value = googleEmail;
+                }
                 if (ticketMsg && data?.params?.context) {
-                  ticketMsg.value = `Ringkasan dari AI Navigator:\n${data.params.context}\n\nDetail tambahan:`;
+                  const userHeader = (googleName || googleEmail)
+                    ? `User Google: ${googleName || '-'} <${googleEmail || '-'}>\n`
+                    : '';
+                  ticketMsg.value = `${userHeader}Ringkasan dari AI Navigator:\n${data.params.context}\n\nDetail tambahan:`;
                 }
                 if (categoryEl && /forum|kasar|moderasi/i.test(String(data?.params?.context || ''))) {
                   categoryEl.value = 'forum';
@@ -28951,6 +28964,15 @@
           const FORUM_BADWORDS = ['anjing', 'bangsat', 'brengsek', 'goblok', 'tolol', 'kontol', 'memek', 'jancok', 'ngentot', 'bacot'];
           const FORUM_VIOLATION_LIMIT = 5;
           const forumViolationKey = () => `ytconv:forum:violations:${currentUser?.uid || 'guest'}`;
+          const normalizeForumText = (value) => String(value || '')
+            .toLowerCase()
+            .replace(/[@4]/g, 'a')
+            .replace(/[3]/g, 'e')
+            .replace(/[1!|]/g, 'i')
+            .replace(/[0]/g, 'o')
+            .replace(/[5$]/g, 's')
+            .replace(/[7]/g, 't')
+            .replace(/[^a-z0-9\s]/g, '');
 
           function getForumViolationCount() {
             try { return Number(localStorage.getItem(forumViolationKey()) || '0') || 0; } catch { return 0; }
@@ -28984,8 +29006,26 @@
             const text = forumInput.value.trim();
             if (!text && selectedFiles.length === 0) return;
             if (!currentUser) { setToast('Anda belum login!', 'warning'); return; }
+            if (getForumViolationCount() >= FORUM_VIOLATION_LIMIT) {
+              forumInput.disabled = true;
+              setToast('🚫 Akun kamu sudah dibatasi karena 5x pelanggaran. Ketik "saya mau appeal" di AI Navigator.', 'danger');
+              return;
+            }
 
-            const normalized = text.toLowerCase();
+            try {
+              const forumStatusResp = await fetch(`/api/forum/status?userId=${encodeURIComponent(currentUser.uid)}`);
+              const forumStatusData = await forumStatusResp.json().catch(() => ({}));
+              if (forumStatusResp.ok && forumStatusData?.ok && forumStatusData.blocked) {
+                setForumViolationCount(Math.max(FORUM_VIOLATION_LIMIT, Number(forumStatusData.violationCount || 0) || FORUM_VIOLATION_LIMIT));
+                forumInput.disabled = true;
+                forumInput.placeholder = 'Akun dibatasi (5x pelanggaran). Ketik "saya mau appeal" di AI Navigator.';
+                updateSendButtonState();
+                setToast('🚫 Status akun forum kamu sedang dibatasi oleh sistem moderasi.', 'danger');
+                return;
+              }
+            } catch { }
+
+            const normalized = normalizeForumText(text);
             const hasBadWord = FORUM_BADWORDS.some((w) => normalized.includes(w));
             if (hasBadWord) {
               const nextCount = getForumViolationCount() + 1;
@@ -28993,6 +29033,8 @@
               await reportForumModeration(text, nextCount);
               if (nextCount >= FORUM_VIOLATION_LIMIT) {
                 setToast('🚫 Kamu diblokir sementara setelah 5x pelanggaran. Buka AI Navigator lalu ketik "saya mau appeal" untuk mengajukan pemulihan.', 'danger');
+                forumInput.disabled = true;
+                forumInput.placeholder = 'Akun dibatasi (5x pelanggaran). Ketik "saya mau appeal" di AI Navigator.';
                 forumInput.value = '';
                 updateSendButtonState();
                 return;
@@ -29072,6 +29114,7 @@
               forumInput.placeholder = 'Akun dibatasi (5x pelanggaran). Ketik "saya mau appeal" di AI Navigator.';
               return;
             }
+            forumInput.disabled = false;
             if (voiceState.isRecording) {
               forumSendBtn.disabled = false;
               forumSendBtn.classList.remove('btn-primary');

--- a/index.js
+++ b/index.js
@@ -8413,6 +8413,51 @@ const healthMetrics = {
   errorCount: 0,
   totalResponseMs: 0,
 };
+const loadTestReports = [];
+const MAX_LOAD_TEST_REPORTS = 80;
+
+const addLoadTestReport = (report = {}) => {
+  if (!report || typeof report !== "object") return null;
+  const startedAtRaw = report.startedAt ? new Date(report.startedAt) : new Date();
+  const finishedAtRaw = report.finishedAt ? new Date(report.finishedAt) : new Date();
+  const startedAt = Number.isNaN(startedAtRaw.getTime()) ? new Date() : startedAtRaw;
+  const finishedAt = Number.isNaN(finishedAtRaw.getTime()) ? new Date() : finishedAtRaw;
+  const totalRequests = Number(report.totalRequests || 0);
+  const failedRequests = Number(report.failedRequests || 0);
+  const reportItem = {
+    runId: String(report.runId || `K6-${Date.now().toString(36).toUpperCase()}`).slice(0, 64),
+    scenario: String(report.scenario || report.testName || "k6_default").slice(0, 120),
+    environment: String(report.environment || process.env.NODE_ENV || "unknown").slice(0, 60),
+    baseUrl: String(report.baseUrl || "").slice(0, 320),
+    vus: Number(report.vus || 0) || 0,
+    iterations: Number(report.iterations || 0) || 0,
+    totalRequests,
+    failedRequests,
+    failureRate: Number(totalRequests > 0 ? (failedRequests / totalRequests) * 100 : 0),
+    avgMs: Number(report.avgMs || 0) || 0,
+    p90Ms: Number(report.p90Ms || 0) || 0,
+    p95Ms: Number(report.p95Ms || 0) || 0,
+    p99Ms: Number(report.p99Ms || 0) || 0,
+    maxMs: Number(report.maxMs || 0) || 0,
+    minMs: Number(report.minMs || 0) || 0,
+    checksPassRate: Number(report.checksPassRate || 0) || 0,
+    notes: String(report.notes || "").slice(0, 1200),
+    source: String(report.source || "k6").slice(0, 32),
+    receivedAt: new Date().toISOString(),
+    startedAt: startedAt.toISOString(),
+    finishedAt: finishedAt.toISOString(),
+  };
+  loadTestReports.unshift(reportItem);
+  if (loadTestReports.length > MAX_LOAD_TEST_REPORTS) {
+    loadTestReports.length = MAX_LOAD_TEST_REPORTS;
+  }
+  pushActivityLog("load_test_report", `Load test ${reportItem.runId} (${reportItem.scenario}) diterima`, {
+    runId: reportItem.runId,
+    failureRate: reportItem.failureRate,
+    p95Ms: reportItem.p95Ms,
+  });
+  return reportItem;
+};
 
 const pushActivityLog = (type, message, meta = {}) => {
   activityLogs.unshift({
@@ -8910,6 +8955,33 @@ app.get("/api/admin/appeals", (req, res) => {
   return res.json({ ok: true, appeals });
 });
 
+app.post("/api/load-test/report", express.json({ limit: "256kb" }), (req, res) => {
+  const expectedToken = String(process.env.LOAD_TEST_REPORT_TOKEN || "").trim();
+  const authHeader = String(req.headers.authorization || "");
+  const bearerToken = authHeader.toLowerCase().startsWith("bearer ") ? authHeader.slice(7).trim() : "";
+  const headerToken = String(req.headers["x-loadtest-token"] || "").trim();
+  const providedToken = bearerToken || headerToken;
+  const hasValidToken = expectedToken && providedToken && providedToken === expectedToken;
+  if (!hasValidToken && !isAdminBearerValid(req)) {
+    return res.status(401).json({ ok: false, error: "unauthorized" });
+  }
+  const saved = addLoadTestReport(req.body || {});
+  if (!saved) return res.status(400).json({ ok: false, error: "invalid_payload" });
+  io.emit("admin:loadTestReport", {
+    runId: saved.runId,
+    scenario: saved.scenario,
+    failureRate: saved.failureRate,
+    p95Ms: saved.p95Ms,
+    receivedAt: saved.receivedAt,
+  });
+  return res.json({ ok: true, report: saved });
+});
+
+app.get("/api/admin/load-tests", (req, res) => {
+  if (!isAdminBearerValid(req)) return res.status(401).json({ ok: false, error: "unauthorized" });
+  return res.json({ ok: true, reports: loadTestReports.slice(0, 40) });
+});
+
 app.patch("/api/admin/appeals/:appealId", express.json({ limit: "256kb" }), (req, res) => {
   if (!isAdminBearerValid(req)) return res.status(401).json({ ok: false, error: "unauthorized" });
   const appealId = String(req.params.appealId || "").trim().toUpperCase();
@@ -9042,6 +9114,8 @@ app.get("/api/admin/stats", (req, res) => {
     return acc;
   }, {});
   const blockedForumUsers = Array.from(userViolations.values()).filter((x) => x?.banned).length;
+  const loadTestSummary = loadTestReports.slice(0, 20);
+  const latestLoadTest = loadTestSummary[0] || null;
   const disabledFeatureUsage = {};
   appeals.forEach((a) => {
     (a.disabledFeatures || []).forEach((f) => {
@@ -9143,6 +9217,11 @@ app.get("/api/admin/stats", (req, res) => {
       blockedForumUsers,
       disabledFeatureUsage,
       storedSessionReplay: sessionReplayStore.size,
+    },
+    loadTesting: {
+      totalReports: loadTestReports.length,
+      latest: latestLoadTest,
+      reports: loadTestSummary,
     },
     abTesting: abMetrics,
     smartInsights,

--- a/load-tests/k6-admin-dashboard.js
+++ b/load-tests/k6-admin-dashboard.js
@@ -1,0 +1,83 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Counter, Rate, Trend } from 'k6/metrics';
+
+const failedRequests = new Counter('failed_requests');
+const checkRate = new Rate('check_pass_rate');
+const latencyTrend = new Trend('api_latency_ms');
+
+export const options = {
+  vus: Number(__ENV.K6_VUS || 10),
+  duration: __ENV.K6_DURATION || '30s',
+  thresholds: {
+    http_req_failed: ['rate<0.1'],
+    http_req_duration: ['p(95)<1500'],
+  },
+};
+
+const BASE_URL = (__ENV.K6_BASE_URL || 'http://localhost:3000').replace(/\/$/, '');
+const REPORT_URL = __ENV.K6_REPORT_URL || `${BASE_URL}/api/load-test/report`;
+
+const routes = [
+  '/',
+  '/api/dashboard',
+  '/api/health',
+  '/api/forum/status?userId=loadtest-user',
+];
+
+export default function () {
+  const route = routes[Math.floor(Math.random() * routes.length)];
+  const res = http.get(`${BASE_URL}${route}`, { timeout: '15s' });
+  latencyTrend.add(res.timings.duration);
+
+  const ok = check(res, {
+    'status < 500': (r) => r.status < 500,
+  });
+  checkRate.add(ok ? 1 : 0);
+  if (!ok) failedRequests.add(1);
+  sleep(0.4);
+}
+
+export function handleSummary(data) {
+  const totalRequests = Number(data.metrics.http_reqs?.values?.count || 0);
+  const failed = Number(data.metrics.http_req_failed?.values?.fails || 0);
+  const reportPayload = {
+    runId: `K6-${Date.now().toString(36).toUpperCase()}`,
+    scenario: __ENV.K6_SCENARIO || 'baseline_mix',
+    environment: __ENV.K6_ENV || 'local',
+    baseUrl: BASE_URL,
+    vus: Number(options.vus || 0),
+    iterations: Number(data.metrics.iterations?.values?.count || 0),
+    totalRequests,
+    failedRequests: failed,
+    avgMs: Number(data.metrics.http_req_duration?.values?.avg || 0),
+    minMs: Number(data.metrics.http_req_duration?.values?.min || 0),
+    maxMs: Number(data.metrics.http_req_duration?.values?.max || 0),
+    p90Ms: Number(data.metrics.http_req_duration?.values?.['p(90)'] || 0),
+    p95Ms: Number(data.metrics.http_req_duration?.values?.['p(95)'] || 0),
+    p99Ms: Number(data.metrics.http_req_duration?.values?.['p(99)'] || 0),
+    checksPassRate: Number(data.metrics.checks?.values?.rate || 0) * 100,
+    source: 'k6',
+    notes: __ENV.K6_NOTES || '',
+    startedAt: new Date(Date.now() - Number(data.state?.testRunDurationMs || 0)).toISOString(),
+    finishedAt: new Date().toISOString(),
+  };
+
+  const headers = { 'Content-Type': 'application/json' };
+  if (__ENV.LOAD_TEST_REPORT_TOKEN) {
+    headers['x-loadtest-token'] = __ENV.LOAD_TEST_REPORT_TOKEN;
+  }
+
+  try {
+    const resp = http.post(REPORT_URL, JSON.stringify(reportPayload), { headers, timeout: '20s' });
+    if (resp.status >= 400) {
+      console.error(`Gagal kirim report load test: HTTP ${resp.status} ${resp.body}`);
+    }
+  } catch (err) {
+    console.error(`Gagal kirim report load test: ${err.message || err}`);
+  }
+
+  return {
+    stdout: JSON.stringify({ summary: data.metrics.http_req_duration?.values || {}, reportPayload }, null, 2),
+  };
+}

--- a/public-ui/admin-dashboard.html
+++ b/public-ui/admin-dashboard.html
@@ -102,7 +102,7 @@
       </div>
 </section>
 
-<section class="grid lg:grid-cols-2 gap-3">
+    <section class="grid lg:grid-cols-2 gap-3">
       <div class="rounded-2xl border border-slate-800 bg-slate-900 p-4">
         <h2 class="font-bold mb-2">🌍 Geo Tracking</h2>
         <ul id="geoStats" class="text-sm space-y-1"></ul>
@@ -110,6 +110,20 @@
       <div class="rounded-2xl border border-slate-800 bg-slate-900 p-4">
         <h2 class="font-bold mb-2">📡 API Monitoring</h2>
         <ul id="apiStats" class="text-xs space-y-1 max-h-36 overflow-auto"></ul>
+      </div>
+    </section>
+
+    <section class="rounded-2xl border border-slate-800 bg-slate-900 p-4">
+      <h2 class="font-bold mb-2">🧪 Load Testing Monitor (k6)</h2>
+      <div class="text-xs text-slate-400 mb-2">Menampilkan laporan load test terbaru yang dikirim dari script k6/JMeter ke endpoint backend.</div>
+      <div id="loadTestSummary" class="text-sm mb-2">Belum ada laporan load test.</div>
+      <div class="overflow-auto rounded-xl border border-slate-800">
+        <table class="min-w-full text-xs">
+          <thead class="bg-slate-800/80 text-slate-300">
+            <tr><th class="text-left p-2">Run</th><th class="text-left p-2">Scenario</th><th class="text-left p-2">Req</th><th class="text-left p-2">Fail %</th><th class="text-left p-2">Latency p95</th><th class="text-left p-2">Waktu</th></tr>
+          </thead>
+          <tbody id="loadTestRows"></tbody>
+        </table>
       </div>
     </section>
 
@@ -312,9 +326,21 @@ function renderAdvanced(data){
   evaluateAlerts(data);
 }
 
+function renderLoadTesting(data){
+  const payload = data.loadTesting || {};
+  const reports = Array.isArray(payload.reports) ? payload.reports : [];
+  const latest = payload.latest || reports[0] || null;
+  if (latest) {
+    el('loadTestSummary').textContent = `Total report: ${payload.totalReports || reports.length} • Latest ${latest.runId} • Fail ${Number(latest.failureRate || 0).toFixed(2)}% • p95 ${Number(latest.p95Ms || 0).toFixed(2)} ms`;
+  } else {
+    el('loadTestSummary').textContent = 'Belum ada laporan load test.';
+  }
+  el('loadTestRows').innerHTML = reports.map((r) => `<tr class="border-t border-slate-800"><td class="p-2 font-mono">${r.runId}</td><td class="p-2">${r.scenario || '-'}</td><td class="p-2">${r.totalRequests || 0}</td><td class="p-2">${Number(r.failureRate || 0).toFixed(2)}%</td><td class="p-2">${Number(r.p95Ms || 0).toFixed(2)} ms</td><td class="p-2">${r.receivedAt ? fmt.format(new Date(r.receivedAt)) : '-'}</td></tr>`).join('') || '<tr><td class="p-2 text-slate-400" colspan="6">Belum ada data load testing.</td></tr>';
+}
+
 function renderAppeals(){const items=state.appeals||[];const by={pending:0,accepted:0,rejected:0};items.forEach((a)=>{if(by[a.status]!==undefined)by[a.status]+=1;});el('appealSummary').textContent=`Pending: ${by.pending||0} • Diterima: ${by.accepted||0} • Ditolak: ${by.rejected||0}`;el('appealRows').innerHTML=items.map((a)=>`<tr class="border-t border-slate-800"><td class="p-2 font-semibold">${a.appealId}</td><td class="p-2">${(a.name||'-').replace(/</g,'&lt;')}<div class="text-[10px] text-slate-400">${(a.userId||'-').replace(/</g,'&lt;')}</div></td><td class="p-2">${(a.socketId||'-').replace(/</g,'&lt;')}</td><td class="p-2">${(a.disabledFeatures||[]).join(', ')||'-'}</td><td class="p-2">${(a.reason||'-').replace(/</g,'&lt;')}</td><td class="p-2">${a.statusLabel||a.status||'-'}</td><td class="p-2"><div class="flex gap-1"><button data-appeal="${a.appealId}" data-status="accepted" class="px-2 py-1 rounded bg-emerald-600 text-[10px]">Accept</button><button data-appeal="${a.appealId}" data-status="rejected" class="px-2 py-1 rounded bg-rose-600 text-[10px]">Reject</button></div></td></tr>`).join('')||'<tr><td class="p-2 text-slate-400" colspan="7">Belum ada appeal masuk.</td></tr>';}
 
-async function loadStats(){const token=getToken();if(!token)return;const res=await fetch('/api/admin/stats',{headers:{Authorization:`Bearer ${token}`}});const data=await res.json().catch(()=>({}));if(!res.ok||!data.ok){el('authState').textContent='Token invalid';return;}el('authState').textContent=`Aktif • ${fmt.format(new Date(data.timestamp))}`;state.allTickets=data.tickets?.all||[];state.appeals=data.appeals?.all||[];renderMetrics(data);updateCharts(data);renderLive(data);renderAdvanced(data);renderAppeals();applyFilters();}
+async function loadStats(){const token=getToken();if(!token)return;const res=await fetch('/api/admin/stats',{headers:{Authorization:`Bearer ${token}`}});const data=await res.json().catch(()=>({}));if(!res.ok||!data.ok){el('authState').textContent='Token invalid';return;}el('authState').textContent=`Aktif • ${fmt.format(new Date(data.timestamp))}`;state.allTickets=data.tickets?.all||[];state.appeals=data.appeals?.all||[];renderMetrics(data);updateCharts(data);renderLive(data);renderAdvanced(data);renderLoadTesting(data);renderAppeals();applyFilters();}
 
 function renderChatHistory(items){el('chatHistory').innerHTML=items.map((c)=>`<div class="text-xs rounded p-2 ${c.sender==='admin'?'bg-indigo-900/50 border border-indigo-700':'bg-slate-900 border border-slate-700'}"><div class="text-slate-400 mb-1">${c.sender||'system'} • ${c.at?fmt.format(new Date(c.at)):'-'}</div><div class="whitespace-pre-wrap break-words">${(c.message||'').replace(/</g,'&lt;')}</div></div>`).join('')||'<div class="text-slate-500 text-xs">Belum ada chat.</div>';el('chatLimitHint').textContent='Chat admin tanpa batas.';el('chatInput').disabled=false;el('chatHistory').scrollTop=el('chatHistory').scrollHeight;}
 
@@ -324,7 +350,7 @@ async function sendChat(evt){evt.preventDefault();if(!state.currentTicket)return
 
 function exportExcel(){const rows=state.filteredTickets.map((t)=>({ID:t.ticketId,Nama:t.name,Email:t.email,Kategori:t.category,Status:t.statusLabel||t.status,SubmittedAt:t.submittedAt}));const ws=XLSX.utils.json_to_sheet(rows);const wb=XLSX.utils.book_new();XLSX.utils.book_append_sheet(wb,ws,'Tickets');XLSX.writeFile(wb,`tickets-${Date.now()}.xlsx`);}
 
-function initSocket(){if(socket)return;socket=io({transports:['websocket','polling']});socket.on('connect',()=>socket.emit('page_change',{page:'/admin/dashboard'}));socket.on('dashboard_stats',(payload)=>renderLive({live:{...payload,conversion:payload.conversion||{}}}));socket.on('admin:newTicket',(payload)=>{setBadge(state.unread+1);toast(`Ticket baru: ${payload.ticketId}`);playNotif();loadStats().catch(()=>{});});socket.on('admin:ticketUpdated',()=>loadStats().catch(()=>{}));socket.on('admin:ticketChat',(payload)=>{if(state.currentTicket?.ticketId===payload.ticketId){state.currentTicket.chatHistory=[...(state.currentTicket.chatHistory||[]),payload.chat];renderChatHistory(state.currentTicket.chatHistory||[]);}toast(`Chat baru di ${payload.ticketId}`);playNotif();});socket.on('admin:controlUpdated',()=>loadStats().catch(()=>{}));socket.on('admin:appealCreated',(payload)=>{toast(`Appeal baru: ${payload.appealId}`);playNotif();loadStats().catch(()=>{});});socket.on('admin:appealUpdated',()=>loadStats().catch(()=>{}));}
+function initSocket(){if(socket)return;socket=io({transports:['websocket','polling']});socket.on('connect',()=>socket.emit('page_change',{page:'/admin/dashboard'}));socket.on('dashboard_stats',(payload)=>renderLive({live:{...payload,conversion:payload.conversion||{}}}));socket.on('admin:newTicket',(payload)=>{setBadge(state.unread+1);toast(`Ticket baru: ${payload.ticketId}`);playNotif();loadStats().catch(()=>{});});socket.on('admin:ticketUpdated',()=>loadStats().catch(()=>{}));socket.on('admin:ticketChat',(payload)=>{if(state.currentTicket?.ticketId===payload.ticketId){state.currentTicket.chatHistory=[...(state.currentTicket.chatHistory||[]),payload.chat];renderChatHistory(state.currentTicket.chatHistory||[]);}toast(`Chat baru di ${payload.ticketId}`);playNotif();});socket.on('admin:controlUpdated',()=>loadStats().catch(()=>{}));socket.on('admin:appealCreated',(payload)=>{toast(`Appeal baru: ${payload.appealId}`);playNotif();loadStats().catch(()=>{});});socket.on('admin:appealUpdated',()=>loadStats().catch(()=>{}));socket.on('admin:loadTestReport',(payload)=>{toast(`Load test baru: ${payload.runId}`);playNotif();loadStats().catch(()=>{});});}
 
 async function control(action,extra={}){const token=getToken();const r=await fetch('/api/admin/control',{method:'POST',headers:{'Content-Type':'application/json',Authorization:`Bearer ${token}`},body:JSON.stringify({action,...extra})});const d=await r.json().catch(()=>({}));if(!r.ok||!d.ok)return toast(d.error||'Control gagal','error');toast(`Action ${action} berhasil`);loadStats().catch(()=>{});}
 async function updateAppeal(appealId,status){const token=getToken();const r=await fetch(`/api/admin/appeals/${encodeURIComponent(appealId)}`,{method:'PATCH',headers:{'Content-Type':'application/json',Authorization:`Bearer ${token}`},body:JSON.stringify({status,reviewedBy:'admin_dashboard'})});const d=await r.json().catch(()=>({}));if(!r.ok||!d.ok)return toast(d.error||'Update appeal gagal','error');toast(`Appeal ${appealId} -> ${status}`);loadStats().catch(()=>{});}

--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -18367,12 +18367,25 @@
                 const ticketMsg = document.getElementById('emailMsg');
                 const ticketIdEl = document.getElementById('emailTicketId');
                 const categoryEl = document.getElementById('emailCategory');
+                const nameEl = document.getElementById('emailName');
+                const emailEl = document.getElementById('emailAddr');
+                const googleName = state?.currentUser?.displayName || '';
+                const googleEmail = state?.currentUser?.email || '';
                 if (ticketIdEl && !ticketIdEl.value) {
                   const seed = Date.now().toString(36).toUpperCase().slice(-8);
                   ticketIdEl.value = `TKT-${seed}`;
                 }
+                if (nameEl && !nameEl.value && googleName) {
+                  nameEl.value = googleName;
+                }
+                if (emailEl && !emailEl.value && googleEmail) {
+                  emailEl.value = googleEmail;
+                }
                 if (ticketMsg && data?.params?.context) {
-                  ticketMsg.value = `Ringkasan dari AI Navigator:\n${data.params.context}\n\nDetail tambahan:`;
+                  const userHeader = (googleName || googleEmail)
+                    ? `User Google: ${googleName || '-'} <${googleEmail || '-'}>\n`
+                    : '';
+                  ticketMsg.value = `${userHeader}Ringkasan dari AI Navigator:\n${data.params.context}\n\nDetail tambahan:`;
                 }
                 if (categoryEl && /forum|kasar|moderasi/i.test(String(data?.params?.context || ''))) {
                   categoryEl.value = 'forum';
@@ -29608,6 +29621,15 @@
           const FORUM_BADWORDS = ['anjing', 'bangsat', 'brengsek', 'goblok', 'tolol', 'kontol', 'memek', 'jancok', 'ngentot', 'bacot'];
           const FORUM_VIOLATION_LIMIT = 5;
           const forumViolationKey = () => `ytconv:forum:violations:${currentUser?.uid || 'guest'}`;
+          const normalizeForumText = (value) => String(value || '')
+            .toLowerCase()
+            .replace(/[@4]/g, 'a')
+            .replace(/[3]/g, 'e')
+            .replace(/[1!|]/g, 'i')
+            .replace(/[0]/g, 'o')
+            .replace(/[5$]/g, 's')
+            .replace(/[7]/g, 't')
+            .replace(/[^a-z0-9\s]/g, '');
 
           function getForumViolationCount() {
             try { return Number(localStorage.getItem(forumViolationKey()) || '0') || 0; } catch { return 0; }
@@ -29644,8 +29666,29 @@
             const text = forumInput.value.trim();
             if (!text && selectedFiles.length === 0) return;
             if (!currentUser) { setToast('Anda belum login!', 'warning'); return; }
+            if (getForumViolationCount() >= FORUM_VIOLATION_LIMIT && !forumUnblockedByAppeal) {
+              forumInput.disabled = true;
+              setToast('🚫 Akun kamu dibatasi setelah 5x pelanggaran. Ajukan appeal via AI Navigator / tiket email.', 'danger');
+              return;
+            }
 
-            const normalized = text.toLowerCase();
+            try {
+              const forumStatusResp = await fetch(`/api/forum/status?userId=${encodeURIComponent(currentUser.uid)}`);
+              const forumStatusData = await forumStatusResp.json().catch(() => ({}));
+              if (forumStatusResp.ok && forumStatusData?.ok) {
+                forumUnblockedByAppeal = Boolean(forumStatusData.unblockedByAppeal);
+                if (forumStatusData.blocked && !forumUnblockedByAppeal) {
+                  setForumViolationCount(Math.max(FORUM_VIOLATION_LIMIT, Number(forumStatusData.violationCount || 0) || FORUM_VIOLATION_LIMIT));
+                  forumInput.disabled = true;
+                  forumInput.placeholder = 'Akun forum dibatasi karena 5x pelanggaran. Ajukan appeal via AI Navigator / tiket email (respon 2x24 jam).';
+                  updateSendButtonState();
+                  setToast('🚫 Status akun forum kamu sedang dibatasi oleh sistem moderasi.', 'danger');
+                  return;
+                }
+              }
+            } catch { }
+
+            const normalized = normalizeForumText(text);
             const hasBadWord = FORUM_BADWORDS.some((w) => normalized.includes(w));
             if (hasBadWord) {
               const nextCount = getForumViolationCount() + 1;
@@ -29653,6 +29696,8 @@
               await reportForumModeration(text, nextCount);
               if (nextCount >= FORUM_VIOLATION_LIMIT) {
                 setToast('🚫 Kamu diblokir sementara setelah 5x pelanggaran. Ajukan appeal lewat AI Navigator / tiket email. Estimasi review 2x24 jam.', 'danger');
+                forumInput.disabled = true;
+                forumInput.placeholder = 'Akun forum dibatasi karena 5x pelanggaran. Ajukan appeal via AI Navigator / tiket email (respon 2x24 jam).';
                 forumInput.value = '';
                 updateSendButtonState();
                 return;


### PR DESCRIPTION
### Motivation

- Provide an easy way to run load tests (k6) and surface results inside the Admin Dashboard for quick monitoring and post-mortem.
- Ensure tickets created by the AI Navigator include the user's Google name/email so support has context when handling issues.
- Make forum moderation deterministic so users that hit the toxic threshold are reliably prevented from posting and the client/server states stay in sync.

### Description

- Add in-memory storage and helper for load test reports (`loadTestReports`, `addLoadTestReport`) and expose ingest endpoint `POST /api/load-test/report` that accepts a bearer or `x-loadtest-token` protected token.
- Add admin endpoints `GET /api/admin/load-tests` and include `loadTesting` summary in `GET /api/admin/stats` so dashboard can display latest reports.
- Add a k6 script `load-tests/k6-admin-dashboard.js` that runs mixed requests and posts a summarized report to `/api/load-test/report` in `handleSummary` (configurable via env vars such as `K6_VUS`, `K6_DURATION`, `LOAD_TEST_REPORT_TOKEN`).
- Update Admin Dashboard UI (`public-ui/admin-dashboard.html`) with a new "Load Testing Monitor (k6)" panel, a `renderLoadTesting` renderer, and socket support (`admin:loadTestReport`) to notify and refresh when new reports arrive.
- Change AI Navigator flow in the frontend (`index.html`) so `open_ticket` action pre-fills `name` and `email` from the Google session and injects a `User Google: <name> <email>` header into the ticket body.
- Harden forum moderation on the client (`index.html`) by adding `normalizeForumText` (basic leetspeak/symbol normalization), querying server state via `/api/forum/status?userId=...` before sending, and enforcing disable/placeholder when violation count >= 5.
- Document quick usage in `README.md` for the k6 script and required server env `LOAD_TEST_REPORT_TOKEN`.

### Testing

- Ran `node --check index.js` to validate server file syntax and it succeeded.
- Verified repository changes are staged/committed and `git status` shows the new/modified files (`README.md`, `index.js`, `index.html`, `public-ui/admin-dashboard.html`, `load-tests/k6-admin-dashboard.js`).
- No automated unit tests added; runtime behavior for load test ingestion and dashboard rendering should be validated by running the server and executing the `k6` script with `LOAD_TEST_REPORT_TOKEN` set (instructions added to `README.md`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcf721b2d4832fb384ac7d9117332f)