### PR TITLE
Improve downloader fallback and lighten mobile header UI

### DIFF
--- a/download_audio.py
+++ b/download_audio.py
@@ -10,7 +10,7 @@ YouTube = None
 
 def upgrade_ytdlp() -> bool:
     global YoutubeDL
-    flag = str(os.environ.get("YTDLP_AUTO_UPGRADE", "1") or "").strip().lower()
+    flag = str(os.environ.get("YTDLP_AUTO_UPGRADE", "0") or "").strip().lower()
     if flag in {"0", "false", "no", "off"}:
         return False
     try:
@@ -24,7 +24,7 @@ def upgrade_ytdlp() -> bool:
 
 
 def ensure_ytdlp() -> bool:
-    """Lazily import yt_dlp, installing it when absent."""
+    """Lazily import yt_dlp without mutating externally-managed Python envs."""
 
     global YoutubeDL
     if YoutubeDL is not None:
@@ -35,9 +35,12 @@ def ensure_ytdlp() -> bool:
         YoutubeDL = _YoutubeDL
         return True
     except ModuleNotFoundError:
+        if str(os.environ.get("YTDLP_HELPER_PIP_INSTALL", "0") or "").strip().lower() not in {"1", "true", "yes", "on"}:
+            print("yt_dlp module is not installed; skipping pip install in managed Python", file=sys.stderr)
+            return False
         try:
             subprocess.check_call(
-                [sys.executable, "-m", "pip", "install", "--quiet", "yt-dlp"]
+                [sys.executable, "-m", "pip", "install", "--quiet", "--user", "yt-dlp"]
             )
             from yt_dlp import YoutubeDL as _YoutubeDL  # type: ignore
 
@@ -126,12 +129,18 @@ def download_with_ytdlp(
     compat_opts["force_ipv4"] = True
     compat_opts["extractor_args"] = {"youtube": {"player_client": ["android"]}}
 
+    tv_opts = dict(base_opts)
+    tv_opts["extractor_args"] = {"youtube": {"player_client": ["tv_embedded", "android"]}}
+
     relaxed_opts = dict(compat_opts)
     relaxed_opts["format"] = "best"
 
+    http_opts = dict(relaxed_opts)
+    http_opts["format"] = "bestaudio[protocol^=http]/best[protocol^=http]/bestaudio/best"
+
     last_exc: Optional[Exception] = None
     upgrade_tried = False
-    attempts = [base_opts, compat_opts, relaxed_opts]
+    attempts = [base_opts, compat_opts, tv_opts, relaxed_opts, http_opts]
     for opts in attempts:
         try:
             with YoutubeDL(opts) as ydl:  # type: ignore[misc]

--- a/index.js
+++ b/index.js
@@ -7089,9 +7089,11 @@ const buildYtDlpFallbackArgs = (args = []) => {
   const isUrlLike = typeof url === "string" && (url.startsWith("http://") || url.startsWith("https://") || url.startsWith("ytsearch:"));
   const urlArg = isUrlLike ? next.pop() : null;
 
-  const hasExtractorArgs = next.includes("--extractor-args");
-  if (!hasExtractorArgs) {
-    next.push("--extractor-args", "youtube:player_client=android");
+  const extractorIndex = next.indexOf("--extractor-args");
+  if (extractorIndex >= 0 && typeof next[extractorIndex + 1] === "string") {
+    next[extractorIndex + 1] = "youtube:player_client=tv_embedded,android";
+  } else {
+    next.push("--extractor-args", "youtube:player_client=tv_embedded,android");
   }
 
   if (!next.includes("--force-ipv4")) {
@@ -7102,7 +7104,7 @@ const buildYtDlpFallbackArgs = (args = []) => {
     if (next[i] === "-f" && typeof next[i + 1] === "string") {
       const selector = next[i + 1];
       if (selector.includes("bestaudio")) {
-        next[i + 1] = "bestaudio/best";
+        next[i + 1] = "bestaudio[protocol^=http]/best[protocol^=http]/bestaudio/best";
       }
       break;
     }

--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -882,7 +882,7 @@
         align-items: center;
         gap: 0.5rem;
         transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
-        font-family: 'Comfortaa', cursive;
+        font-family: Inter, 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, Arial, sans-serif;
         letter-spacing: 0.5px;
         position: relative;
         overflow: hidden;
@@ -2164,6 +2164,61 @@
 
     body.has-open-modal .offcanvas {
       pointer-events: auto !important;
+    }
+
+
+
+    /* Lightweight UI overrides: header only, mobile friendly */
+    .app-header-lite {
+      box-shadow: none !important;
+      filter: none !important;
+      backdrop-filter: none !important;
+      -webkit-backdrop-filter: none !important;
+      border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+    }
+
+    .cute-clock {
+      background: rgba(15, 23, 42, 0.08) !important;
+      color: #e5eefc !important;
+      border: 1px solid rgba(148, 163, 184, 0.24) !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      font-family: Inter, "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, Arial, sans-serif !important;
+    }
+
+    [data-bs-theme="dark"] .cute-clock {
+      background: rgba(15, 23, 42, 0.18) !important;
+      color: #f8fafc !important;
+    }
+
+    .cute-clock:hover {
+      transform: none !important;
+      box-shadow: none !important;
+    }
+
+    .cute-clock i { animation: none !important; }
+
+    .cute-clock .seconds {
+      background: transparent !important;
+      color: #93c5fd !important;
+      padding: 0 !important;
+    }
+
+    .forum-google-login-btn {
+      max-width: min(100%, 420px);
+      min-height: 54px;
+      white-space: normal;
+      touch-action: manipulation;
+      box-shadow: none !important;
+    }
+
+    @media (max-width: 576px) {
+      .app-header-lite .container { gap: .5rem !important; }
+      .app-header-lite .btn,
+      .app-header-lite .app-nav-btn { box-shadow: none !important; transition: none !important; }
+      .cute-clock { padding: .35rem .65rem !important; letter-spacing: 0 !important; }
+      .forum-google-login-btn { width: calc(100vw - 2rem); padding-left: 1rem !important; padding-right: 1rem !important; }
+      .forum-google-login-btn img { flex: 0 0 auto; }
     }
 
     body .modal {
@@ -5218,7 +5273,7 @@
 
 <body>
   <a href="#mainContent" class="visually-hidden-focusable">Lewati ke konten utama</a>
-  <nav class="navbar navbar-expand-lg sticky-top bg-body-tertiary shadow-sm">
+  <nav class="navbar navbar-expand-lg sticky-top bg-body-tertiary app-header-lite">
     <div class="container d-flex align-items-center gap-3">
       <div class="d-flex align-items-center gap-2 flex-grow-1">
         <button class="btn btn-outline-primary d-lg-none" type="button" data-bs-toggle="offcanvas"
@@ -8444,7 +8499,7 @@
                 warga lainnya.</p>
 
               <button id="forumGoogleLoginBtn"
-                class="btn btn-light rounded-pill py-3 px-5 fw-bold d-flex align-items-center gap-3 shadow-lg hover-scale">
+                class="btn btn-light rounded-pill py-3 px-5 fw-bold d-flex align-items-center justify-content-center gap-3 forum-google-login-btn">
                 <img src="https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg" width="24" height="24"
                   alt="G">
                 <span>Masuk dengan Google</span>
@@ -25884,6 +25939,28 @@
             }
           }
 
+
+
+        // FAQ fallback: keep accordion text visible even if Bootstrap collapse misses a tap.
+        document.querySelectorAll('#faqTabContent [data-bs-toggle="collapse"]').forEach((btn) => {
+          if (btn.dataset.faqFallbackBound) return;
+          btn.dataset.faqFallbackBound = '1';
+          btn.addEventListener('click', () => {
+            const selector = btn.getAttribute('data-bs-target') || btn.getAttribute('href');
+            if (!selector) return;
+            const panel = document.querySelector(selector);
+            if (!panel) return;
+            setTimeout(() => {
+              const isOpen = panel.classList.contains('show');
+              if (!isOpen && document.activeElement === btn) {
+                panel.classList.add('show');
+                btn.classList.remove('collapsed');
+                btn.setAttribute('aria-expanded', 'true');
+              }
+            }, 180);
+          }, { passive: true });
+        });
+
           // 1. FAQ Trouble Links (Mobile vs Desktop)
           const linkContainer = document.getElementById('admin-contact-buttons');
           if (linkContainer) {
@@ -29889,7 +29966,7 @@
               <h3 class="fw-bold mb-2 text-white" style="letter-spacing: -0.5px;">Gabung Forum</h3>
               <p class="text-secondary mb-4" style="max-width: 300px;">Diskusi seru, berbagi gambar, dan stiker dengan warga lainnya.</p>
               
-              <button id="forumGoogleLoginBtn" class="btn btn-light rounded-pill py-3 px-5 fw-bold d-flex align-items-center gap-3 shadow-lg hover-scale">
+              <button id="forumGoogleLoginBtn" class="btn btn-light rounded-pill py-3 px-5 fw-bold d-flex align-items-center justify-content-center gap-3 forum-google-login-btn">
                   <img src="https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg" width="24" height="24" alt="G">
                   <span>Masuk dengan Google</span>
               </button>`;
@@ -30726,12 +30803,18 @@
             if (!btn) return;
             if (!window.firebaseModules || !window.firebaseModules.auth) return;
             const { auth, signInWithPopup, GoogleAuthProvider, signInWithRedirect } = window.firebaseModules;
-            btn.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>...';
+            btn.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>Login...';
             btn.disabled = true;
             try {
               const provider = new GoogleAuthProvider();
               provider.setCustomParameters({ prompt: 'select_account' });
               try {
+                const preferRedirect = window.matchMedia('(max-width: 768px), (display-mode: standalone)').matches;
+                if (preferRedirect) {
+                  sessionStorage.setItem('forum_login_pending', 'true');
+                  await signInWithRedirect(auth, provider);
+                  return;
+                }
                 const result = await signInWithPopup(auth, provider);
                 if (result && result.user) {
                   setToast('Login berhasil!', 'success');


### PR DESCRIPTION
### Motivation
- Prevent downloader failures caused by environment-managed Python (PEP 668) and YouTube format errors by improving yt-dlp fallbacks and avoiding unwanted pip mutations.  
- Reduce heavy header/mobile UI effects (drop-shadows, clock animation) that make the interface feel heavy on devices.  
- Fix a few mobile UX bugs: unreliable Google sign-in on small screens and FAQ accordion taps that sometimes don't reveal content.

### Description
- Change `download_audio.py` to avoid auto-installing/upgrading `yt-dlp` by default (`YTDLP_AUTO_UPGRADE` default -> `0`) and add an opt-in `YTDLP_HELPER_PIP_INSTALL` gate, plus add `tv_embedded` and HTTP-friendly format options and new attempt order (`tv_opts`, `http_opts`) to improve fallback downloads.  
- Update `buildYtDlpFallbackArgs` in `index.js` to prefer `tv_embedded,android` extractor client and use an HTTP-friendly audio selector (`bestaudio[protocol^=http]/best[protocol^=http]/...`) when falling back.  
- Lighten UI in `public-ui/index.html` by applying an `app-header-lite` class (remove heavy header shadow), switching the clock to a sans font and removing animations/shadows, adjust Google login button markup and add a mobile redirect fallback for sign-in, and add a small JS fallback to ensure FAQ accordion panels open reliably on tap.

### Testing
- `node --check index.js` — succeeded.  
- `python3 -m py_compile download_audio.py` — succeeded.  
- `git diff --check -- public-ui/index.html download_audio.py index.js` — succeeded (no whitespace/check errors).  
- `node --test tests/ui-polish.test.js` — passed (UI polish tests green); `npm test` could not be run because `package.json` does not define a `test` script.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a429d38e9fc832b9ba81593d5468349)