### PR TITLE
Lighten UI and harden downloader fallbacks

### DIFF
--- a/download_audio.py
+++ b/download_audio.py
@@ -136,11 +136,14 @@ def download_with_ytdlp(
     relaxed_opts["format"] = "best"
 
     http_opts = dict(relaxed_opts)
-    http_opts["format"] = "bestaudio[protocol^=http]/best[protocol^=http]/bestaudio/best"
+    http_opts["format"] = "ba[protocol^=http]/b[protocol^=http]/ba/best/worst"
+
+    universal_opts = dict(tv_opts)
+    universal_opts.pop("format", None)
 
     last_exc: Optional[Exception] = None
     upgrade_tried = False
-    attempts = [base_opts, compat_opts, tv_opts, relaxed_opts, http_opts]
+    attempts = [base_opts, compat_opts, tv_opts, relaxed_opts, http_opts, universal_opts]
     for opts in attempts:
         try:
             with YoutubeDL(opts) as ydl:  # type: ignore[misc]

--- a/index.js
+++ b/index.js
@@ -7103,9 +7103,7 @@ const buildYtDlpFallbackArgs = (args = []) => {
   for (let i = 0; i < next.length - 1; i++) {
     if (next[i] === "-f" && typeof next[i + 1] === "string") {
       const selector = next[i + 1];
-      if (selector.includes("bestaudio")) {
-        next[i + 1] = "bestaudio[protocol^=http]/best[protocol^=http]/bestaudio/best";
-      }
+      next[i + 1] = "ba[protocol^=http]/b[protocol^=http]/ba/best/worst";
       break;
     }
   }
@@ -7516,7 +7514,11 @@ const convertSingle = async (payload = {}) => {
     emitProgress({ stage: "downloading", message: "Menyiapkan unduhan", percent: 15 });
 
     const sanitizedAbrForDownload = isVideoFormat ? undefined : targetAbr || Number(abr) || undefined;
-    const baseAudioSelector = atmos ? "bestaudio[channels>2]/bestaudio/best" : "bestaudio/best";
+    // Prefer audio-only, but keep broad fallbacks so YouTube videos with unusual/limited formats
+    // do not fail immediately with "Requested format is not available".
+    const baseAudioSelector = atmos
+      ? "ba[channels>2]/ba/best/worst"
+      : "ba/bestaudio/best/worst";
 
     if (isVideoFormat) {
       const selector = buildVideoFormatSelector(fmt, targetVideoQuality);
@@ -7529,7 +7531,7 @@ const convertSingle = async (payload = {}) => {
         args.push("--merge-output-format", "mkv");
       }
     } else if (fmt === "m4a") {
-      args.push("-f", "bestaudio[ext=m4a]/bestaudio/best");
+      args.push("-f", "ba[ext=m4a]/ba/bestaudio/best/worst");
     } else if (fmt === "alac") {
       args.push("-f", baseAudioSelector);
       args.push("-x", "--audio-format", "alac");
@@ -7620,6 +7622,22 @@ const convertSingle = async (payload = {}) => {
             const fallbackArgs = buildYtDlpFallbackArgs(args);
             downloadResult = await runYtDlpDownload({ args: fallbackArgs, id, onProgress: handleDownloadProgress });
             logs = downloadResult.logs || baseLogs;
+          } catch (retryErr) {
+            logs = retryErr?.logs || logs || baseLogs;
+          }
+        }
+        if (!downloadResult && shouldRetryWithFallbackArgs) {
+          try {
+            emitProgress({ stage: "downloading", message: "Mencoba format universal", percent: mapDownloadPercent(19) });
+            const universalArgs = buildYtDlpFallbackArgs(args);
+            for (let i = 0; i < universalArgs.length - 1; i++) {
+              if (universalArgs[i] === "-f") {
+                universalArgs.splice(i, 2);
+                break;
+              }
+            }
+            downloadResult = await runYtDlpDownload({ args: universalArgs, id, onProgress: handleDownloadProgress });
+            logs = downloadResult.logs || logs || baseLogs;
           } catch (retryErr) {
             logs = retryErr?.logs || logs || baseLogs;
           }

--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -2216,6 +2216,41 @@
       .app-header-lite .container { gap: .5rem !important; }
       .app-header-lite .btn,
       .app-header-lite .app-nav-btn { box-shadow: none !important; transition: none !important; }
+
+
+      /* Lightweight UI pass: remove heavy glass/drop shadows outside the header. */
+      body:not(.keep-rich-shadows) main,
+      body:not(.keep-rich-shadows) footer,
+      body:not(.keep-rich-shadows) .app-section,
+      body:not(.keep-rich-shadows) .modal,
+      body:not(.keep-rich-shadows) .offcanvas {
+        --bs-box-shadow: none;
+        --bs-box-shadow-sm: none;
+        --bs-box-shadow-lg: none;
+      }
+
+      body:not(.keep-rich-shadows) main :where(.card, .glass, .btn, .badge, .dropdown-menu, .accordion-item, .accordion-button, .form-control, .form-select, .input-group-text, .toast, .alert, .list-group-item, .nav-link, .modern-card, .feature-card, .status-card, .history-card),
+      body:not(.keep-rich-shadows) footer :where(.card, .glass, .btn, .badge, .dropdown-menu, .accordion-item, .accordion-button, .form-control, .form-select, .input-group-text, .toast, .alert, .list-group-item, .nav-link),
+      body:not(.keep-rich-shadows) .modal :where(.modal-content, .card, .btn, .form-control, .form-select),
+      body:not(.keep-rich-shadows) .offcanvas :where(.offcanvas, .card, .btn, .form-control, .form-select) {
+        box-shadow: none !important;
+        filter: none !important;
+        backdrop-filter: none !important;
+        -webkit-backdrop-filter: none !important;
+      }
+
+      body:not(.keep-rich-shadows) main :where(.card, .glass, .accordion-item, .list-group-item, .modern-card, .feature-card, .status-card, .history-card),
+      body:not(.keep-rich-shadows) footer :where(.card, .glass, .accordion-item, .list-group-item) {
+        background-color: color-mix(in srgb, var(--bs-body-bg) 88%, var(--bs-tertiary-bg) 12%) !important;
+        border-color: color-mix(in srgb, var(--bs-border-color) 78%, transparent) !important;
+      }
+
+      body:not(.keep-rich-shadows) header,
+      body:not(.keep-rich-shadows) .app-header,
+      body:not(.keep-rich-shadows) .app-header-lite,
+      body:not(.keep-rich-shadows) .navbar {
+        /* Header keeps its depth as requested. */
+      }
       .cute-clock { padding: .35rem .65rem !important; letter-spacing: 0 !important; }
       .forum-google-login-btn { width: calc(100vw - 2rem); padding-left: 1rem !important; padding-right: 1rem !important; }
       .forum-google-login-btn img { flex: 0 0 auto; }
@@ -6810,12 +6845,12 @@
               <div class="accordion accordion-flush" id="accGeneral">
                 <div class="accordion-item">
                   <h2 class="accordion-header">
-                    <button class="accordion-button fw-semibold collapsed" type="button" data-bs-toggle="collapse"
-                      data-bs-target="#q-gen-1">
+                    <button class="accordion-button fw-semibold" type="button" data-bs-toggle="collapse"
+                      data-bs-target="#q-gen-1" aria-expanded="true">
                       <i class="bi bi-currency-dollar me-2 text-success"></i>Apakah layanan ini benar-benar gratis?
                     </button>
                   </h2>
-                  <div id="q-gen-1" class="accordion-collapse collapse" data-bs-parent="#accGeneral">
+                  <div id="q-gen-1" class="accordion-collapse collapse show" data-bs-parent="#accGeneral">
                     <div class="accordion-body text-secondary">
                       Ya, 100% gratis. Kami tidak memungut biaya berlangganan. Jika Anda ingin mendukung operasional
                       server, Anda bisa berdonasi melalui tab <strong>Saweria</strong>.
@@ -7547,6 +7582,32 @@
                         <li>Jika masih meleset, edit metadata di mode Advanced (judul, artis, album, tahun).</li>
                         <li>Untuk koleksi musik, pilih format M4A/FLAC agar metadata lebih konsisten di banyak player.</li>
                       </ol>
+                    </div>
+                  </div>
+                </div>
+                <div class="accordion-item">
+                  <h2 class="accordion-header">
+                    <button class="accordion-button fw-semibold collapsed" type="button" data-bs-toggle="collapse"
+                      data-bs-target="#q-tr-18">
+                      <i class="bi bi-music-note-list me-2 text-primary"></i>Kenapa muncul Requested format is not available?
+                    </button>
+                  </h2>
+                  <div id="q-tr-18" class="accordion-collapse collapse" data-bs-parent="#accTrouble">
+                    <div class="accordion-body text-secondary">
+                      Artinya format asli yang diminta YouTube sedang tidak tersedia untuk video itu. Sistem sekarang otomatis mencoba format audio kompatibel, mode HTTP, client alternatif, format universal, lalu helper Python sebelum menampilkan error final. Jika tetap gagal, biasanya video dibatasi umur, wilayah, login, atau membutuhkan cookies terbaru.
+                    </div>
+                  </div>
+                </div>
+                <div class="accordion-item">
+                  <h2 class="accordion-header">
+                    <button class="accordion-button fw-semibold collapsed" type="button" data-bs-toggle="collapse"
+                      data-bs-target="#q-tr-19">
+                      <i class="bi bi-cookie me-2 text-warning"></i>Kapan perlu upload cookies baru?
+                    </button>
+                  </h2>
+                  <div id="q-tr-19" class="accordion-collapse collapse" data-bs-parent="#accTrouble">
+                    <div class="accordion-body text-secondary">
+                      Upload cookies baru jika error menyebut login, age-restricted, bot check, HTTP 400/403, atau video hanya bisa diputar dari akun tertentu. Gunakan Admin Cookies, lalu coba convert ulang dengan MP3/M4A terlebih dahulu.
                     </div>
                   </div>
                 </div>

--- a/public-ui/ticket-status.html
+++ b/public-ui/ticket-status.html
@@ -10,7 +10,7 @@
   <script src="/tailwind-ui-bridge.js" defer></script>
   <style>
     body { background: radial-gradient(circle at top left, rgba(37,99,235,.36), transparent 34rem), radial-gradient(circle at top right, rgba(6,182,212,.18), transparent 30rem), #020617; }
-    .glass { background: rgba(15, 23, 42, .84); backdrop-filter: blur(20px); box-shadow: 0 24px 80px rgba(2, 6, 23, .35); }
+    .glass { background: rgba(15, 23, 42, .92); backdrop-filter: none; box-shadow: none; }
     .glass:hover { border-color: rgba(125, 211, 252, .26); }
     .tw-enhanced .tw-pressed { transform: translateY(1px) scale(.99); }
     .pulse-dot { animation: pulseDot 1.8s ease-in-out infinite; }
@@ -20,7 +20,7 @@
 </head>
 <body class="min-h-screen text-slate-100 antialiased">
   <main class="mx-auto max-w-5xl space-y-5 p-4 pb-12 md:p-7">
-    <header class="glass overflow-hidden rounded-3xl border border-white/10 shadow-2xl shadow-blue-950/40">
+    <header class="glass overflow-hidden rounded-3xl border border-white/10">
       <div class="bg-gradient-to-r from-indigo-600/25 via-cyan-500/10 to-transparent p-5 md:p-7">
         <div class="flex flex-wrap items-start justify-between gap-4">
           <div>
@@ -39,7 +39,7 @@
             <span class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-4 text-slate-500">#</span>
             <input id="lookupInput" autocomplete="off" spellcheck="false" maxlength="80" class="w-full rounded-xl border border-slate-700 bg-slate-950/90 py-3 pl-9 pr-4 font-mono text-sm uppercase outline-none transition placeholder:text-slate-600 focus:border-cyan-400 focus:ring-4 focus:ring-cyan-400/10" placeholder="TKT-XXXXXXXX" />
           </div>
-          <button id="lookupBtn" type="submit" class="rounded-xl bg-gradient-to-r from-indigo-500 to-cyan-500 px-5 py-3 text-sm font-bold shadow-lg shadow-indigo-950/40 transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-60">Cari Tiket</button>
+          <button id="lookupBtn" type="submit" class="rounded-xl bg-gradient-to-r from-indigo-500 to-cyan-500 px-5 py-3 text-sm font-bold transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-60">Cari Tiket</button>
         </form>
         <div id="lookupError" class="mt-2 hidden text-sm text-rose-300" role="alert"></div>
         <div id="recentWrap" class="mt-3 hidden items-center gap-2 text-xs text-slate-400">
@@ -48,13 +48,13 @@
       </div>
     </header>
 
-    <section id="emptyState" class="glass rounded-3xl border border-white/10 p-8 text-center shadow-xl">
+    <section id="emptyState" class="glass rounded-3xl border border-white/10 p-8 text-center">
       <div class="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-indigo-500/15 text-3xl">🎫</div>
       <h2 class="mt-4 text-xl font-bold">Siapkan nomor tiketmu</h2>
       <p class="mx-auto mt-2 max-w-lg text-sm leading-6 text-slate-400">Nomor tiket tersedia setelah laporan berhasil dikirim dan biasanya diawali dengan <span class="font-mono text-slate-200">TKT-</span>.</p>
     </section>
 
-    <section id="loadingState" class="glass hidden rounded-3xl border border-white/10 p-6 shadow-xl" aria-live="polite">
+    <section id="loadingState" class="glass hidden rounded-3xl border border-white/10 p-6" aria-live="polite">
       <div class="animate-pulse space-y-4">
         <div class="h-5 w-40 rounded bg-slate-700"></div>
         <div class="grid gap-3 sm:grid-cols-3"><div class="h-24 rounded-2xl bg-slate-800"></div><div class="h-24 rounded-2xl bg-slate-800"></div><div class="h-24 rounded-2xl bg-slate-800"></div></div>
@@ -62,7 +62,7 @@
       </div>
     </section>
 
-    <section id="notFoundState" class="glass hidden rounded-3xl border border-rose-500/20 p-7 text-center shadow-xl" role="alert">
+    <section id="notFoundState" class="glass hidden rounded-3xl border border-rose-500/20 p-7 text-center" role="alert">
       <div class="text-4xl">🔍</div>
       <h2 class="mt-3 text-xl font-bold">Tiket tidak ditemukan</h2>
       <p class="mt-2 text-sm text-slate-400">Periksa kembali nomor tiket. Pastikan tidak ada spasi atau karakter yang tertinggal.</p>
@@ -70,7 +70,7 @@
     </section>
 
     <div id="ticketContent" class="hidden space-y-5">
-      <section class="glass rounded-3xl border border-white/10 p-5 shadow-xl md:p-6">
+      <section class="glass rounded-3xl border border-white/10 p-5 md:p-6">
         <div class="flex flex-wrap items-center justify-between gap-3">
           <div>
             <div class="text-xs font-semibold uppercase tracking-[.2em] text-slate-500">Nomor tiket</div>
@@ -87,7 +87,7 @@
       </section>
 
       <div class="grid gap-5 lg:grid-cols-[1.05fr_.95fr]">
-        <section class="glass rounded-3xl border border-white/10 p-5 shadow-xl md:p-6">
+        <section class="glass rounded-3xl border border-white/10 p-5 md:p-6">
           <h2 class="text-lg font-bold">Ringkasan laporan</h2>
           <div class="mt-4 space-y-4">
             <div><div class="mb-1.5 text-xs font-semibold uppercase tracking-wider text-slate-500">Pesan kamu</div><div id="msg" class="min-h-20 whitespace-pre-wrap break-words rounded-2xl border border-slate-800 bg-slate-950/70 p-4 text-sm leading-6 text-slate-300">-</div></div>
@@ -96,13 +96,13 @@
           </div>
         </section>
 
-        <section class="glass rounded-3xl border border-white/10 p-5 shadow-xl md:p-6">
+        <section class="glass rounded-3xl border border-white/10 p-5 md:p-6">
           <h2 class="text-lg font-bold">Timeline penanganan</h2>
           <ol id="history" class="mt-5 space-y-0"></ol>
         </section>
       </div>
 
-      <section class="glass rounded-3xl border border-white/10 p-5 shadow-xl md:p-6">
+      <section class="glass rounded-3xl border border-white/10 p-5 md:p-6">
         <div class="flex items-center justify-between gap-3"><div><h2 class="text-lg font-bold">Chat dengan admin</h2><p class="mt-1 text-xs text-slate-500">Pesan baru akan muncul otomatis tanpa reload halaman.</p></div><span id="chatCount" class="rounded-full bg-slate-800 px-2.5 py-1 text-xs text-slate-400">0 pesan</span></div>
         <div id="chatHistory" class="mt-4 h-80 space-y-3 overflow-auto rounded-2xl border border-slate-800 bg-slate-950/70 p-4"></div>
         <form id="chatForm" class="mt-3 flex flex-col gap-2 sm:flex-row">
@@ -111,7 +111,7 @@
         <div id="chatHint" class="mt-2 text-xs text-slate-400" aria-live="polite"></div>
       </section>
 
-      <section id="proofSection" class="glass rounded-3xl border border-white/10 p-5 shadow-xl md:p-6">
+      <section id="proofSection" class="glass rounded-3xl border border-white/10 p-5 md:p-6">
         <div class="flex flex-wrap items-start justify-between gap-3"><div><h2 class="text-lg font-bold">Upload bukti tambahan</h2><p id="proofHint" class="mt-1 text-xs text-slate-400">Aktif jika admin meminta bukti tambahan.</p></div><span class="rounded-full border border-slate-700 px-2.5 py-1 text-xs text-slate-400">Maks. 4 gambar</span></div>
         <input id="proofFiles" type="file" accept="image/*" multiple class="mt-4 block w-full text-sm text-slate-300 file:mr-3 file:rounded-lg file:border-0 file:bg-slate-700 file:px-3 file:py-2 file:text-slate-100">
         <div id="proofPreview" class="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-4"></div>
@@ -120,7 +120,7 @@
       </section>
     </div>
 
-    <div id="toast" class="pointer-events-none fixed bottom-5 left-1/2 z-50 hidden -translate-x-1/2 rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-sm shadow-2xl" role="status"></div>
+    <div id="toast" class="pointer-events-none fixed bottom-5 left-1/2 z-50 hidden -translate-x-1/2 rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-sm" role="status"></div>
   </main>
 <script>
 const RECENT_KEY = 'ytconv_recent_tickets_v1';
@@ -141,7 +141,7 @@ let refreshTimer = null;
 
 const asLocal = (iso) => { const date = new Date(iso || ''); return Number.isNaN(date.getTime()) ? (iso || '-') : fmt.format(date); };
 const setVisible = (id, visible) => $(id).classList.toggle('hidden', !visible);
-const showToast = (message, tone = 'normal') => { const el = $('toast'); el.textContent = message; el.className = `pointer-events-none fixed bottom-5 left-1/2 z-50 -translate-x-1/2 rounded-xl border px-4 py-3 text-sm shadow-2xl ${tone === 'error' ? 'border-rose-500/30 bg-rose-950 text-rose-200' : 'border-white/10 bg-slate-900 text-slate-100'}`; clearTimeout(showToast.timer); showToast.timer = setTimeout(() => el.classList.add('hidden'), 2600); };
+const showToast = (message, tone = 'normal') => { const el = $('toast'); el.textContent = message; el.className = `pointer-events-none fixed bottom-5 left-1/2 z-50 -translate-x-1/2 rounded-xl border px-4 py-3 text-sm ${tone === 'error' ? 'border-rose-500/30 bg-rose-950 text-rose-200' : 'border-white/10 bg-slate-900 text-slate-100'}`; clearTimeout(showToast.timer); showToast.timer = setTimeout(() => el.classList.add('hidden'), 2600); };
 const makeBadge = (label, status) => { const span = document.createElement('span'); span.className = `inline-flex rounded-full border px-3 py-1 text-sm font-bold ${statusStyles[status] || 'border-slate-600 bg-slate-700/50 text-slate-200'}`; span.textContent = label || status || '-'; return span; };
 
 function readRecentTickets() { try { const value = JSON.parse(localStorage.getItem(RECENT_KEY) || '[]'); return Array.isArray(value) ? value.filter((x) => x?.ticketId).slice(0, 5) : []; } catch { return []; } }


### PR DESCRIPTION
### Motivation
- Reduce visual weight of the public UI by removing heavy glass, drop-shadows and backdrop blurs in most areas while keeping header depth intact to improve perceived performance and readability.
- Make the downloader more robust against frequent yt-dlp errors like "Requested format is not available" by widening format selectors and adding extra fallback strategies.
- Improve UX and support surface by expanding the FAQ troubleshooting entries (including guidance about unavailable formats and cookies) and make the first FAQ item open by default.
- Make the ticket status page lighter and remove excessive shadowing so it matches the lighter UI direction.

### Description
- UI: added a lightweight CSS override in `public-ui/index.html` to remove box-shadow/backdrop-filter for main content, modals and cards unless `body.keep-rich-shadows` is set, and preserved header styling; updated FAQ markup so the first answer is open by default and added two troubleshooting entries about unavailable formats and cookie refreshing.
- Ticket page: simplified `public-ui/ticket-status.html` styles by removing heavy glass blur/shadow and several `shadow-*` usages and reduced toast/card shadow usage for a lighter look.
- Downloader: widened yt-dlp selectors and fallback behavior in `index.js` (made `buildYtDlpFallbackArgs` inject broader selectors, use tolerant audio selectors for `m4a` and audio-only cases, and added a "format universal" retry that strips the `-f` selector before retrying).
- Python helper: updated `download_audio.py` to use broader HTTP audio selectors and appended a `universal_opts` attempt to the yt-dlp attempt list so the Python helper will try a more permissive extraction sequence before failing.

### Testing
- `node --check index.js` — succeeded with no syntax errors.
- `python3 -m py_compile download_audio.py` — succeeded (Python helper compiles cleanly).
- `npm test -- --runInBand` — failed because the repository has no `test` npm script (observed and reported).
- `node --test tests/*.test.js` and targeted test runs (`tests/ui-polish.test.js`, `tests/ticket-status-ui.test.js`, `tests/format-options.test.js`) — several unit/UI assertions passed (format rules, selectors, UI polish checks), but full test runs were partially blocked by the local environment (missing Assistant API configuration) and a long-running server/auto-maintenance process that prevented the test runner from exiting; format-related tests were observed to pass before the run was interrupted.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a433cdb89788331ad06d63078ad04cf)