### PR TITLE
Fix persistent realtime support tickets

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,6 +60,12 @@ import {
   listRecentSupports,
 } from "./support_store.js";
 import { CacheStore } from "./lib/cache_store.js";
+import {
+  createTicket,
+  getTicket,
+  listTickets,
+  updateTicket,
+} from "./ticket_store.js";
 // Tambahan untuk ffmpeg portable (opsional)
 let ffmpegPath = null;
 try {
@@ -9505,7 +9511,15 @@ app.get("/internal/worker/cookies", async (req, res) => {
 
 // ===== /api/contact: Ticket Submission Endpoint =====
 const userViolations = new Map(); // userId -> { count, banned, bannedAt }
-const supportTickets = new Map(); // ticketId -> ticket payload
+const supportTickets = new Map(); // local cache for dashboard metrics only
+const ticketRoom = (ticketId) => `ticket:${String(ticketId || "").trim().toUpperCase()}`;
+try {
+  const persistedTickets = await listTickets();
+  persistedTickets.forEach((ticket) => supportTickets.set(ticket.ticketId, ticket));
+  console.log(`[ticket-store] loaded ${persistedTickets.length} persisted ticket(s)`);
+} catch (err) {
+  console.error("[ticket-store] gagal memuat ticket saat startup", err);
+}
 const activityLogs = [];
 const MAX_ACTIVITY_LOGS = 300;
 const conversionMetrics = {
@@ -9738,7 +9752,7 @@ app.post('/api/contact', async (req, res) => {
     if (!name || !email || !message) {
       return res.status(400).json({ ok: false, error: 'Lengkapi data tiket' });
     }
-    const tid = ticketId || ('TKT-' + Date.now().toString(36).toUpperCase().slice(-8));
+    const tid = String(ticketId || ('TKT-' + Date.now().toString(36).toUpperCase().slice(-8))).trim().toUpperCase();
     const ticket = {
       ticketId: tid,
       name: String(name).slice(0, 100),
@@ -9788,6 +9802,27 @@ app.post('/api/contact', async (req, res) => {
       }
     }
 
+    // Persist before any email/network side effect so a restart cannot lose the ticket.
+    const statusLink = `${DEFAULT_PUBLIC_BASE_URL || "https://ytconv.up.railway.app"}/ticket-status.html?ticket_id=${encodeURIComponent(tid)}`;
+    const initialTicket = await createTicket({
+      ...ticket,
+      proofs: uploadedProofs,
+      status: "received",
+      statusLabel: "Diterima",
+      statusUpdatedAt: ticket.submittedAt,
+      statusHistory: [{ status: "received", label: "Diterima", at: ticket.submittedAt, note: "Tiket dibuat oleh user" }],
+      adminReply: "",
+      chatHistory: [{
+        id: `CHAT-${Date.now().toString(36).toUpperCase().slice(-8)}`,
+        sender: "user",
+        message: ticket.message,
+        at: ticket.submittedAt,
+      }],
+      statusLink,
+      autoReplyEmailStatus: "queued",
+    });
+    supportTickets.set(tid, initialTicket);
+
     // Log the ticket for admin
     console.log('[YTConv CS Ticket]', JSON.stringify(ticket));
 
@@ -9828,7 +9863,6 @@ app.post('/api/contact', async (req, res) => {
       console.warn(`[YTConv CS Ticket] email belum terkirim untuk ${tid}: ${emailResult.reason || 'unknown reason'}`);
     }
 
-    const statusLink = `${DEFAULT_PUBLIC_BASE_URL || "https://ytconv.up.railway.app"}/ticket-status.html?ticket_id=${encodeURIComponent(tid)}`;
     const autoReplyHtml = `
 <div style="font-family: Arial, sans-serif; background:#f4f6f9; padding:20px;">
   <div style="max-width:600px; margin:auto; background:#ffffff; border-radius:12px; overflow:hidden; box-shadow:0 10px 25px rgba(0,0,0,0.08);">
@@ -9873,23 +9907,11 @@ app.post('/api/contact', async (req, res) => {
       html: autoReplyHtml,
     });
 
-    supportTickets.set(tid, {
-      ...ticket,
-      proofs: uploadedProofs,
-      status: "received",
-      statusLabel: "Diterima",
-      statusUpdatedAt: ticket.submittedAt,
-      statusHistory: [{ status: "received", label: "Diterima", at: ticket.submittedAt, note: "Tiket dibuat oleh user" }],
-      adminReply: "",
-      chatHistory: [{
-        id: `CHAT-${Date.now().toString(36).toUpperCase().slice(-8)}`,
-        sender: "user",
-        message: ticket.message,
-        at: ticket.submittedAt,
-      }],
-      statusLink,
-      autoReplyEmailStatus: autoReplyResult.sent ? "sent" : "queued",
-    });
+    const persistedTicket = await updateTicket(tid, (current) => {
+      current.autoReplyEmailStatus = autoReplyResult.sent ? "sent" : "queued";
+      return current;
+    }) || initialTicket;
+    supportTickets.set(tid, persistedTicket);
     pushActivityLog("ticket_created", `Tiket ${tid} dibuat`, { ticketId: tid, category: ticket.category });
     io.emit("admin:newTicket", {
       ticketId: tid,
@@ -10025,49 +10047,62 @@ app.get("/api/forum/status", (req, res) => {
   });
 });
 
-app.get("/api/ticket/:ticketId", (req, res) => {
+app.get("/api/ticket/:ticketId", async (req, res) => {
   const ticketId = String(req.params.ticketId || "").trim().toUpperCase();
   if (!ticketId) return res.status(400).json({ ok: false, error: "ticket_id_invalid" });
-  const ticket = supportTickets.get(ticketId);
-  if (!ticket) return res.status(404).json({ ok: false, error: "ticket_not_found" });
-  return res.json({
-    ok: true,
-    ticket: {
-      ticketId: ticket.ticketId,
-      name: ticket.name,
-      email: ticket.email,
-      category: ticket.category,
-      message: ticket.message,
-      status: ticket.status,
-      statusLabel: ticket.statusLabel,
-      statusUpdatedAt: ticket.statusUpdatedAt,
-      statusHistory: ticket.statusHistory || [],
-      adminReply: ticket.adminReply || "",
-      chatHistory: ticket.chatHistory || [],
-      submittedAt: ticket.submittedAt,
-      proofs: (ticket.proofs || []).map((p) => ({ name: p.name, url: p.url, type: p.type, size: p.size })),
-    },
-  });
+  try {
+    const ticket = await getTicket(ticketId);
+    if (!ticket) return res.status(404).json({ ok: false, error: "ticket_not_found" });
+    supportTickets.set(ticketId, ticket);
+    return res.json({
+      ok: true,
+      ticket: {
+        ticketId: ticket.ticketId,
+        name: ticket.name,
+        email: ticket.email,
+        category: ticket.category,
+        message: ticket.message,
+        status: ticket.status,
+        statusLabel: ticket.statusLabel,
+        statusUpdatedAt: ticket.statusUpdatedAt,
+        statusHistory: ticket.statusHistory || [],
+        adminReply: ticket.adminReply || "",
+        chatHistory: ticket.chatHistory || [],
+        submittedAt: ticket.submittedAt,
+        proofs: (ticket.proofs || []).map((p) => ({ name: p.name, url: p.url, type: p.type, size: p.size })),
+      },
+    });
+  } catch (err) {
+    console.error(`[ticket-store] gagal membaca ${ticketId}`, err);
+    return res.status(503).json({ ok: false, error: "ticket_store_unavailable" });
+  }
 });
 
-app.get("/api/admin/tickets", (req, res) => {
+app.get("/api/admin/tickets", async (req, res) => {
   if (!isAdminBearerValid(req)) return res.status(401).json({ ok: false, error: "unauthorized" });
-  const items = Array.from(supportTickets.values())
-    .sort((a, b) => String(b.submittedAt || "").localeCompare(String(a.submittedAt || "")))
-    .map((ticket) => ({
-      ticketId: ticket.ticketId,
-      name: ticket.name,
-      email: ticket.email,
-      category: ticket.category,
-      message: ticket.message,
-      status: ticket.status,
-      statusLabel: ticket.statusLabel,
-      statusUpdatedAt: ticket.statusUpdatedAt,
-      submittedAt: ticket.submittedAt,
-      proofs: ticket.proofs || [],
-      adminReply: ticket.adminReply || "",
-    }));
-  return res.json({ ok: true, tickets: items });
+  try {
+    const persistedTickets = await listTickets();
+    persistedTickets.forEach((ticket) => supportTickets.set(ticket.ticketId, ticket));
+    const items = persistedTickets
+      .sort((a, b) => String(b.submittedAt || "").localeCompare(String(a.submittedAt || "")))
+      .map((ticket) => ({
+        ticketId: ticket.ticketId,
+        name: ticket.name,
+        email: ticket.email,
+        category: ticket.category,
+        message: ticket.message,
+        status: ticket.status,
+        statusLabel: ticket.statusLabel,
+        statusUpdatedAt: ticket.statusUpdatedAt,
+        submittedAt: ticket.submittedAt,
+        proofs: ticket.proofs || [],
+        adminReply: ticket.adminReply || "",
+      }));
+    return res.json({ ok: true, tickets: items });
+  } catch (err) {
+    console.error("[ticket-store] gagal memuat daftar ticket", err);
+    return res.status(503).json({ ok: false, error: "ticket_store_unavailable" });
+  }
 });
 
 app.get("/api/admin/appeals", (req, res) => {
@@ -10367,87 +10402,108 @@ app.get("/api/admin/stats", (req, res) => {
 app.patch("/api/admin/tickets/:ticketId", express.json({ limit: "512kb" }), async (req, res) => {
   if (!isAdminBearerValid(req)) return res.status(401).json({ ok: false, error: "unauthorized" });
   const ticketId = String(req.params.ticketId || "").trim().toUpperCase();
-  const ticket = supportTickets.get(ticketId);
-  if (!ticket) return res.status(404).json({ ok: false, error: "ticket_not_found" });
-  const status = String(req.body?.status || ticket.status || "received").trim().toLowerCase();
-  const statusLabel = String(req.body?.statusLabel || "").trim() || ({
+  const requestedStatus = String(req.body?.status || "").trim().toLowerCase();
+  const requestedLabel = String(req.body?.statusLabel || "").trim();
+  const adminReply = String(req.body?.adminReply || "").slice(0, 4000);
+  const nowIso = new Date().toISOString();
+  const statusLabels = {
     received: "Diterima",
     reviewing: "Diproses",
     waiting_user: "Menunggu User",
     resolved: "Selesai",
     rejected: "Ditolak",
-  }[status] || status);
-  const adminReply = String(req.body?.adminReply || "").slice(0, 4000);
-  const nowIso = new Date().toISOString();
-  ticket.status = status;
-  ticket.statusLabel = statusLabel;
-  ticket.statusUpdatedAt = nowIso;
-  if (adminReply) ticket.adminReply = adminReply;
-  if (!Array.isArray(ticket.statusHistory)) ticket.statusHistory = [];
-  ticket.statusHistory.push({ status, label: statusLabel, at: nowIso, note: adminReply || "Update status admin" });
-  supportTickets.set(ticketId, ticket);
-  io.emit("admin:ticketUpdated", {
-    ticketId,
-    status,
-    statusLabel,
-    adminReply,
-    statusUpdatedAt: nowIso,
-  });
-  pushActivityLog("ticket_updated", `Tiket ${ticketId} diubah ke ${statusLabel}`, { ticketId, status });
+  };
 
-  const statusLink = ticket.statusLink || `${DEFAULT_PUBLIC_BASE_URL || "https://ytconv.up.railway.app"}/ticket-status.html?ticket_id=${encodeURIComponent(ticketId)}`;
-  const uploadProofHint = `${statusLink}#upload-proof`;
-  const waitingUserTemplate = `Mohon upload bukti tambahan via link ini: ${uploadProofHint} atau buka halaman status tiket dan gunakan nomor tiket ${ticketId}.`;
-  if (status === "waiting_user") {
-    ticket.adminReply = adminReply || waitingUserTemplate;
+  try {
+    const ticket = await updateTicket(ticketId, (current) => {
+      const status = requestedStatus || current.status || "received";
+      const statusLabel = requestedLabel || statusLabels[status] || status;
+      const statusLink = current.statusLink || `${DEFAULT_PUBLIC_BASE_URL || "https://ytconv.up.railway.app"}/ticket-status.html?ticket_id=${encodeURIComponent(ticketId)}`;
+      const waitingUserTemplate = `Mohon upload bukti tambahan via link ini: ${statusLink}#upload-proof atau buka halaman status tiket dan gunakan nomor tiket ${ticketId}.`;
+      current.status = status;
+      current.statusLabel = statusLabel;
+      current.statusUpdatedAt = nowIso;
+      if (adminReply || status === "waiting_user") current.adminReply = adminReply || waitingUserTemplate;
+      if (!Array.isArray(current.statusHistory)) current.statusHistory = [];
+      current.statusHistory.push({
+        status,
+        label: statusLabel,
+        at: nowIso,
+        note: current.adminReply || "Update status admin",
+      });
+      return current;
+    });
+    if (!ticket) return res.status(404).json({ ok: false, error: "ticket_not_found" });
+
     supportTickets.set(ticketId, ticket);
-  }
-  const effectiveReply = ticket.adminReply || adminReply || "";
-  const replyHtml = `
-  <div style="font-family:Arial,sans-serif;padding:18px;background:#f8fafc;">
-    <div style="max-width:640px;margin:auto;background:#fff;border:1px solid #e5e7eb;border-radius:10px;padding:18px;">
-      <h3 style="margin-top:0;">Update Status Tiket ${ticketId}</h3>
-      <p>Status terbaru: <b>${statusLabel}</b></p>
-      ${effectiveReply ? `<p>Pesan admin:</p><div style="background:#f3f4f6;padding:10px;border-radius:6px;">${effectiveReply.replace(/\n/g, "<br>")}</div>` : ""}
-      <p><a href="${statusLink}" target="_blank" rel="noopener noreferrer">Cek Status Tiket</a></p>
-    </div>
-  </div>`;
-  await sendSupportEmail({
-    to: ticket.email,
-    subject: `[TIKET ${ticketId}] Update status: ${statusLabel}`,
-    lines: [`Tiket ${ticketId} status terbaru: ${statusLabel}`, `Cek status: ${statusLink}`],
-    html: replyHtml,
-  });
+    const updatePayload = {
+      ticketId,
+      status: ticket.status,
+      statusLabel: ticket.statusLabel,
+      adminReply: ticket.adminReply || "",
+      statusUpdatedAt: nowIso,
+    };
+    io.emit("admin:ticketUpdated", updatePayload);
+    io.to(ticketRoom(ticketId)).emit("ticket:updated", updatePayload);
+    pushActivityLog("ticket_updated", `Tiket ${ticketId} diubah ke ${ticket.statusLabel}`, { ticketId, status: ticket.status });
 
-  return res.json({ ok: true, ticket });
+    const statusLink = ticket.statusLink || `${DEFAULT_PUBLIC_BASE_URL || "https://ytconv.up.railway.app"}/ticket-status.html?ticket_id=${encodeURIComponent(ticketId)}`;
+    const effectiveReply = ticket.adminReply || "";
+    const replyHtml = `
+    <div style="font-family:Arial,sans-serif;padding:18px;background:#f8fafc;">
+      <div style="max-width:640px;margin:auto;background:#fff;border:1px solid #e5e7eb;border-radius:10px;padding:18px;">
+        <h3 style="margin-top:0;">Update Status Tiket ${ticketId}</h3>
+        <p>Status terbaru: <b>${ticket.statusLabel}</b></p>
+        ${effectiveReply ? `<p>Pesan admin:</p><div style="background:#f3f4f6;padding:10px;border-radius:6px;">${effectiveReply.replace(/\n/g, "<br>")}</div>` : ""}
+        <p><a href="${statusLink}" target="_blank" rel="noopener noreferrer">Cek Status Tiket</a></p>
+      </div>
+    </div>`;
+    await sendSupportEmail({
+      to: ticket.email,
+      subject: `[TIKET ${ticketId}] Update status: ${ticket.statusLabel}`,
+      lines: [`Tiket ${ticketId} status terbaru: ${ticket.statusLabel}`, `Cek status: ${statusLink}`],
+      html: replyHtml,
+    });
+
+    return res.json({ ok: true, ticket });
+  } catch (err) {
+    console.error(`[ticket-store] gagal update ${ticketId}`, err);
+    return res.status(503).json({ ok: false, error: "ticket_store_unavailable" });
+  }
 });
 
-app.post("/api/admin/tickets/:ticketId/chat", express.json({ limit: "512kb" }), (req, res) => {
+app.post("/api/admin/tickets/:ticketId/chat", express.json({ limit: "512kb" }), async (req, res) => {
   if (!isAdminBearerValid(req)) return res.status(401).json({ ok: false, error: "unauthorized" });
   const ticketId = String(req.params.ticketId || "").trim().toUpperCase();
-  const ticket = supportTickets.get(ticketId);
-  if (!ticket) return res.status(404).json({ ok: false, error: "ticket_not_found" });
   const text = String(req.body?.message || "").trim();
   if (!text) return res.status(400).json({ ok: false, error: "message_required" });
-  const nowIso = new Date().toISOString();
   const chatEntry = {
     id: `CHAT-${Date.now().toString(36).toUpperCase().slice(-8)}`,
     sender: "admin",
     message: text.slice(0, 2000),
-    at: nowIso,
+    at: new Date().toISOString(),
   };
-  if (!Array.isArray(ticket.chatHistory)) ticket.chatHistory = [];
-  ticket.chatHistory.push(chatEntry);
-  supportTickets.set(ticketId, ticket);
-  io.emit("admin:ticketChat", { ticketId, chat: chatEntry });
-  pushActivityLog("admin_reply", `Admin membalas tiket ${ticketId}`, { ticketId });
-  return res.json({ ok: true, chat: chatEntry, ticketId });
+
+  try {
+    const ticket = await updateTicket(ticketId, (current) => {
+      if (!Array.isArray(current.chatHistory)) current.chatHistory = [];
+      current.chatHistory.push(chatEntry);
+      return current;
+    });
+    if (!ticket) return res.status(404).json({ ok: false, error: "ticket_not_found" });
+    supportTickets.set(ticketId, ticket);
+    io.emit("admin:ticketChat", { ticketId, chat: chatEntry });
+    io.to(ticketRoom(ticketId)).emit("ticket:chat", { ticketId, chat: chatEntry });
+    pushActivityLog("admin_reply", `Admin membalas tiket ${ticketId}`, { ticketId });
+    return res.json({ ok: true, chat: chatEntry, ticketId });
+  } catch (err) {
+    console.error(`[ticket-store] gagal menyimpan chat admin ${ticketId}`, err);
+    return res.status(503).json({ ok: false, error: "ticket_store_unavailable" });
+  }
 });
 
-app.post("/api/ticket/:ticketId/chat", express.json({ limit: "512kb" }), (req, res) => {
+app.post("/api/ticket/:ticketId/chat", express.json({ limit: "512kb" }), async (req, res) => {
   const ticketId = String(req.params.ticketId || "").trim().toUpperCase();
-  const ticket = supportTickets.get(ticketId);
-  if (!ticket) return res.status(404).json({ ok: false, error: "ticket_not_found" });
   const text = String(req.body?.message || "").trim();
   if (!text) return res.status(400).json({ ok: false, error: "message_required" });
   const nowIso = new Date().toISOString();
@@ -10457,22 +10513,35 @@ app.post("/api/ticket/:ticketId/chat", express.json({ limit: "512kb" }), (req, r
     message: text.slice(0, 2000),
     at: nowIso,
   };
-  if (!Array.isArray(ticket.chatHistory)) ticket.chatHistory = [];
-  ticket.chatHistory.push(chatEntry);
-  ticket.status = ticket.status === "resolved" ? "reviewing" : ticket.status;
-  ticket.statusLabel = ticket.status === "reviewing" ? "Diproses" : ticket.statusLabel;
-  ticket.statusUpdatedAt = nowIso;
-  supportTickets.set(ticketId, ticket);
-  io.emit("admin:ticketChat", { ticketId, chat: chatEntry });
-  io.emit("admin:ticketUpdated", { ticketId, status: ticket.status, statusLabel: ticket.statusLabel, statusUpdatedAt: nowIso });
-  pushActivityLog("user_reply", `User membalas tiket ${ticketId}`, { ticketId });
-  return res.json({ ok: true, chat: chatEntry, ticketId, remaining: null });
+
+  try {
+    const ticket = await updateTicket(ticketId, (current) => {
+      if (!Array.isArray(current.chatHistory)) current.chatHistory = [];
+      current.chatHistory.push(chatEntry);
+      current.status = current.status === "resolved" ? "reviewing" : current.status;
+      current.statusLabel = current.status === "reviewing" ? "Diproses" : current.statusLabel;
+      current.statusUpdatedAt = nowIso;
+      return current;
+    });
+    if (!ticket) return res.status(404).json({ ok: false, error: "ticket_not_found" });
+    supportTickets.set(ticketId, ticket);
+    const payload = { ticketId, chat: chatEntry };
+    io.emit("admin:ticketChat", payload);
+    io.to(ticketRoom(ticketId)).emit("ticket:chat", payload);
+    io.emit("admin:ticketUpdated", { ticketId, status: ticket.status, statusLabel: ticket.statusLabel, statusUpdatedAt: nowIso });
+    io.to(ticketRoom(ticketId)).emit("ticket:updated", { ticketId, status: ticket.status, statusLabel: ticket.statusLabel, statusUpdatedAt: nowIso });
+    pushActivityLog("user_reply", `User membalas tiket ${ticketId}`, { ticketId });
+    return res.json({ ok: true, chat: chatEntry, ticketId, remaining: null });
+  } catch (err) {
+    console.error(`[ticket-store] gagal menyimpan chat user ${ticketId}`, err);
+    return res.status(503).json({ ok: false, error: "ticket_store_unavailable" });
+  }
 });
 
 app.post("/api/ticket/:ticketId/proofs", express.json({ limit: "12mb" }), async (req, res) => {
   const ticketId = String(req.params.ticketId || "").trim().toUpperCase();
-  const ticket = supportTickets.get(ticketId);
-  if (!ticket) return res.status(404).json({ ok: false, error: "ticket_not_found" });
+  const existingTicket = await getTicket(ticketId).catch(() => null);
+  if (!existingTicket) return res.status(404).json({ ok: false, error: "ticket_not_found" });
   const proofs = Array.isArray(req.body?.proofs) ? req.body.proofs : [];
   if (!proofs.length) return res.status(400).json({ ok: false, error: "proof_required" });
   const note = String(req.body?.note || "").trim().slice(0, 2000);
@@ -10515,24 +10584,38 @@ app.post("/api/ticket/:ticketId/proofs", express.json({ limit: "12mb" }), async 
     }
   }
   if (!uploaded.length) return res.status(400).json({ ok: false, error: "proof_upload_failed" });
-  if (!Array.isArray(ticket.proofs)) ticket.proofs = [];
-  ticket.proofs.push(...uploaded);
-  if (!Array.isArray(ticket.chatHistory)) ticket.chatHistory = [];
+
   const nowIso = new Date().toISOString();
-  ticket.chatHistory.push({
+  const chatEntry = {
     id: `CHAT-${Date.now().toString(36).toUpperCase().slice(-8)}`,
     sender: "user",
     message: `Mengirim bukti tambahan (${uploaded.length} file).${note ? ` Catatan: ${note}` : ""}`,
     at: nowIso,
-  });
-  ticket.status = ticket.status === "waiting_user" ? "reviewing" : ticket.status;
-  ticket.statusLabel = ticket.status === "reviewing" ? "Diproses" : ticket.statusLabel;
-  ticket.statusUpdatedAt = nowIso;
-  supportTickets.set(ticketId, ticket);
-  io.emit("admin:ticketUpdated", { ticketId, status: ticket.status, statusLabel: ticket.statusLabel, statusUpdatedAt: nowIso });
-  io.emit("admin:ticketChat", { ticketId, chat: ticket.chatHistory[ticket.chatHistory.length - 1] });
-  pushActivityLog("ticket_proof_uploaded", `User upload bukti tambahan ${ticketId}`, { ticketId, count: uploaded.length });
-  return res.json({ ok: true, uploaded, count: uploaded.length, ticketId });
+  };
+  try {
+    const ticket = await updateTicket(ticketId, (current) => {
+      if (!Array.isArray(current.proofs)) current.proofs = [];
+      current.proofs.push(...uploaded);
+      if (!Array.isArray(current.chatHistory)) current.chatHistory = [];
+      current.chatHistory.push(chatEntry);
+      current.status = current.status === "waiting_user" ? "reviewing" : current.status;
+      current.statusLabel = current.status === "reviewing" ? "Diproses" : current.statusLabel;
+      current.statusUpdatedAt = nowIso;
+      return current;
+    });
+    if (!ticket) return res.status(404).json({ ok: false, error: "ticket_not_found" });
+    supportTickets.set(ticketId, ticket);
+    const updatePayload = { ticketId, status: ticket.status, statusLabel: ticket.statusLabel, statusUpdatedAt: nowIso };
+    io.emit("admin:ticketUpdated", updatePayload);
+    io.to(ticketRoom(ticketId)).emit("ticket:updated", updatePayload);
+    io.emit("admin:ticketChat", { ticketId, chat: chatEntry });
+    io.to(ticketRoom(ticketId)).emit("ticket:chat", { ticketId, chat: chatEntry });
+    pushActivityLog("ticket_proof_uploaded", `User upload bukti tambahan ${ticketId}`, { ticketId, count: uploaded.length });
+    return res.json({ ok: true, uploaded, count: uploaded.length, ticketId });
+  } catch (err) {
+    console.error(`[ticket-store] gagal menyimpan bukti ${ticketId}`, err);
+    return res.status(503).json({ ok: false, error: "ticket_store_unavailable" });
+  }
 });
 
 app.post("/api/admin/control", express.json({ limit: "128kb" }), (req, res) => {
@@ -10702,6 +10785,26 @@ io.on("connection", (socket) => {
   conversionMetrics.entered += 1;
   pushActivityLog("user_connected", `Socket ${socket.id} connected`, { socketId: socket.id });
   emitDashboardStats();
+
+  socket.on("ticket:subscribe", async (payload, acknowledge) => {
+    const ticketId = String(payload?.ticketId || "").trim().toUpperCase();
+    if (!ticketId) {
+      if (typeof acknowledge === "function") acknowledge({ ok: false, error: "ticket_id_invalid" });
+      return;
+    }
+    try {
+      const ticket = await getTicket(ticketId);
+      if (!ticket) {
+        if (typeof acknowledge === "function") acknowledge({ ok: false, error: "ticket_not_found" });
+        return;
+      }
+      socket.join(ticketRoom(ticketId));
+      if (typeof acknowledge === "function") acknowledge({ ok: true, ticketId });
+    } catch (err) {
+      console.error(`[ticket-store] gagal subscribe ${ticketId}`, err);
+      if (typeof acknowledge === "function") acknowledge({ ok: false, error: "ticket_store_unavailable" });
+    }
+  });
 
   socket.on("page_change", (payload) => {
     const page = String(payload?.page || "unknown").slice(0, 128);

--- a/public-ui/ticket-status.html
+++ b/public-ui/ticket-status.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Status Tiket • YTConv</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <script src="/socket.io/socket.io.js"></script>
 </head>
 <body class="min-h-screen bg-slate-950 text-slate-100">
   <main class="max-w-3xl mx-auto p-4 md:p-6 space-y-4">
@@ -67,6 +68,8 @@ const pathParts = location.pathname.split('/').filter(Boolean);
 const routeTicketId = pathParts[0] === 'ticket' && pathParts[1] ? String(pathParts[1]).trim().toUpperCase() : '';
 const ticketId = queryTicketId || routeTicketId;
 const fmt = new Intl.DateTimeFormat(undefined, { dateStyle:'full', timeStyle:'medium' });
+let refreshInFlight = null;
+let hasLoadedTicket = false;
 
 const statusColor = (st) => ({ received:'bg-blue-500/20 text-blue-300 border-blue-500/40', reviewing:'bg-amber-500/20 text-amber-300 border-amber-500/40', waiting_user:'bg-purple-500/20 text-purple-300 border-purple-500/40', resolved:'bg-emerald-500/20 text-emerald-300 border-emerald-500/40', rejected:'bg-rose-500/20 text-rose-300 border-rose-500/40' }[st] || 'bg-slate-700 text-slate-100 border-slate-500');
 const badge = (label, st) => `<span class="inline-flex px-2.5 py-1 rounded-full border text-sm font-semibold ${statusColor(st)}">${label || '-'}</span>`;
@@ -121,12 +124,20 @@ const renderProofPreview = () => {
 
 async function refresh(){
   if (!ticketId) return;
+  if (refreshInFlight) return refreshInFlight;
+  refreshInFlight = (async () => {
   try {
-    const r = await fetch(`/api/ticket/${encodeURIComponent(ticketId)}`);
+    const r = await fetch(`/api/ticket/${encodeURIComponent(ticketId)}`, { cache: 'no-store' });
     const d = await r.json().catch(() => ({}));
-    if (!r.ok || !d.ok) throw new Error(d.error || 'ticket_not_found');
+    if (!r.ok || !d.ok) {
+      const error = new Error(d.error || 'ticket_not_found');
+      error.status = r.status;
+      throw error;
+    }
     const t = d.ticket || {};
     currentTicket = t;
+    hasLoadedTicket = true;
+    hintEl.textContent = 'Status tersambung dan diperbarui otomatis secara realtime.';
     statusWrap.innerHTML = badge(t.statusLabel || t.status, t.status);
     updatedEl.textContent = asLocal(t.statusUpdatedAt);
     msgEl.textContent = t.message || '-';
@@ -148,9 +159,17 @@ async function refresh(){
       ? 'Admin meminta bukti tambahan. Upload foto lalu klik kirim ke admin.'
       : 'Upload bukti aktif saat status tiket: Menunggu User.';
   } catch (e) {
-    statusWrap.innerHTML = badge('Tiket tidak ditemukan', 'rejected');
-    replyEl.textContent = e.message || 'unknown_error';
+    if (!hasLoadedTicket && e.status === 404) {
+      statusWrap.innerHTML = badge('Tiket tidak ditemukan', 'rejected');
+      replyEl.textContent = 'Pastikan ID tiket sudah benar.';
+    } else {
+      hintEl.textContent = 'Koneksi sedang terganggu. Data ticket terakhir tetap ditampilkan dan sistem akan mencoba lagi otomatis.';
+    }
+  } finally {
+    refreshInFlight = null;
   }
+  })();
+  return refreshInFlight;
 }
 
 document.getElementById('chatForm').addEventListener('submit', async (evt) => {
@@ -223,7 +242,32 @@ proofSubmitBtn.addEventListener('click', async () => {
 });
 
 refresh();
+
+if (ticketId && typeof io === 'function') {
+  const socket = io({ transports: ['websocket', 'polling'] });
+  socket.on('connect', () => {
+    socket.emit('ticket:subscribe', { ticketId }, (result) => {
+      if (result?.ok) {
+        hintEl.textContent = 'Status tersambung dan diperbarui otomatis secara realtime.';
+      }
+    });
+  });
+  socket.on('ticket:updated', (payload) => {
+    if (String(payload?.ticketId || '').toUpperCase() === ticketId) refresh();
+  });
+  socket.on('ticket:chat', (payload) => {
+    if (String(payload?.ticketId || '').toUpperCase() === ticketId) refresh();
+  });
+  socket.on('disconnect', () => {
+    if (hasLoadedTicket) hintEl.textContent = 'Realtime terputus sementara; sinkronisasi berkala masih aktif.';
+  });
+}
+
 setInterval(refresh, 5000);
+window.addEventListener('focus', refresh);
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'visible') refresh();
+});
 </script>
 </body>
 </html>

--- a/tests/ticket-store.test.js
+++ b/tests/ticket-store.test.js
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+const tempDir = await mkdtemp(join(tmpdir(), "ytconv-ticket-store-"));
+const storePath = join(tempDir, "tickets.json");
+process.env.TICKET_STORE_PATH = storePath;
+delete process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
+delete process.env.FIREBASE_SERVICE_ACCOUNT_BASE64;
+
+const {
+  createTicket,
+  getTicket,
+  getTicketStoreBackend,
+  listTickets,
+  updateTicket,
+} = await import(`../ticket_store.js?test=${Date.now()}`);
+
+test.after(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+test("ticket disimpan persisten dan ID dinormalisasi", async () => {
+  assert.equal(getTicketStoreBackend(), "file");
+  const created = await createTicket({
+    ticketId: "tkt-persist-1",
+    name: "User",
+    status: "received",
+    chatHistory: [],
+  });
+
+  assert.equal(created.ticketId, "TKT-PERSIST-1");
+  assert.equal((await getTicket("tkt-persist-1")).name, "User");
+
+  const disk = JSON.parse(await readFile(storePath, "utf8"));
+  assert.equal(disk.tickets["TKT-PERSIST-1"].status, "received");
+});
+
+test("update concurrent tidak menghilangkan chat", async () => {
+  await Promise.all([
+    updateTicket("TKT-PERSIST-1", async (ticket) => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      ticket.chatHistory.push({ id: "CHAT-1", sender: "user" });
+      return ticket;
+    }),
+    updateTicket("TKT-PERSIST-1", (ticket) => {
+      ticket.chatHistory.push({ id: "CHAT-2", sender: "admin" });
+      return ticket;
+    }),
+  ]);
+
+  const ticket = await getTicket("TKT-PERSIST-1");
+  assert.deepEqual(ticket.chatHistory.map((entry) => entry.id), ["CHAT-1", "CHAT-2"]);
+  assert.equal((await listTickets()).length, 1);
+});
+
+test("ticket duplikat ditolak dan ticket yang tidak ada tetap null", async () => {
+  await assert.rejects(
+    createTicket({ ticketId: "TKT-PERSIST-1" }),
+    /ticket_already_exists/,
+  );
+  assert.equal(await getTicket("TKT-NOT-FOUND"), null);
+  assert.equal(await updateTicket("TKT-NOT-FOUND", (ticket) => ticket), null);
+});

--- a/ticket_store.js
+++ b/ticket_store.js
@@ -1,0 +1,175 @@
+import { promises as fsp } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { cert, getApps, initializeApp } from "firebase-admin/app";
+import { getFirestore } from "firebase-admin/firestore";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DATA_DIR = join(__dirname, "data");
+const TICKETS_PATH = process.env.TICKET_STORE_PATH || join(DATA_DIR, "tickets.json");
+const COLLECTION = "support-tickets";
+
+let fileWriteQueue = Promise.resolve();
+let firestoreDb;
+let backendLogged = false;
+
+const normalizeTicketId = (value) => String(value || "").trim().toUpperCase().slice(0, 80);
+
+const clone = (value) => {
+  if (value == null) return value;
+  return structuredClone(value);
+};
+
+const parseServiceAccount = () => {
+  const raw = String(process.env.FIREBASE_SERVICE_ACCOUNT_JSON || "").trim();
+  if (raw) return JSON.parse(raw);
+
+  const base64 = String(process.env.FIREBASE_SERVICE_ACCOUNT_BASE64 || "").trim();
+  if (base64) return JSON.parse(Buffer.from(base64, "base64").toString("utf8"));
+
+  return null;
+};
+
+const getTicketFirestore = () => {
+  if (firestoreDb !== undefined) return firestoreDb;
+
+  const serviceAccount = parseServiceAccount();
+  if (!serviceAccount) {
+    firestoreDb = null;
+    return firestoreDb;
+  }
+
+  const app = getApps()[0] || initializeApp({
+    credential: cert(serviceAccount),
+    projectId: process.env.FIREBASE_PROJECT_ID || serviceAccount.project_id,
+  });
+  firestoreDb = getFirestore(app);
+  return firestoreDb;
+};
+
+const logBackend = (name) => {
+  if (backendLogged) return;
+  backendLogged = true;
+  console.log(`[ticket-store] backend: ${name}`);
+};
+
+const readFileStore = async () => {
+  try {
+    const raw = await fsp.readFile(TICKETS_PATH, "utf8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return { tickets: {} };
+    if (!parsed.tickets || typeof parsed.tickets !== "object") parsed.tickets = {};
+    return parsed;
+  } catch (err) {
+    if (err?.code === "ENOENT") return { tickets: {} };
+    throw err;
+  }
+};
+
+const writeFileStore = async (data) => {
+  await fsp.mkdir(DATA_DIR, { recursive: true });
+  const tmpPath = `${TICKETS_PATH}.${process.pid}.${Date.now()}.tmp`;
+  await fsp.writeFile(tmpPath, JSON.stringify(data, null, 2), "utf8");
+  await fsp.rename(tmpPath, TICKETS_PATH);
+};
+
+const withFileWrite = (operation) => {
+  const run = fileWriteQueue.then(operation, operation);
+  fileWriteQueue = run.catch(() => {});
+  return run;
+};
+
+export const getTicketStoreBackend = () => (getTicketFirestore() ? "firestore" : "file");
+
+export const createTicket = async (ticket) => {
+  const ticketId = normalizeTicketId(ticket?.ticketId);
+  if (!ticketId) throw new Error("ticket_id_invalid");
+  const record = { ...clone(ticket), ticketId };
+  const db = getTicketFirestore();
+
+  if (db) {
+    logBackend("firestore");
+    const ref = db.collection(COLLECTION).doc(ticketId);
+    await db.runTransaction(async (transaction) => {
+      const snapshot = await transaction.get(ref);
+      if (snapshot.exists) throw new Error("ticket_already_exists");
+      transaction.set(ref, record);
+    });
+    return clone(record);
+  }
+
+  logBackend("file");
+  return withFileWrite(async () => {
+    const data = await readFileStore();
+    if (data.tickets[ticketId]) throw new Error("ticket_already_exists");
+    data.tickets[ticketId] = record;
+    await writeFileStore(data);
+    return clone(record);
+  });
+};
+
+export const getTicket = async (ticketIdValue) => {
+  const ticketId = normalizeTicketId(ticketIdValue);
+  if (!ticketId) return null;
+  const db = getTicketFirestore();
+
+  if (db) {
+    logBackend("firestore");
+    const snapshot = await db.collection(COLLECTION).doc(ticketId).get();
+    return snapshot.exists ? { ...snapshot.data(), ticketId } : null;
+  }
+
+  logBackend("file");
+  await fileWriteQueue;
+  const data = await readFileStore();
+  return clone(data.tickets[ticketId] || null);
+};
+
+export const listTickets = async () => {
+  const db = getTicketFirestore();
+  if (db) {
+    logBackend("firestore");
+    const snapshot = await db.collection(COLLECTION).get();
+    return snapshot.docs.map((doc) => ({ ...doc.data(), ticketId: doc.id }));
+  }
+
+  logBackend("file");
+  await fileWriteQueue;
+  const data = await readFileStore();
+  return Object.values(data.tickets).map(clone);
+};
+
+export const updateTicket = async (ticketIdValue, updater) => {
+  const ticketId = normalizeTicketId(ticketIdValue);
+  if (!ticketId) return null;
+  if (typeof updater !== "function") throw new TypeError("updater must be a function");
+  const db = getTicketFirestore();
+
+  if (db) {
+    logBackend("firestore");
+    const ref = db.collection(COLLECTION).doc(ticketId);
+    return db.runTransaction(async (transaction) => {
+      const snapshot = await transaction.get(ref);
+      if (!snapshot.exists) return null;
+      const current = { ...snapshot.data(), ticketId };
+      const updated = await updater(clone(current));
+      if (!updated) return null;
+      const record = { ...clone(updated), ticketId };
+      transaction.set(ref, record);
+      return clone(record);
+    });
+  }
+
+  logBackend("file");
+  return withFileWrite(async () => {
+    const data = await readFileStore();
+    const current = data.tickets[ticketId];
+    if (!current) return null;
+    const updated = await updater(clone(current));
+    if (!updated) return null;
+    const record = { ...clone(updated), ticketId };
+    data.tickets[ticketId] = record;
+    await writeFileStore(data);
+    return clone(record);
+  });
+};


### PR DESCRIPTION
### Motivation
- Tickets were stored only in an in-memory `Map`, causing tickets to disappear after restarts and producing inconsistent "not found" results in multi-instance deployments.
- The ticket UI relied solely on periodic polling so updates were not reliably realtime and the client could lose its last-known ticket state during transient failures.

### Description
- Add a new persistent ticket store `ticket_store.js` that supports Firestore (when service-account creds are provided) and an atomic JSON-file fallback for local environments, exposing `createTicket`, `getTicket`, `listTickets`, and `updateTicket` APIs. 
- Persist tickets before any email/network side effects and replace in-process-only writes with store-backed create/read/update flows in `index.js` so all ticket operations (create, status update, admin/user chat, proof upload, admin list) use the persistent store and are safe for concurrent updates. 
- Add Socket.IO ticket subscriptions and per-ticket rooms/events (`ticket:subscribe`, `ticket:updated`, `ticket:chat`) and emit those events when tickets are updated so clients receive realtime updates; keep a small local cache `supportTickets` for dashboard metrics only. 
- Update the client `public-ui/ticket-status.html` to connect to Socket.IO for realtime updates, keep the last-rendered ticket visible on transient failures, and retain periodic/focus-based fallback polling; add tests `tests/ticket-store.test.js` covering persistence, ID normalization, duplicate rejection, missing-ticket behavior, and concurrent updates.

### Testing
- Unit tests: ran `node --test tests/ticket-store.test.js` and all ticket-store tests passed (concurrency and persistence checks succeeded). 
- Static checks: ran `node --check index.js`, `node --check ticket_store.js`, and `node --check /tmp/ticket-status-script.js` (extracted client script) with no syntax errors reported. 
- Integration/manual: created a ticket via `POST /api/contact`, restarted the Node process, then verified `GET /api/ticket/:id` returned the same ticket (persistence across restart succeeded). 
- Notes: the full project test suite includes environment-dependent tests that fail in this environment (Assistant API/Groq not configured and `yt-dlp` auto-maintenance runs), those are pre-existing and did not block the ticket-store changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26cbfd9364832f8ae8cb902e7ea8d3)