### PR TITLE
Polish AI Navigator: carousel suggestions + Lite Mode

### DIFF
--- a/public-ui/app-main.js
+++ b/public-ui/app-main.js
@@ -8368,6 +8368,8 @@
             const chip = document.createElement('button');
             chip.type = 'button';
             chip.className = 'assistant-suggestion-chip';
+            chip.setAttribute('role', 'listitem');
+            chip.setAttribute('aria-label', `Pakai saran cepat: ${label}`);
             chip.textContent = label;
             chip.addEventListener('click', () => {
               if (assistantInput) {
@@ -16392,35 +16394,44 @@
             const selectBasic = document.getElementById('selectBasicMode');
             const selectAdvanced = document.getElementById('selectAdvancedMode');
             const selectGaptek = document.getElementById('selectGaptekMode');
+            const selectLite = document.getElementById('selectLiteMode');
             const modeKey = 'ytmp3_mode_pref';
 
             const setMode = (mode) => {
-              const isBasic = mode === 'basic';
+              const isLite = mode === 'lite';
+              const isBasic = mode === 'basic' || isLite;
               const isGaptek = mode === 'gaptek';
               const isAdvanced = !isBasic && !isGaptek;
+
+              document.body.classList.toggle('lite-mode', isLite);
 
               if (containerBasic) containerBasic.hidden = !isBasic;
               if (containerAdvanced) containerAdvanced.hidden = !isAdvanced;
               if (containerGaptek) containerGaptek.hidden = !isGaptek;
 
               if (labelToggle) {
-                if (isBasic) labelToggle.textContent = 'Mode: Basic';
+                if (isLite) labelToggle.textContent = 'Mode: Lite';
+                else if (isBasic) labelToggle.textContent = 'Mode: Basic';
                 else if (isGaptek) labelToggle.textContent = 'Mode: Gaptek';
                 else labelToggle.textContent = 'Mode: Advanced';
               }
               if (btnToggle) {
                 const icon = btnToggle.querySelector('i');
                 if (icon) {
-                  if (isBasic) icon.className = 'bi bi-magic';
+                  if (isLite) icon.className = 'bi bi-phone';
+                  else if (isBasic) icon.className = 'bi bi-magic';
                   else if (isGaptek) icon.className = 'bi bi-emoji-smile';
                   else icon.className = 'bi bi-sliders';
                 }
-                btnToggle.title = isBasic
-                  ? 'Basic Mode: cepat dan simpel'
-                  : (isGaptek ? 'Gaptek Mode: dipandu langkah demi langkah' : 'Advanced Mode: fitur paling lengkap');
+                btnToggle.title = isLite
+                  ? 'Lite Mode: ringan untuk hape jadul'
+                  : (isBasic
+                    ? 'Basic Mode: cepat dan simpel'
+                    : (isGaptek ? 'Gaptek Mode: dipandu langkah demi langkah' : 'Advanced Mode: fitur paling lengkap'));
                 // Update button style
-                btnToggle.classList.remove('text-primary', 'text-secondary', 'text-success');
-                if (isBasic) btnToggle.classList.add('text-primary');
+                btnToggle.classList.remove('text-primary', 'text-secondary', 'text-success', 'text-info');
+                if (isLite) btnToggle.classList.add('text-info');
+                else if (isBasic) btnToggle.classList.add('text-primary');
                 else if (isGaptek) btnToggle.classList.add('text-success');
                 else btnToggle.classList.add('text-secondary');
               }
@@ -16433,14 +16444,16 @@
             if (btnToggle) {
               btnToggle.addEventListener('click', () => {
                 const now = localStorage.getItem(modeKey) || 'basic';
-                // Cycle: Basic -> Advanced -> Gaptek -> Basic
+                // Cycle: Basic -> Lite -> Advanced -> Gaptek -> Basic
                 let next = 'basic';
-                if (now === 'basic') next = 'advanced';
+                if (now === 'basic') next = 'lite';
+                else if (now === 'lite') next = 'advanced';
                 else if (now === 'advanced') next = 'gaptek';
                 else next = 'basic';
 
                 setMode(next);
                 let msg = 'Basic Mode aktif';
+                if (next === 'lite') msg = 'Lite Mode aktif';
                 if (next === 'advanced') msg = 'Advanced Mode aktif';
                 if (next === 'gaptek') msg = 'Gaptek Mode aktif';
                 setToast(msg);
@@ -16511,8 +16524,17 @@
               };
 
               if (selectBasic) selectBasic.onclick = () => handleSelection('basic');
+              if (selectLite) selectLite.onclick = () => handleSelection('lite');
               if (selectAdvanced) selectAdvanced.onclick = () => handleSelection('advanced');
               if (selectGaptek) selectGaptek.onclick = () => handleSelection('gaptek');
+              [selectBasic, selectLite, selectAdvanced, selectGaptek].filter(Boolean).forEach((card) => {
+                card.addEventListener('keydown', (event) => {
+                  if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    card.click();
+                  }
+                });
+              });
 
               // Show if no mode selected
               if (!currentMode) {

--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -68,11 +68,23 @@
         document.head.appendChild(script);
       });
     };
-    window.addEventListener('load', function () {
+    (function () {
       var run = window.__ytconvLoadDeferredScripts;
-      if ('requestIdleCallback' in window) requestIdleCallback(run, { timeout: 1800 });
-      else setTimeout(run, 900);
-    }, { once: true });
+      var trigger = function () { run(); cleanup(); };
+      var cleanup = function () {
+        ['pointerdown', 'keydown', 'touchstart'].forEach(function (eventName) {
+          window.removeEventListener(eventName, trigger, { passive: true });
+        });
+      };
+      ['pointerdown', 'keydown', 'touchstart'].forEach(function (eventName) {
+        window.addEventListener(eventName, trigger, { once: true, passive: true });
+      });
+      window.addEventListener('load', function () {
+        if (document.body && document.body.classList.contains('lite-mode')) return;
+        if ('requestIdleCallback' in window) requestIdleCallback(run, { timeout: 6500 });
+        else setTimeout(run, 4500);
+      }, { once: true });
+    })();
   </script>
   <script>
     window.tailwind = window.tailwind || {};
@@ -3429,14 +3441,22 @@
     }
 
     .assistant-quick-suggestions {
-      display: grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: .45rem;
-      margin-top: .35rem;
-      max-height: 6.2rem;
-      overflow-y: auto;
-      padding: .15rem .15rem .3rem;
-      overscroll-behavior: contain;
+      display: flex;
+      gap: .5rem;
+      margin-top: .45rem;
+      overflow-x: auto;
+      overflow-y: hidden;
+      padding: .2rem .15rem .55rem;
+      overscroll-behavior-inline: contain;
+      scroll-snap-type: inline mandatory;
+      scrollbar-width: thin;
+      -webkit-overflow-scrolling: touch;
+    }
+
+    .assistant-quick-suggestions::before,
+    .assistant-quick-suggestions::after {
+      content: "";
+      flex: 0 0 .05rem;
     }
 
     .assistant-suggestion-chip {
@@ -3450,8 +3470,9 @@
       line-height: 1.15;
       text-align: center;
       white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
+      min-width: max-content;
+      flex: 0 0 auto;
+      scroll-snap-align: start;
       box-shadow: 0 8px 20px rgba(13, 110, 253, .12);
       transition: transform .16s ease, box-shadow .16s ease, background-color .16s ease;
     }
@@ -4126,14 +4147,52 @@
       }
 
       .assistant-quick-suggestions {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-        max-height: 5.3rem;
+        gap: .4rem;
+        padding-bottom: .45rem;
       }
 
       .assistant-suggestion-chip {
         font-size: .7rem;
-        padding-inline: .48rem;
+        padding-inline: .55rem;
       }
+    }
+
+
+    /* Lite mode keeps the same converter logic, but trims visual effects for old/low-end phones. */
+    body.lite-mode {
+      --lite-shadow: 0 8px 20px rgba(15, 23, 42, .18);
+    }
+
+    body.lite-mode *,
+    body.lite-mode *::before,
+    body.lite-mode *::after {
+      animation-duration: .001ms !important;
+      animation-iteration-count: 1 !important;
+      scroll-behavior: auto !important;
+      transition-duration: .001ms !important;
+    }
+
+    body.lite-mode .seasonal-bg,
+    body.lite-mode .background-orb,
+    body.lite-mode .aurora-orb,
+    body.lite-mode .legendary-stage,
+    body.lite-mode .music-widget,
+    body.lite-mode #forumWidget {
+      display: none !important;
+    }
+
+    body.lite-mode .card,
+    body.lite-mode .glass-card,
+    body.lite-mode .assistant-panel {
+      box-shadow: var(--lite-shadow) !important;
+      backdrop-filter: none !important;
+    }
+
+    body.lite-mode #basic-mode .card,
+    body.lite-mode #gaptek-mode .card {
+      border: 1px solid rgba(13, 110, 253, .28) !important;
+      border-radius: 1.25rem !important;
+      background: linear-gradient(180deg, rgba(15,23,42,.96), rgba(17,24,39,.98)) !important;
     }
 
     .ai-output {
@@ -5471,7 +5530,7 @@
       <!-- Gaptek Mode Container (Task 2) -->
       <div id="gaptek-mode" class="animate__animated animate__fadeIn" hidden>
         <div class="text-center mb-5 mt-4">
-          <h1 class="display-4 fw-bold text-primary mb-3">DOWNLOAD LAGU</h1>
+          <h2 class="display-4 fw-bold text-primary mb-3">DOWNLOAD LAGU</h2>
           <p class="lead fs-4 text-secondary">Cara paling gampang ambil lagu dari YouTube</p>
         </div>
 
@@ -9225,7 +9284,7 @@
         </header>
         <div class="assistant-body">
           <div class="assistant-messages" id="assistantMessages" aria-live="polite" tabindex="0"></div>
-          <div class="assistant-quick-suggestions" id="assistantQuickSuggestions" aria-label="Saran cepat AI Navigator"></div>
+          <div class="assistant-quick-suggestions" id="assistantQuickSuggestions" aria-label="Saran cepat AI Navigator" role="list" tabindex="0"></div>
           <div class="assistant-typing" id="assistantTyping" hidden>AI Navigator mengetik...</div>
           <div class="assistant-input">
             <input type="text" id="assistantInput" class="form-control"
@@ -9632,7 +9691,7 @@
 
             <div class="row g-4 justify-content-center">
               <!-- Gaptek Mode Card -->
-              <div class="col-lg-4 col-md-6">
+              <div class="col-lg-3 col-md-6">
                 <div class="card h-100 border-success border-2 shadow-sm hover-scale cursor-pointer"
                   id="selectGaptekMode" role="button">
                   <div class="card-body p-4">
@@ -9649,7 +9708,7 @@
               </div>
 
               <!-- Basic Mode Card -->
-              <div class="col-lg-4 col-md-6">
+              <div class="col-lg-3 col-md-6">
                 <div class="card h-100 border-primary border-2 shadow-sm hover-scale cursor-pointer"
                   id="selectBasicMode" role="button">
                   <div class="card-body p-4">
@@ -9665,8 +9724,25 @@
                 </div>
               </div>
 
+              <!-- Lite Mode Card -->
+              <div class="col-lg-3 col-md-6">
+                <div class="card h-100 border-info border-2 shadow-sm hover-scale cursor-pointer"
+                  id="selectLiteMode" role="button" tabindex="0" aria-label="Pilih Lite Mode untuk hape jadul">
+                  <div class="card-body p-4">
+                    <div class="display-4 text-info mb-3"><i class="bi bi-phone"></i></div>
+                    <h3 class="fw-bold text-info fs-4">Lite Mode</h3>
+                    <p class="text-muted small">Versi ringan buat hape kentang/jadul. Fitur converter tetap jalan.</p>
+                    <ul class="list-unstyled text-start small text-secondary mx-auto" style="max-width: 200px;">
+                      <li><i class="bi bi-check-circle-fill text-success me-2"></i>Animasi minimal</li>
+                      <li><i class="bi bi-check-circle-fill text-success me-2"></i>UI lebih ringkas</li>
+                      <li><i class="bi bi-check-circle-fill text-success me-2"></i>Hemat memori</li>
+                    </ul>
+                  </div>
+                </div>
+              </div>
+
               <!-- Advanced Mode Card -->
-              <div class="col-lg-4 col-md-6">
+              <div class="col-lg-3 col-md-6">
                 <div class="card h-100 border-secondary border-opacity-50 shadow-sm hover-scale cursor-pointer"
                   id="selectAdvancedMode" role="button">
                   <div class="card-body p-4">

--- a/tests/ui-polish.test.js
+++ b/tests/ui-polish.test.js
@@ -109,7 +109,7 @@ test("homepage menunda script berat dan menguatkan SEO", () => {
   assert.match(pages.home, /content-visibility: auto/);
   assert.match(pages.home, /modal-backdrop[\s\S]{0,220}background: rgba\(3, 7, 18, \.82\)/);
   assert.match(pages.home, /font-family: "Inter", "Segoe UI", system-ui/);
-  assert.match(pages.home, /requestIdleCallback\(run, \{ timeout: 1800 \}\)/);
+  assert.match(pages.home, /requestIdleCallback\(run, \{ timeout: 6500 \}\)/);
   assert.doesNotMatch(pages.home, /<script src="https:\/\/cdnjs\.cloudflare\.com\/ajax\/libs\/howler\/2\.2\.4\/howler\.min\.js"/);
   assert.doesNotMatch(pages.home, /<script src="https:\/\/accounts\.google\.com\/gsi\/client"/);
   assert.match(pages.home, /aria-label="Cari pertanyaan FAQ"/);
@@ -126,8 +126,8 @@ test("homepage memindahkan JavaScript utama ke asset cacheable", () => {
 
 
 test("AI Navigator dan backdrop modal tetap rapi", () => {
-  assert.match(pages.home, /\.assistant-quick-suggestions \{[\s\S]{0,180}grid-template-columns: repeat\(2, minmax\(0, 1fr\)\)/);
-  assert.match(pages.home, /text-overflow: ellipsis/);
+  assert.match(pages.home, /\.assistant-quick-suggestions \{[\s\S]{0,220}scroll-snap-type: inline mandatory/);
+  assert.match(pages.home, /\.assistant-suggestion-chip \{[\s\S]{0,700}scroll-snap-align: start/);
   assert.match(pages.home, /\.assistant-panel \.assistant-messages \{[\s\S]{0,180}max-height: clamp\(12rem, 40vh, 22rem\)/);
   assert.match(pages.home, /body \.modal-backdrop \{[\s\S]{0,180}pointer-events: auto !important/);
   assert.match(pages.home, /body \.modal-backdrop\.show \{[\s\S]{0,180}backdrop-filter: blur\(5px\)/);


### PR DESCRIPTION
### Motivation
- Improve the AI Navigator quick-suggestions layout to be touch-friendly and more accessible while preserving existing JS flows. 
- Raise perceived performance by deferring heavy third-party scripts until user interaction or a longer idle window. 
- Provide a lightweight UI variant for low-end / older phones that keeps converter functionality but reduces animations and heavy visuals. 

### Description
- Converted the AI quick suggestions from a two-column grid to a horizontal, scroll-snap carousel and added list semantics with `role="list"` on the container and `role="listitem"` + `aria-label` on suggestion chips (`public-ui/index.html`, `public-ui/app-main.js`).
- Added a `lite-mode` stylesheet block that disables animations/backdrops and trims visual effects for older phones, plus a new "Lite Mode" card in the welcome modal (`public-ui/index.html`).
- Extended the mode-switching logic to support `lite` mode, toggle `body.lite-mode`, update toggle icon/label, keyboard activation, and cycle order (`public-ui/app-main.js`).
- Changed deferred script loading to trigger on first interaction (pointer/keydown/touch) with a longer `requestIdleCallback` timeout for idle-triggered loading, and left Lite Mode exempt from idle-script loading to avoid delaying essential UX (`public-ui/index.html`).
- Minor accessibility/SEO polish: adjusted heading level for the Gaptek hero from `h1` to `h2` and added `tabindex`/ARIA where appropriate, and updated UI test expectations (`tests/ui-polish.test.js`).

### Testing
- Ran `node --check public-ui/app-main.js` to validate modified JS syntax (success).
- Ran `node --test tests/ui-polish.test.js tests/ticket-status-ui.test.js` to verify UI polish assertions and mode logic (tests passed).
- Attempted full test run `node --test tests/*.test.js` but some assistant-related integration tests require external Assistant API configuration and failed with an unconfigured Assistant API; UI-focused tests were completed successfully.
- Attempted `npm test` which failed because `package.json` does not define a `test` script (informational).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a342906f45c832fb6b03feaee948ffc)