### PR TITLE
Add Lite UI and Classic Pro theme; enhance mode switcher, assistant chips, and deferred script loading

### DIFF
--- a/public-ui/app-main.js
+++ b/public-ui/app-main.js
@@ -8368,6 +8368,8 @@
             const chip = document.createElement('button');
             chip.type = 'button';
             chip.className = 'assistant-suggestion-chip';
+            chip.setAttribute('role', 'listitem');
+            chip.setAttribute('aria-label', `Pakai saran cepat: ${label}`);
             chip.textContent = label;
             chip.addEventListener('click', () => {
               if (assistantInput) {
@@ -16392,35 +16394,54 @@
             const selectBasic = document.getElementById('selectBasicMode');
             const selectAdvanced = document.getElementById('selectAdvancedMode');
             const selectGaptek = document.getElementById('selectGaptekMode');
+            const settingsModeButtons = Array.from(document.querySelectorAll('[data-settings-mode]'));
+            const settingsModeBadge = document.getElementById('settingsModeBadge');
             const modeKey = 'ytmp3_mode_pref';
 
             const setMode = (mode) => {
-              const isBasic = mode === 'basic';
+              const isLite = mode === 'lite';
+              const isBasic = mode === 'basic' || isLite;
               const isGaptek = mode === 'gaptek';
               const isAdvanced = !isBasic && !isGaptek;
+
+              document.body.classList.toggle('lite-mode', isLite);
+              settingsModeButtons.forEach((button) => {
+                const active = button.dataset.settingsMode === mode;
+                button.classList.toggle('active', active);
+                button.setAttribute('aria-pressed', active ? 'true' : 'false');
+              });
+              if (settingsModeBadge) {
+                settingsModeBadge.textContent = isLite ? 'Lite' : (isBasic ? 'Basic' : (isGaptek ? 'Gaptek' : 'Advanced'));
+                settingsModeBadge.className = `badge ${isLite ? 'text-bg-info' : (isGaptek ? 'text-bg-success' : (isAdvanced ? 'text-bg-secondary' : 'text-bg-primary'))}`;
+              }
 
               if (containerBasic) containerBasic.hidden = !isBasic;
               if (containerAdvanced) containerAdvanced.hidden = !isAdvanced;
               if (containerGaptek) containerGaptek.hidden = !isGaptek;
 
               if (labelToggle) {
-                if (isBasic) labelToggle.textContent = 'Mode: Basic';
+                if (isLite) labelToggle.textContent = 'Mode: Lite';
+                else if (isBasic) labelToggle.textContent = 'Mode: Basic';
                 else if (isGaptek) labelToggle.textContent = 'Mode: Gaptek';
                 else labelToggle.textContent = 'Mode: Advanced';
               }
               if (btnToggle) {
                 const icon = btnToggle.querySelector('i');
                 if (icon) {
-                  if (isBasic) icon.className = 'bi bi-magic';
+                  if (isLite) icon.className = 'bi bi-phone';
+                  else if (isBasic) icon.className = 'bi bi-magic';
                   else if (isGaptek) icon.className = 'bi bi-emoji-smile';
                   else icon.className = 'bi bi-sliders';
                 }
-                btnToggle.title = isBasic
-                  ? 'Basic Mode: cepat dan simpel'
-                  : (isGaptek ? 'Gaptek Mode: dipandu langkah demi langkah' : 'Advanced Mode: fitur paling lengkap');
+                btnToggle.title = isLite
+                  ? 'Lite Mode: ringan untuk hape jadul'
+                  : (isBasic
+                    ? 'Basic Mode: cepat dan simpel'
+                    : (isGaptek ? 'Gaptek Mode: dipandu langkah demi langkah' : 'Advanced Mode: fitur paling lengkap'));
                 // Update button style
-                btnToggle.classList.remove('text-primary', 'text-secondary', 'text-success');
-                if (isBasic) btnToggle.classList.add('text-primary');
+                btnToggle.classList.remove('text-primary', 'text-secondary', 'text-success', 'text-info');
+                if (isLite) btnToggle.classList.add('text-info');
+                else if (isBasic) btnToggle.classList.add('text-primary');
                 else if (isGaptek) btnToggle.classList.add('text-success');
                 else btnToggle.classList.add('text-secondary');
               }
@@ -16433,19 +16454,28 @@
             if (btnToggle) {
               btnToggle.addEventListener('click', () => {
                 const now = localStorage.getItem(modeKey) || 'basic';
-                // Cycle: Basic -> Advanced -> Gaptek -> Basic
+                // Cycle: Basic -> Advanced -> Gaptek -> Basic. Lite is intentionally enabled from Settings only.
                 let next = 'basic';
-                if (now === 'basic') next = 'advanced';
+                if (now === 'basic' || now === 'lite') next = 'advanced';
                 else if (now === 'advanced') next = 'gaptek';
                 else next = 'basic';
 
                 setMode(next);
                 let msg = 'Basic Mode aktif';
+                if (next === 'lite') msg = 'Lite Mode aktif';
                 if (next === 'advanced') msg = 'Advanced Mode aktif';
                 if (next === 'gaptek') msg = 'Gaptek Mode aktif';
                 setToast(msg);
               });
             }
+
+            settingsModeButtons.forEach((button) => {
+              button.addEventListener('click', () => {
+                const next = button.dataset.settingsMode || 'basic';
+                setMode(next);
+                setToast(next === 'lite' ? 'Lite UI aktif' : `Mode ${next} aktif`);
+              });
+            });
 
             // Admin Login Form - Prevent Auto Submit/Refresh
             const adminForm = document.getElementById('adminLoginForm');
@@ -16462,27 +16492,8 @@
             if (btnResetMode) {
               btnResetMode.addEventListener('click', () => {
                 localStorage.removeItem(modeKey);
-
-                if (welcomeModalEl && bootstrapGlobal?.Modal) {
-                  // Close settings offcanvas if open
-                  const settingsOffcanvas = document.getElementById('offcanvasSettings');
-                  if (settingsOffcanvas && bootstrapGlobal?.Offcanvas) {
-                    const offcanvasInstance = bootstrapGlobal.Offcanvas.getInstance(settingsOffcanvas);
-                    if (offcanvasInstance) offcanvasInstance.hide();
-                  }
-
-                  // Show welcome modal
-                  if (welcomeModalInstance) {
-                    welcomeModalInstance.show();
-                  } else {
-                    // Fallback if instance lost (shouldn't happen)
-                    const modal = new bootstrapGlobal.Modal(welcomeModalEl);
-                    modal.show();
-                  }
-                } else {
-                  setMode('basic');
-                  setToast('Mode direset ke Basic');
-                }
+                setMode('basic');
+                setToast('Mode direset ke Basic');
               });
             }
 
@@ -16513,6 +16524,14 @@
               if (selectBasic) selectBasic.onclick = () => handleSelection('basic');
               if (selectAdvanced) selectAdvanced.onclick = () => handleSelection('advanced');
               if (selectGaptek) selectGaptek.onclick = () => handleSelection('gaptek');
+              [selectBasic, selectAdvanced, selectGaptek].filter(Boolean).forEach((card) => {
+                card.addEventListener('keydown', (event) => {
+                  if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    card.click();
+                  }
+                });
+              });
 
               // Show if no mode selected
               if (!currentMode) {

--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -68,11 +68,23 @@
         document.head.appendChild(script);
       });
     };
-    window.addEventListener('load', function () {
+    (function () {
       var run = window.__ytconvLoadDeferredScripts;
-      if ('requestIdleCallback' in window) requestIdleCallback(run, { timeout: 1800 });
-      else setTimeout(run, 900);
-    }, { once: true });
+      var trigger = function () { run(); cleanup(); };
+      var cleanup = function () {
+        ['pointerdown', 'keydown', 'touchstart'].forEach(function (eventName) {
+          window.removeEventListener(eventName, trigger, { passive: true });
+        });
+      };
+      ['pointerdown', 'keydown', 'touchstart'].forEach(function (eventName) {
+        window.addEventListener(eventName, trigger, { once: true, passive: true });
+      });
+      window.addEventListener('load', function () {
+        if (document.body && document.body.classList.contains('lite-mode')) return;
+        if ('requestIdleCallback' in window) requestIdleCallback(run, { timeout: 6500 });
+        else setTimeout(run, 4500);
+      }, { once: true });
+    })();
   </script>
   <script>
     window.tailwind = window.tailwind || {};
@@ -3429,14 +3441,22 @@
     }
 
     .assistant-quick-suggestions {
-      display: grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: .45rem;
-      margin-top: .35rem;
-      max-height: 6.2rem;
-      overflow-y: auto;
-      padding: .15rem .15rem .3rem;
-      overscroll-behavior: contain;
+      display: flex;
+      gap: .5rem;
+      margin-top: .45rem;
+      overflow-x: auto;
+      overflow-y: hidden;
+      padding: .2rem .15rem .55rem;
+      overscroll-behavior-inline: contain;
+      scroll-snap-type: inline mandatory;
+      scrollbar-width: thin;
+      -webkit-overflow-scrolling: touch;
+    }
+
+    .assistant-quick-suggestions::before,
+    .assistant-quick-suggestions::after {
+      content: "";
+      flex: 0 0 .05rem;
     }
 
     .assistant-suggestion-chip {
@@ -3450,8 +3470,9 @@
       line-height: 1.15;
       text-align: center;
       white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
+      min-width: max-content;
+      flex: 0 0 auto;
+      scroll-snap-align: start;
       box-shadow: 0 8px 20px rgba(13, 110, 253, .12);
       transition: transform .16s ease, box-shadow .16s ease, background-color .16s ease;
     }
@@ -4126,14 +4147,52 @@
       }
 
       .assistant-quick-suggestions {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-        max-height: 5.3rem;
+        gap: .4rem;
+        padding-bottom: .45rem;
       }
 
       .assistant-suggestion-chip {
         font-size: .7rem;
-        padding-inline: .48rem;
+        padding-inline: .55rem;
       }
+    }
+
+
+    /* Lite mode keeps the same converter logic, but trims visual effects for old/low-end phones. */
+    body.lite-mode {
+      --lite-shadow: 0 8px 20px rgba(15, 23, 42, .18);
+    }
+
+    body.lite-mode *,
+    body.lite-mode *::before,
+    body.lite-mode *::after {
+      animation-duration: .001ms !important;
+      animation-iteration-count: 1 !important;
+      scroll-behavior: auto !important;
+      transition-duration: .001ms !important;
+    }
+
+    body.lite-mode .seasonal-bg,
+    body.lite-mode .background-orb,
+    body.lite-mode .aurora-orb,
+    body.lite-mode .legendary-stage,
+    body.lite-mode .music-widget,
+    body.lite-mode #forumWidget {
+      display: none !important;
+    }
+
+    body.lite-mode .card,
+    body.lite-mode .glass-card,
+    body.lite-mode .assistant-panel {
+      box-shadow: var(--lite-shadow) !important;
+      backdrop-filter: none !important;
+    }
+
+    body.lite-mode #basic-mode .card,
+    body.lite-mode #gaptek-mode .card {
+      border: 1px solid rgba(13, 110, 253, .28) !important;
+      border-radius: 1.25rem !important;
+      background: linear-gradient(180deg, rgba(15,23,42,.96), rgba(17,24,39,.98)) !important;
     }
 
     .ai-output {
@@ -5372,6 +5431,265 @@
       gap: 6px;
       align-items: center;
     }
+
+
+    /* Classic professional Web3 UI pass: simple, tidy, and feature-safe. */
+    :root {
+      --ytc-classic-page: #eef1f6;
+      --ytc-classic-ink: #020617;
+      --ytc-classic-muted: #64748b;
+      --ytc-classic-line: #e5e7eb;
+      --ytc-classic-panel: #ffffff;
+      --ytc-classic-soft: #f8fafc;
+      --ytc-classic-accent: #2563eb;
+      --ytc-classic-danger: #dc2626;
+      --ytc-classic-radius-lg: 28px;
+      --ytc-classic-radius-md: 20px;
+      --ytc-classic-shadow: 0 28px 80px rgba(15, 23, 42, .16);
+    }
+
+    html[data-bs-theme='dark'] body.ytc-classic-pro {
+      --ytc-classic-page: #0f1f3d;
+      --ytc-classic-ink: #f8fafc;
+      --ytc-classic-muted: #a8b3c7;
+      --ytc-classic-line: rgba(148, 163, 184, .28);
+      --ytc-classic-panel: #17233f;
+      --ytc-classic-soft: #1f2f53;
+      --ytc-classic-shadow: 0 28px 80px rgba(2, 6, 23, .34);
+    }
+
+    body.ytc-classic-pro {
+      background:
+        radial-gradient(56rem 36rem at 50% -10%, rgba(37, 99, 235, .18), transparent 62%),
+        linear-gradient(180deg, var(--ytc-classic-page), color-mix(in srgb, var(--ytc-classic-page) 88%, #020617 12%));
+      color: var(--ytc-classic-ink);
+    }
+
+    body.ytc-classic-pro #mainContent {
+      max-width: 1180px;
+    }
+
+    body.ytc-classic-pro .navbar {
+      background: color-mix(in srgb, var(--ytc-classic-panel) 90%, transparent) !important;
+      border-bottom: 1px solid var(--ytc-classic-line);
+      box-shadow: 0 18px 48px rgba(15, 23, 42, .10);
+      backdrop-filter: blur(16px);
+    }
+
+    body.ytc-classic-pro .navbar-brand,
+    body.ytc-classic-pro .section-header h1,
+    body.ytc-classic-pro h1,
+    body.ytc-classic-pro h2,
+    body.ytc-classic-pro h3 {
+      color: var(--ytc-classic-ink);
+      letter-spacing: -.035em;
+    }
+
+    body.ytc-classic-pro .section-header {
+      position: relative;
+      align-items: center;
+      margin-bottom: 1.25rem;
+      padding: 1.35rem;
+      background: var(--ytc-classic-soft);
+      border: 1px solid var(--ytc-classic-line);
+      border-radius: var(--ytc-classic-radius-lg);
+      box-shadow: var(--ytc-classic-shadow);
+      overflow: hidden;
+    }
+
+    body.ytc-classic-pro .section-header::before,
+    body.ytc-classic-pro .card::before,
+    body.ytc-classic-pro .modal-content::before,
+    body.ytc-classic-pro .offcanvas::before,
+    body.ytc-classic-pro .assistant-panel::before {
+      content: "";
+      position: absolute;
+      inset: 0 0 auto 0;
+      height: 7px;
+      background: linear-gradient(90deg, #020617, #ef4444, #f59e0b, #6366f1, #020617);
+      pointer-events: none;
+      z-index: 2;
+    }
+
+    body.ytc-classic-pro .section-header p,
+    body.ytc-classic-pro .text-secondary,
+    body.ytc-classic-pro .text-muted,
+    body.ytc-classic-pro .form-text,
+    body.ytc-classic-pro .small {
+      color: var(--ytc-classic-muted) !important;
+    }
+
+    body.ytc-classic-pro .app-section,
+    body.ytc-classic-pro .card,
+    body.ytc-classic-pro .modal-content,
+    body.ytc-classic-pro .offcanvas,
+    body.ytc-classic-pro .dropdown-menu,
+    body.ytc-classic-pro .assistant-panel,
+    body.ytc-classic-pro .app-footer,
+    body.ytc-classic-pro .aero-footer {
+      position: relative;
+      background: var(--ytc-classic-panel) !important;
+      border: 1px solid var(--ytc-classic-line) !important;
+      border-radius: var(--ytc-classic-radius-lg) !important;
+      box-shadow: var(--ytc-classic-shadow) !important;
+      overflow: hidden;
+      backdrop-filter: none !important;
+    }
+
+    body.ytc-classic-pro .app-section {
+      padding: clamp(1rem, 2vw, 1.5rem);
+    }
+
+    body.ytc-classic-pro .card .card,
+    body.ytc-classic-pro .bg-body-tertiary,
+    body.ytc-classic-pro .list-group-item,
+    body.ytc-classic-pro .accordion-item,
+    body.ytc-classic-pro .ai-output,
+    body.ytc-classic-pro .assistant-messages,
+    body.ytc-classic-pro .history-card,
+    body.ytc-classic-pro .trust-card {
+      background: var(--ytc-classic-soft) !important;
+      border: 1px solid var(--ytc-classic-line) !important;
+      border-radius: var(--ytc-classic-radius-md) !important;
+      box-shadow: none !important;
+    }
+
+    body.ytc-classic-pro .btn,
+    body.ytc-classic-pro .app-nav-btn,
+    body.ytc-classic-pro .badge,
+    body.ytc-classic-pro .assistant-suggestion-chip {
+      border-radius: 999px !important;
+      font-weight: 900 !important;
+      letter-spacing: .02em;
+      box-shadow: none !important;
+    }
+
+    body.ytc-classic-pro .btn-primary,
+    body.ytc-classic-pro .primary-cta-btn {
+      background: #020617 !important;
+      border-color: #020617 !important;
+      color: #fff !important;
+    }
+
+    body.ytc-classic-pro .btn-outline-primary,
+    body.ytc-classic-pro .app-nav-btn,
+    body.ytc-classic-pro .assistant-suggestion-chip {
+      background: var(--ytc-classic-soft) !important;
+      border: 1px solid var(--ytc-classic-line) !important;
+      color: var(--ytc-classic-ink) !important;
+    }
+
+    body.ytc-classic-pro .btn:hover,
+    body.ytc-classic-pro .app-nav-btn:hover,
+    body.ytc-classic-pro .assistant-suggestion-chip:hover {
+      transform: translateY(-1px);
+      border-color: color-mix(in srgb, var(--ytc-classic-accent) 42%, var(--ytc-classic-line)) !important;
+    }
+
+    body.ytc-classic-pro .form-control,
+    body.ytc-classic-pro .form-select,
+    body.ytc-classic-pro .input-group-text,
+    body.ytc-classic-pro textarea {
+      background: var(--ytc-classic-soft) !important;
+      border: 1px solid var(--ytc-classic-line) !important;
+      border-radius: 14px !important;
+      color: var(--ytc-classic-ink) !important;
+      box-shadow: none !important;
+    }
+
+    body.ytc-classic-pro .form-label,
+    body.ytc-classic-pro label,
+    body.ytc-classic-pro strong {
+      color: var(--ytc-classic-ink);
+      font-weight: 900;
+    }
+
+    body.ytc-classic-pro .form-text,
+    body.ytc-classic-pro .section-header p,
+    body.ytc-classic-pro #basic-mode > .text-center p,
+    body.ytc-classic-pro #gaptek-mode > .text-center p,
+    body.ytc-classic-pro .card p.small {
+      max-width: 62ch;
+      line-height: 1.55;
+      font-size: .82rem !important;
+    }
+
+    body.ytc-classic-pro #basic-mode > .text-center,
+    body.ytc-classic-pro #gaptek-mode > .text-center:first-child {
+      margin-bottom: 1rem !important;
+    }
+
+    body.ytc-classic-pro #basic-mode > .text-center h2,
+    body.ytc-classic-pro #gaptek-mode h2 {
+      font-size: clamp(1.65rem, 3vw, 2.4rem);
+      font-weight: 900;
+    }
+
+    body.ytc-classic-pro .assistant-quick-suggestions {
+      padding: .25rem .1rem .65rem;
+      border-bottom: 1px solid var(--ytc-classic-line);
+    }
+
+    body.ytc-classic-pro .assistant-suggestion-chip {
+      background: #020617 !important;
+      color: #fff !important;
+      border-color: #020617 !important;
+    }
+
+    body.ytc-classic-pro .footer-pill,
+    body.ytc-classic-pro .aero-tag,
+    body.ytc-classic-pro .trust-card .badge {
+      background: var(--ytc-classic-soft) !important;
+      border: 1px solid var(--ytc-classic-line) !important;
+      color: var(--ytc-classic-ink) !important;
+    }
+
+    body.ytc-classic-pro .modal-body .card[role="button"],
+    body.ytc-classic-pro #selectBasicMode,
+    body.ytc-classic-pro #selectGaptekMode,
+    body.ytc-classic-pro #selectAdvancedMode {
+      min-height: 100%;
+      border-radius: 22px !important;
+      background: var(--ytc-classic-soft) !important;
+    }
+
+    body.ytc-classic-pro.lite-mode .app-section,
+    body.ytc-classic-pro.lite-mode .card,
+    body.ytc-classic-pro.lite-mode .modal-content,
+    body.ytc-classic-pro.lite-mode .assistant-panel {
+      box-shadow: 0 12px 34px rgba(15, 23, 42, .14) !important;
+    }
+
+    body.ytc-classic-pro .lite-mode-preview {
+      background: color-mix(in srgb, #38bdf8 9%, var(--ytc-classic-soft));
+      border: 1px dashed color-mix(in srgb, #38bdf8 42%, var(--ytc-classic-line));
+      border-radius: 18px;
+      padding: .85rem;
+    }
+
+    body.ytc-classic-pro.lite-mode .lite-mode-preview {
+      background: color-mix(in srgb, #38bdf8 16%, var(--ytc-classic-soft));
+      border-style: solid;
+    }
+
+
+    @media (max-width: 768px) {
+      body.ytc-classic-pro .section-header,
+      body.ytc-classic-pro .app-section,
+      body.ytc-classic-pro .card,
+      body.ytc-classic-pro .modal-content,
+      body.ytc-classic-pro .offcanvas {
+        border-radius: 20px !important;
+      }
+
+      body.ytc-classic-pro .section-header {
+        gap: .75rem;
+      }
+
+      body.ytc-classic-pro .app-section {
+        padding: .85rem;
+      }
+    }
   </style>
   <!-- Cropper.js -->
   <link rel="preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/cropperjs/1.5.13/cropper.min.css"
@@ -5383,7 +5701,7 @@
 
 </head>
 
-<body>
+<body class="ytc-classic-pro">
   <a href="#mainContent" class="visually-hidden-focusable">Lewati ke konten utama</a>
   <nav class="navbar navbar-expand-lg sticky-top bg-body-tertiary shadow-sm">
     <div class="container d-flex align-items-center gap-3">
@@ -5471,7 +5789,7 @@
       <!-- Gaptek Mode Container (Task 2) -->
       <div id="gaptek-mode" class="animate__animated animate__fadeIn" hidden>
         <div class="text-center mb-5 mt-4">
-          <h1 class="display-4 fw-bold text-primary mb-3">DOWNLOAD LAGU</h1>
+          <h2 class="display-4 fw-bold text-primary mb-3">DOWNLOAD LAGU</h2>
           <p class="lead fs-4 text-secondary">Cara paling gampang ambil lagu dari YouTube</p>
         </div>
 
@@ -8381,9 +8699,45 @@
 
         <hr class="my-4">
         <h6 class="mb-2">Tampilan Mode</h6>
-        <div class="mb-3">
-          <p class="small text-secondary mb-2">Pilih mode tampilan default (Basic/Advanced).</p>
-          <button class="btn btn-outline-primary w-100" id="resetModePrefBtn">
+        <div class="settings-card p-3 mb-3" id="settingsModePanel">
+          <div class="d-flex align-items-start justify-content-between gap-3 mb-3">
+            <div>
+              <div class="fw-bold">Mode tampilan</div>
+              <div class="small text-secondary">Pilih layout tanpa mengubah fungsi converter.</div>
+            </div>
+            <span class="badge text-bg-primary" id="settingsModeBadge">Basic</span>
+          </div>
+          <div class="row g-2">
+            <div class="col-6">
+              <button class="btn btn-outline-primary w-100" type="button" data-settings-mode="basic">
+                <i class="bi bi-magic me-1"></i> Basic
+              </button>
+            </div>
+            <div class="col-6">
+              <button class="btn btn-outline-info w-100" type="button" id="settingsLiteModeBtn" data-settings-mode="lite">
+                <i class="bi bi-phone me-1"></i> Lite
+              </button>
+            </div>
+            <div class="col-6">
+              <button class="btn btn-outline-secondary w-100" type="button" data-settings-mode="advanced">
+                <i class="bi bi-sliders me-1"></i> Advanced
+              </button>
+            </div>
+            <div class="col-6">
+              <button class="btn btn-outline-success w-100" type="button" data-settings-mode="gaptek">
+                <i class="bi bi-emoji-smile me-1"></i> Gaptek
+              </button>
+            </div>
+          </div>
+          <div class="lite-mode-preview mt-3" aria-live="polite">
+            <div class="d-flex align-items-center gap-2">
+              <i class="bi bi-speedometer2 text-info"></i>
+              <strong>Lite UI</strong>
+              <span class="badge text-bg-info ms-auto">Ringan</span>
+            </div>
+            <div class="small text-secondary mt-1">Tampilan lebih simpel untuk hape jadul/kentang; tombol dan proses convert tetap sama.</div>
+          </div>
+          <button class="btn btn-outline-primary w-100 mt-3" id="resetModePrefBtn" type="button">
             <i class="bi bi-arrow-repeat me-1"></i> Reset Pilihan Mode
           </button>
         </div>
@@ -9225,7 +9579,7 @@
         </header>
         <div class="assistant-body">
           <div class="assistant-messages" id="assistantMessages" aria-live="polite" tabindex="0"></div>
-          <div class="assistant-quick-suggestions" id="assistantQuickSuggestions" aria-label="Saran cepat AI Navigator"></div>
+          <div class="assistant-quick-suggestions" id="assistantQuickSuggestions" aria-label="Saran cepat AI Navigator" role="list" tabindex="0"></div>
           <div class="assistant-typing" id="assistantTyping" hidden>AI Navigator mengetik...</div>
           <div class="assistant-input">
             <input type="text" id="assistantInput" class="form-control"

--- a/tests/ui-polish.test.js
+++ b/tests/ui-polish.test.js
@@ -109,7 +109,7 @@ test("homepage menunda script berat dan menguatkan SEO", () => {
   assert.match(pages.home, /content-visibility: auto/);
   assert.match(pages.home, /modal-backdrop[\s\S]{0,220}background: rgba\(3, 7, 18, \.82\)/);
   assert.match(pages.home, /font-family: "Inter", "Segoe UI", system-ui/);
-  assert.match(pages.home, /requestIdleCallback\(run, \{ timeout: 1800 \}\)/);
+  assert.match(pages.home, /requestIdleCallback\(run, \{ timeout: 6500 \}\)/);
   assert.doesNotMatch(pages.home, /<script src="https:\/\/cdnjs\.cloudflare\.com\/ajax\/libs\/howler\/2\.2\.4\/howler\.min\.js"/);
   assert.doesNotMatch(pages.home, /<script src="https:\/\/accounts\.google\.com\/gsi\/client"/);
   assert.match(pages.home, /aria-label="Cari pertanyaan FAQ"/);
@@ -126,9 +126,31 @@ test("homepage memindahkan JavaScript utama ke asset cacheable", () => {
 
 
 test("AI Navigator dan backdrop modal tetap rapi", () => {
-  assert.match(pages.home, /\.assistant-quick-suggestions \{[\s\S]{0,180}grid-template-columns: repeat\(2, minmax\(0, 1fr\)\)/);
-  assert.match(pages.home, /text-overflow: ellipsis/);
+  assert.match(pages.home, /\.assistant-quick-suggestions \{[\s\S]{0,220}scroll-snap-type: inline mandatory/);
+  assert.match(pages.home, /\.assistant-suggestion-chip \{[\s\S]{0,700}scroll-snap-align: start/);
   assert.match(pages.home, /\.assistant-panel \.assistant-messages \{[\s\S]{0,180}max-height: clamp\(12rem, 40vh, 22rem\)/);
   assert.match(pages.home, /body \.modal-backdrop \{[\s\S]{0,180}pointer-events: auto !important/);
   assert.match(pages.home, /body \.modal-backdrop\.show \{[\s\S]{0,180}backdrop-filter: blur\(5px\)/);
+});
+
+
+test("homepage memakai classic professional Web3 UI pass", () => {
+  assert.match(pages.home, /<body class="ytc-classic-pro">/);
+  assert.match(pages.home, /Classic professional Web3 UI pass/);
+  assert.match(pages.home, /--ytc-classic-page: #eef1f6/);
+  assert.match(pages.home, /linear-gradient\(90deg, #020617, #ef4444, #f59e0b, #6366f1, #020617\)/);
+  assert.match(pages.home, /body\.ytc-classic-pro \.app-section/);
+  assert.match(pages.home, /body\.ytc-classic-pro \.assistant-suggestion-chip/);
+});
+
+
+test("Lite mode hanya dipilih dari settings dan tetap memakai Basic flow", () => {
+  assert.match(pages.home, /id="settingsLiteModeBtn"[^>]+data-settings-mode="lite"/);
+  assert.match(pages.home, /id="settingsModeBadge"/);
+  assert.match(pages.home, /class="lite-mode-preview/);
+  assert.doesNotMatch(pages.home, /id="selectLiteMode"/);
+  assert.match(pages.appMain, /Lite is intentionally enabled from Settings only/);
+  assert.match(pages.appMain, /const isBasic = mode === 'basic' \|\| isLite/);
+  assert.match(pages.appMain, /settingsModeButtons\.forEach/);
+  assert.match(pages.appMain, /aria-pressed/);
 });


### PR DESCRIPTION
### Motivation

- Introduce a lightweight "Lite" UI for low-end devices and a new "classic professional" theme to offer alternative polished visual treatments and conserve resources on older phones.
- Improve accessibility and UX of the AI Assistant quick-suggestions and the mode-switcher so users can select a UI mode from Settings and receive clearer ARIA semantics and keyboard support.

### Description

- Added a new `lite` mode toggle and UI in `index.html` with settings controls (`data-settings-mode=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a342906f45c832fb6b03feaee948ffc)