### PR TITLE
Server-managed cookies, yt-dlp robustness, job queue, admin UI & UI polish

### DIFF
--- a/cookie_store.js
+++ b/cookie_store.js
@@ -1,190 +1,190 @@
 import { createHash } from "node:crypto";
 import { promises as fsp } from "node:fs";
 import { dirname, join } from "node:path";
-import { cert, getApps, initializeApp } from "firebase-admin/app";
-import { getFirestore } from "firebase-admin/firestore";
 
-const PERSISTENT_BASE_DIR = process.env.RAILWAY_VOLUME_MOUNT_PATH || process.cwd();
-const DEFAULT_COOKIES_PATH = join(PERSISTENT_BASE_DIR, "cookies.txt");
-const COOKIES_PATH = process.env.COOKIES_PATH || process.env.COOKIE_FILE_PATH || DEFAULT_COOKIES_PATH;
-const STORE_PATH = process.env.COOKIE_STORE_PATH || join(PERSISTENT_BASE_DIR, "data", "cookies-store.json");
-const COLLECTION = "app-secrets";
-const DOCUMENT = "youtube-cookies";
-const MAX_COOKIE_BYTES = 900 * 1024;
+const hasExplicitCookiesPath = Boolean(process.env.COOKIES_PATH || process.env.COOKIE_FILE_PATH);
+const DATA_DIR = process.env.RAILWAY_VOLUME_MOUNT_PATH || "/data";
+const FALLBACK_DIR = join(process.cwd(), "data");
+const BASE_DIR = hasExplicitCookiesPath ? dirname(process.env.COOKIES_PATH || process.env.COOKIE_FILE_PATH) : DATA_DIR;
+const DEFAULT_COOKIES_PATH = hasExplicitCookiesPath
+  ? (process.env.COOKIES_PATH || process.env.COOKIE_FILE_PATH)
+  : join(DATA_DIR, "cookies.txt");
+const COOKIES_PATH = DEFAULT_COOKIES_PATH;
+const META_PATH = process.env.COOKIE_STORE_PATH || join(BASE_DIR || FALLBACK_DIR, "cookies-meta.json");
+const MAX_COOKIE_BYTES = Math.max(16 * 1024, Number(process.env.MAX_COOKIES_BYTES || 900 * 1024));
 const SYNC_INTERVAL_MS = Math.max(5_000, Number(process.env.COOKIES_SYNC_INTERVAL_MS || 15_000));
 
-let firestoreDb;
-let fileQueue = Promise.resolve();
 let syncTimer;
-let lastLocalHash = "";
-let backendLogged = false;
+let fileQueue = Promise.resolve();
+let lastHealth = { health: "unknown", lastTestAt: null, lastErrorCategory: null };
 
 const hashContent = (content) => createHash("sha256").update(content, "utf8").digest("hex");
+const storageName = () => (String(COOKIES_PATH).startsWith("/data/") ? "volume" : "volume");
 
-const parseServiceAccount = () => {
-  const raw = String(process.env.FIREBASE_SERVICE_ACCOUNT_JSON || "").trim();
-  if (raw) return JSON.parse(raw);
-  const base64 = String(process.env.FIREBASE_SERVICE_ACCOUNT_BASE64 || "").trim();
-  if (base64) return JSON.parse(Buffer.from(base64, "base64").toString("utf8"));
-  return null;
-};
-
-const getDb = () => {
-  if (firestoreDb !== undefined) return firestoreDb;
-  const serviceAccount = parseServiceAccount();
-  if (!serviceAccount) {
-    firestoreDb = null;
-    return firestoreDb;
-  }
-  const app = getApps()[0] || initializeApp({
-    credential: cert(serviceAccount),
-    projectId: process.env.FIREBASE_PROJECT_ID || serviceAccount.project_id,
-  });
-  firestoreDb = getFirestore(app);
-  return firestoreDb;
-};
-
-const backendName = () => (getDb() ? "firestore" : "file");
-
-const logBackend = () => {
-  if (backendLogged) return;
-  backendLogged = true;
-  console.log(`[cookie-store] backend: ${backendName()}`);
-};
-
-const normalizeContent = (value) => {
-  if (typeof value !== "string") throw new Error("cookies_invalid_body");
-  const content = value.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n");
-  if (!content.trim()) throw new Error("cookies_empty");
-  const bytes = Buffer.byteLength(content, "utf8");
-  if (bytes > MAX_COOKIE_BYTES) throw new Error("cookies_too_large");
-  return { content, bytes, hash: hashContent(content) };
-};
-
-const readFileRecord = async () => {
-  try {
-    const raw = await fsp.readFile(STORE_PATH, "utf8");
-    const record = JSON.parse(raw);
-    return record && typeof record.content === "string" ? record : null;
-  } catch (err) {
-    if (err?.code === "ENOENT") return null;
-    throw err;
-  }
-};
-
-const writeFileRecord = (record) => {
-  const operation = async () => {
-    await fsp.mkdir(dirname(STORE_PATH), { recursive: true });
-    const temporaryPath = `${STORE_PATH}.${process.pid}.${Date.now()}.tmp`;
-    await fsp.writeFile(temporaryPath, JSON.stringify(record), { encoding: "utf8", mode: 0o600 });
-    await fsp.rename(temporaryPath, STORE_PATH);
-    return record;
-  };
+const queueFile = (operation) => {
   const run = fileQueue.then(operation, operation);
   fileQueue = run.catch(() => {});
   return run;
 };
 
-const writeLocalCookies = async (record, { force = false } = {}) => {
-  if (!record?.content) return false;
-  if (!force && lastLocalHash === record.hash) {
-    try {
-      await fsp.access(COOKIES_PATH);
-      return false;
-    } catch {
-      // The runtime copy was removed; rebuild it from the persistent record.
-    }
+const readMeta = async () => {
+  try {
+    return JSON.parse(await fsp.readFile(META_PATH, "utf8"));
+  } catch (err) {
+    if (err?.code === "ENOENT") return {};
+    return {};
   }
-  await fsp.mkdir(dirname(COOKIES_PATH), { recursive: true });
-  const temporaryPath = `${COOKIES_PATH}.${process.pid}.${Date.now()}.tmp`;
-  await fsp.writeFile(temporaryPath, record.content, { encoding: "utf8", mode: 0o600 });
-  await fsp.rename(temporaryPath, COOKIES_PATH);
-  lastLocalHash = record.hash;
-  return true;
+};
+
+const writeMeta = async (patch = {}) => {
+  const current = await readMeta();
+  const next = { ...current, ...patch, storage: storageName(), path: COOKIES_PATH };
+  await fsp.mkdir(dirname(META_PATH), { recursive: true });
+  await fsp.writeFile(META_PATH, JSON.stringify(next, null, 2), { mode: 0o600 });
+  lastHealth = {
+    health: next.health || lastHealth.health || "unknown",
+    lastTestAt: next.lastTestAt || lastHealth.lastTestAt || null,
+    lastErrorCategory: next.lastErrorCategory || lastHealth.lastErrorCategory || null,
+  };
+  return next;
+};
+
+export const validateCookiesText = (value, { filename = "cookies.txt" } = {}) => {
+  if (typeof value !== "string") throw new Error("cookies_invalid_body");
+  if (!/\.txt$/i.test(String(filename || "cookies.txt"))) throw new Error("cookies_invalid_file_type");
+  const content = value.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n");
+  const bytes = Buffer.byteLength(content, "utf8");
+  if (!content.trim()) throw new Error("cookies_empty");
+  if (bytes > MAX_COOKIE_BYTES) throw new Error("cookies_too_large");
+  if (/[\u0000-\u0008\u000B\u000C\u000E-\u001F]/.test(content)) throw new Error("cookies_suspicious_content");
+
+  const lines = content.split("\n").map((line) => line.trim()).filter(Boolean);
+  const hasHeader = lines.some((line) => /^#\s*Netscape HTTP Cookie File/i.test(line));
+  const cookieRows = lines.filter((line) => !line.startsWith("#"));
+  const validRows = cookieRows.filter((line) => {
+    const parts = line.split("\t");
+    return parts.length >= 7 && parts[0] && /^(TRUE|FALSE)$/i.test(parts[1]) && /^(TRUE|FALSE)$/i.test(parts[3]) && parts[5] && parts.slice(6).join("\t");
+  });
+  if (!hasHeader || validRows.length < 1) throw new Error("cookies_invalid_netscape_format");
+  if (!validRows.some((line) => /(^|\.)youtube\.com\t|(^|\.)google\.com\t|(^|\.)youtu\.be\t/i.test(line))) {
+    throw new Error("cookies_missing_youtube_domain");
+  }
+  return { content, bytes, hash: hashContent(content), cookieCount: validRows.length };
 };
 
 export const getCookiesPath = () => COOKIES_PATH;
-export const getCookieStoreBackend = () => backendName();
+export const getCookieStoreBackend = () => storageName();
 
-export const saveCookies = async (value) => {
-  logBackend();
-  const normalized = normalizeContent(value);
-  const record = {
-    ...normalized,
-    uploadedAt: new Date().toISOString(),
+export const saveCookies = async (value, options = {}) => queueFile(async () => {
+  const normalized = validateCookiesText(value, options);
+  await fsp.mkdir(dirname(COOKIES_PATH), { recursive: true });
+  const tmp = `${COOKIES_PATH}.${process.pid}.${Date.now()}.tmp`;
+  await fsp.writeFile(tmp, normalized.content, { encoding: "utf8", mode: 0o600 });
+  await fsp.rename(tmp, COOKIES_PATH);
+  const uploadedAt = new Date().toISOString();
+  await writeMeta({
+    exists: true,
+    sizeBytes: normalized.bytes,
+    bytes: normalized.bytes,
+    hash: normalized.hash,
+    cookieCount: normalized.cookieCount,
+    updatedAt: uploadedAt,
+    uploadedAt,
     version: Date.now(),
-  };
-  const db = getDb();
-  if (db) {
-    await db.collection(COLLECTION).doc(DOCUMENT).set(record);
-  } else {
-    await writeFileRecord(record);
-  }
-  await writeLocalCookies(record, { force: true });
-  return { bytes: record.bytes, hash: record.hash, uploadedAt: record.uploadedAt, version: record.version };
-};
+    health: "unknown",
+    lastErrorCategory: null,
+  });
+  return { bytes: normalized.bytes, sizeBytes: normalized.bytes, uploadedAt, updatedAt: uploadedAt, version: Date.now(), health: "unknown", storage: storageName() };
+});
 
 export const readCookies = async () => {
-  logBackend();
-  const db = getDb();
-  if (db) {
-    const snapshot = await db.collection(COLLECTION).doc(DOCUMENT).get();
-    if (!snapshot.exists) return null;
-    const record = snapshot.data();
-    return record && typeof record.content === "string" ? record : null;
-  }
   await fileQueue;
-  return readFileRecord();
-};
-
-export const syncCookiesToLocal = async ({ force = false } = {}) => {
-  const record = await readCookies();
-  if (!record) return null;
-  await writeLocalCookies(record, { force });
-  return {
-    exists: true,
-    path: COOKIES_PATH,
-    bytes: Number(record.bytes || Buffer.byteLength(record.content, "utf8")),
-    hash: record.hash || hashContent(record.content),
-    uploadedAt: record.uploadedAt || null,
-    version: record.version || null,
-    backend: backendName(),
-  };
-};
-
-export const initializeCookiesStore = async () => {
-  const persisted = await readCookies();
-  if (persisted) {
-    await writeLocalCookies(persisted, { force: true });
-    return getCookiesStatus();
-  }
-
   try {
-    const legacyContent = await fsp.readFile(COOKIES_PATH, "utf8");
-    if (!legacyContent.trim()) return null;
-    await saveCookies(legacyContent);
-    console.log(`[cookie-store] migrated legacy cookies from ${COOKIES_PATH}`);
-    return getCookiesStatus();
+    const content = await fsp.readFile(COOKIES_PATH, "utf8");
+    const stat = await fsp.stat(COOKIES_PATH);
+    const meta = await readMeta();
+    return {
+      content,
+      bytes: stat.size,
+      sizeBytes: stat.size,
+      hash: hashContent(content),
+      uploadedAt: meta.uploadedAt || stat.mtime.toISOString(),
+      updatedAt: meta.updatedAt || stat.mtime.toISOString(),
+      version: meta.version || stat.mtimeMs,
+      health: meta.health || lastHealth.health || "unknown",
+      lastTestAt: meta.lastTestAt || lastHealth.lastTestAt || null,
+      lastErrorCategory: meta.lastErrorCategory || lastHealth.lastErrorCategory || null,
+    };
   } catch (err) {
     if (err?.code === "ENOENT") return null;
     throw err;
   }
 };
 
-export const getCookiesStatus = async () => {
+export const syncCookiesToLocal = async () => {
   const record = await readCookies();
-  if (!record) return { exists: false, backend: backendName(), path: COOKIES_PATH };
-  await writeLocalCookies(record);
+  if (!record) return null;
   return {
     exists: true,
     path: COOKIES_PATH,
-    bytes: Number(record.bytes || Buffer.byteLength(record.content, "utf8")),
-    hash: record.hash || hashContent(record.content),
-    uploadedAt: record.uploadedAt || null,
-    version: record.version || null,
-    backend: backendName(),
+    bytes: record.bytes,
+    sizeBytes: record.bytes,
+    uploadedAt: record.uploadedAt,
+    updatedAt: record.updatedAt,
+    version: record.version,
+    backend: storageName(),
+    storage: storageName(),
+    health: record.health || "unknown",
+    lastTestAt: record.lastTestAt || null,
+    lastErrorCategory: record.lastErrorCategory || null,
   };
 };
+
+export const initializeCookiesStore = async () => syncCookiesToLocal();
+
+export const getCookiesStatus = async () => {
+  const record = await readCookies();
+  if (!record) {
+    const meta = await readMeta();
+    return {
+      exists: false,
+      sizeBytes: 0,
+      updatedAt: null,
+      storage: storageName(),
+      backend: storageName(),
+      health: "missing",
+      lastTestAt: meta.lastTestAt || null,
+      lastErrorCategory: meta.lastErrorCategory || null,
+    };
+  }
+  return {
+    exists: true,
+    sizeBytes: record.bytes,
+    bytes: record.bytes,
+    updatedAt: record.updatedAt,
+    uploadedAt: record.uploadedAt,
+    storage: storageName(),
+    backend: storageName(),
+    health: record.health || "unknown",
+    lastTestAt: record.lastTestAt || null,
+    lastErrorCategory: record.lastErrorCategory || null,
+  };
+};
+
+export const updateCookiesHealth = async ({ health = "unknown", lastErrorCategory = null } = {}) => {
+  const meta = await writeMeta({ health, lastErrorCategory, lastTestAt: new Date().toISOString() });
+  return {
+    health: meta.health || health,
+    lastErrorCategory: meta.lastErrorCategory || lastErrorCategory,
+    lastTestAt: meta.lastTestAt,
+  };
+};
+
+export const deleteCookies = async () => queueFile(async () => {
+  await fsp.rm(COOKIES_PATH, { force: true });
+  await writeMeta({ exists: false, sizeBytes: 0, bytes: 0, health: "missing", updatedAt: null, lastErrorCategory: null });
+  return { ok: true };
+});
 
 export const startCookiesSync = ({ onError } = {}) => {
   if (syncTimer) return syncTimer;

--- a/download_audio.py
+++ b/download_audio.py
@@ -1,8 +1,10 @@
 # download_audio.py — helper for yt_dlp / PyTube audio download
 import os
+import re
+import shutil
 import subprocess
 import sys
-from typing import Iterable, Optional
+from typing import Dict, Iterable, Optional
 
 YoutubeDL = None
 YouTube = None
@@ -21,6 +23,59 @@ def upgrade_ytdlp() -> bool:
         return ensure_ytdlp()
     except Exception:
         return False
+
+
+def _major_version(value: str) -> int:
+    match = re.search(r"v?(\d+)", value or "")
+    return int(match.group(1)) if match else 0
+
+
+def get_youtube_extractor_args() -> Dict[str, Dict[str, list[str]]]:
+    clients_raw = os.environ.get(
+        "YTDLP_YOUTUBE_PLAYER_CLIENTS",
+        "mweb,web_safari,tv_embedded,android,default",
+    )
+    clients = [item.strip() for item in re.split(r"[,+]", clients_raw) if item.strip()]
+    youtube_args: Dict[str, list[str]] = {}
+    if clients:
+        youtube_args["player_client"] = clients
+    po_token = os.environ.get("YTDLP_YOUTUBE_PO_TOKEN", "").strip()
+    if po_token:
+        youtube_args["po_token"] = [po_token]
+    return {"youtube": youtube_args} if youtube_args else {}
+
+
+def get_js_runtime_options() -> Dict[str, object]:
+    runtime = os.environ.get("YTDLP_JS_RUNTIME", "node").strip().lower()
+    if runtime in {"", "off", "none", "0"}:
+        return {}
+
+    if runtime == "node":
+        node_bin = shutil.which("node")
+        if not node_bin:
+            print("node runtime not found; yt_dlp JS runtime disabled", file=sys.stderr)
+            return {}
+        try:
+            version = subprocess.check_output([node_bin, "--version"], text=True, timeout=3).strip()
+        except Exception as exc:
+            print(f"failed to inspect node version; yt_dlp JS runtime disabled: {exc}", file=sys.stderr)
+            return {}
+        if _major_version(version) < 22:
+            print(f"node {version} is below yt-dlp 2026.06.09 minimum; yt_dlp JS runtime disabled", file=sys.stderr)
+            return {}
+
+    return {
+        "js_runtimes": {runtime: {}},
+        "remote_components": ["ejs:github"],
+        "extractor_retries": 3,
+    }
+
+
+def should_use_cookies() -> bool:
+    # Server-managed cookies are enabled by ENABLE_SERVER_COOKIES in the Node app.
+    # YTDLP_USE_COOKIES remains as a backwards-compatible alias.
+    raw = os.environ.get("ENABLE_SERVER_COOKIES", os.environ.get("YTDLP_USE_COOKIES", "true"))
+    return str(raw).strip().lower() not in {"0", "false", "off", "no"}
 
 
 def ensure_ytdlp() -> bool:
@@ -115,32 +170,39 @@ def download_with_ytdlp(
         "noplaylist": True,
         "quiet": False,
         "no_warnings": False,
-        "js_runtimes": {"node": {}},
-        "remote_components": ["ejs:github"],
         "nocheckcertificate": True,
         "cachedir": False,
         "ignoreerrors": False,
     }
 
-    if cookies_path and os.path.isfile(cookies_path):
+    base_opts.update(get_js_runtime_options())
+
+    extractor_args = get_youtube_extractor_args()
+    if extractor_args:
+        base_opts["extractor_args"] = extractor_args
+
+    if should_use_cookies() and cookies_path and os.path.isfile(cookies_path):
         base_opts["cookiefile"] = cookies_path
 
     compat_opts = dict(base_opts)
     compat_opts["force_ipv4"] = True
-    compat_opts["extractor_args"] = {"youtube": {"player_client": ["android"]}}
+    compat_opts["extractor_args"] = {"youtube": {"player_client": ["android", "mweb"]}}
 
     tv_opts = dict(base_opts)
-    tv_opts["extractor_args"] = {"youtube": {"player_client": ["tv_embedded", "android"]}}
+    tv_opts["extractor_args"] = {"youtube": {"player_client": ["mweb", "web_safari", "tv_embedded", "android"]}}
 
     relaxed_opts = dict(compat_opts)
     relaxed_opts["format"] = "best"
 
     http_opts = dict(relaxed_opts)
-    http_opts["format"] = "bestaudio[protocol^=http]/best[protocol^=http]/bestaudio/best"
+    http_opts["format"] = "bestaudio[protocol^=http]/best[protocol^=http]/bestaudio/best/worst"
+
+    universal_opts = dict(tv_opts)
+    universal_opts.pop("format", None)
 
     last_exc: Optional[Exception] = None
     upgrade_tried = False
-    attempts = [base_opts, compat_opts, tv_opts, relaxed_opts, http_opts]
+    attempts = [base_opts, compat_opts, tv_opts, relaxed_opts, http_opts, universal_opts]
     for opts in attempts:
         try:
             with YoutubeDL(opts) as ydl:  # type: ignore[misc]

--- a/index.js
+++ b/index.js
@@ -47,6 +47,8 @@ import {
   listUserHistory,
   getHistoryEntry,
   updateHistoryEntry,
+  deleteHistoryEntry,
+  clearUserHistory,
   buildUserSummaryById,
   ensureReferralForUser,
   getUserById,
@@ -68,6 +70,8 @@ import {
   saveCookies,
   startCookiesSync,
   syncCookiesToLocal,
+  updateCookiesHealth,
+  deleteCookies,
 } from "./cookie_store.js";
 import {
   createTicket,
@@ -180,6 +184,7 @@ const parseGroqModels = () => {
 };
 const GROQ_MODEL_CANDIDATES = parseGroqModels();
 const COOKIES_PATH = getCookiesPath();
+const shouldUseYtDlpCookies = () => !/^(0|false|off|no)$/i.test(String(process.env.ENABLE_SERVER_COOKIES || "true"));
 try {
   const cookieStatus = await initializeCookiesStore();
   console.log(cookieStatus
@@ -3028,6 +3033,7 @@ const runYtDlpAttempt = (command, args, { label }) =>
     let stderr = "";
     const proc = spawn(command.cmd, [...(command.prefix || []), ...args], {
       stdio: ["ignore", "pipe", "pipe"],
+      cwd: JOBS_DIR,
     });
     const displayArgs = [...(command.prefix || []), ...args].join(" ");
     const baseLog = `${label}: ${command.cmd} ${displayArgs}`.trim();
@@ -3061,6 +3067,55 @@ const runYtDlpAttempt = (command, args, { label }) =>
       }
     });
   });
+
+
+const categorizeYtDlpError = (value = "") => {
+  const raw = String(value || "");
+  if (/sign in to confirm|not a bot|bot check|use --cookies|cookies-from-browser|confirm you(?:\'|’)re not a bot/i.test(raw)) return "BOT_CHECK";
+  if (/login required|sign in|private video|members-only|account/i.test(raw)) return "LOGIN_REQUIRED";
+  if (/age[- ]?restricted|confirm your age|age restriction/i.test(raw)) return "AGE_RESTRICTED";
+  if (/not available in your country|geo|region/i.test(raw)) return "GEO_BLOCKED";
+  if (/private video/i.test(raw)) return "PRIVATE_VIDEO";
+  if (/requested format is not available|no video formats|only images are available|format/i.test(raw)) return "FORMAT_UNAVAILABLE";
+  if (/429|too many requests|rate.?limit/i.test(raw)) return "RATE_LIMITED";
+  if (/ffmpeg/i.test(raw)) return "FFMPEG_MISSING";
+  if (/yt-dlp tidak bisa dijalankan|yt-dlp.*not found|no such file/i.test(raw)) return "YTDLP_MISSING";
+  if (/network|timed?out|econn|enotfound|http error 5\d\d/i.test(raw)) return "NETWORK_ERROR";
+  return "UNKNOWN";
+};
+
+const isCookieRetryCategory = (category) => new Set(["BOT_CHECK", "LOGIN_REQUIRED", "AGE_RESTRICTED", "RATE_LIMITED"]).has(category);
+
+const appendServerCookiesArgs = async (args = []) => {
+  if (!shouldUseYtDlpCookies()) return { args: [...args], used: false, status: null };
+  const status = await syncCookiesToLocal({ force: true }).catch((err) => {
+    console.warn("[cookie-store] sync before yt-dlp retry failed", err?.message || err);
+    return null;
+  });
+  if (!status?.exists || !existsSync(COOKIES_PATH)) return { args: [...args], used: false, status };
+  const next = [...args];
+  const urlArg = next.length ? next[next.length - 1] : null;
+  const hasUrlTail = typeof urlArg === "string" && (/^(https?:|ytsearch|ytmsearch)/i.test(urlArg));
+  if (hasUrlTail) next.pop();
+  if (!next.includes("--cookies")) next.push("--cookies", COOKIES_PATH);
+  if (hasUrlTail) next.push(urlArg);
+  return { args: next, used: true, status };
+};
+
+const publicDownloadError = (err) => {
+  const logs = err?.logs || err?.message || "";
+  const category = err?.errorCategory || categorizeYtDlpError(logs);
+  const needsAdminCookies = ["BOT_CHECK", "LOGIN_REQUIRED", "AGE_RESTRICTED"].includes(category);
+  const message = needsAdminCookies
+    ? "Video membutuhkan cookies YouTube terbaru. Admin perlu memperbarui cookies di Admin Cookies Manager."
+    : (err?.message || "Gagal memproses video");
+  const wrapped = new Error(message);
+  wrapped.errorCategory = category;
+  wrapped.adminActionRequired = needsAdminCookies;
+  wrapped.hint = needsAdminCookies ? "Admin: buka Admin Cookies Manager, upload cookies Netscape terbaru, lalu jalankan Test Cookies." : undefined;
+  wrapped.logs = logs;
+  return wrapped;
+};
 
 const runYtDlpJson = async (args, { label = "yt-dlp" } = {}) => {
   const errors = [];
@@ -3529,11 +3584,8 @@ const fetchVideoInfo = async ({ url, keyword, preferLang } = {}) => {
   if (language) {
     args.push("--sub-lang", language);
   }
-  if (existsSync(COOKIES_PATH)) {
-    args.push("--cookies", COOKIES_PATH);
-  }
-  args.push("--js-runtimes", "node");
-  args.push("--remote-components", "ejs:github");
+  args.push(...getYtDlpJsRuntimeArgs());
+  pushYoutubeExtractorArgs(args);
   args.push(target);
 
   let entry;
@@ -3541,6 +3593,22 @@ const fetchVideoInfo = async ({ url, keyword, preferLang } = {}) => {
     const json = await runYtDlpJson(args, { label: keywordUsed ? "ytsearch" : "info" });
     entry = Array.isArray(json?.entries) && json.entries.length ? json.entries[0] : json;
   } catch (err) {
+    const category = categorizeYtDlpError(err?.logs || err?.message || "");
+    if (isCookieRetryCategory(category)) {
+      const cookieRetry = await appendServerCookiesArgs(args);
+      if (cookieRetry.used) {
+        try {
+          const retryJson = await runYtDlpJson(cookieRetry.args, { label: `${keywordUsed ? "ytsearch" : "info"}-cookies` });
+          entry = Array.isArray(retryJson?.entries) && retryJson.entries.length ? retryJson.entries[0] : retryJson;
+          await updateCookiesHealth({ health: "valid", lastErrorCategory: null }).catch(() => {});
+        } catch (cookieErr) {
+          await updateCookiesHealth({ health: "expired", lastErrorCategory: categorizeYtDlpError(cookieErr?.logs || cookieErr?.message || "") }).catch(() => {});
+        }
+      }
+    }
+    if (entry) {
+      // metadata recovered by admin-managed cookies
+    } else
     // Jika menggunakan ytmsearch dan gagal, coba fallback ke ytsearch biasa dengan query "judul artis audio"
     if (target && target.startsWith("ytmsearch") && originalSource?.type === "spotify") {
       // Update query untuk YouTube biasa: "judul artis audio"
@@ -3560,11 +3628,8 @@ const fetchVideoInfo = async ({ url, keyword, preferLang } = {}) => {
       if (language) {
         fallbackArgs.push("--sub-lang", language);
       }
-      if (existsSync(COOKIES_PATH)) {
-        fallbackArgs.push("--cookies", COOKIES_PATH);
-      }
-      fallbackArgs.push("--js-runtimes", "node");
-      fallbackArgs.push("--remote-components", "ejs:github");
+      fallbackArgs.push(...getYtDlpJsRuntimeArgs());
+      pushYoutubeExtractorArgs(fallbackArgs);
       fallbackArgs.push(fallbackTarget);
 
       try {
@@ -3712,9 +3777,11 @@ const searchYoutubeVideos = async ({ query, limit = 6, preferLang } = {}) => {
   if (language) {
     args.push("--sub-lang", language);
   }
-  if (existsSync(COOKIES_PATH)) {
+  if (shouldUseYtDlpCookies() && existsSync(COOKIES_PATH)) {
     args.push("--cookies", COOKIES_PATH);
   }
+  args.push(...getYtDlpJsRuntimeArgs());
+  pushYoutubeExtractorArgs(args);
   args.push(target);
 
   try {
@@ -6139,7 +6206,9 @@ const fetchWithTimeout = async (url, { timeout = 15000, headers = {} } = {}) => 
 const fetchSubtitleViaYtDlp = async ({ url, langOpt, preferAuto }) => {
   const args = ["--dump-single-json", "--no-progress", "--skip-download", "--no-warnings"];
   if (ffmpegPath) args.push("--ffmpeg-location", ffmpegPath);
-  if (existsSync(COOKIES_PATH)) args.push("--cookies", COOKIES_PATH);
+  if (shouldUseYtDlpCookies() && existsSync(COOKIES_PATH)) args.push("--cookies", COOKIES_PATH);
+  args.push(...getYtDlpJsRuntimeArgs());
+  pushYoutubeExtractorArgs(args);
   args.push(url);
 
   let stdout = "";
@@ -7081,6 +7150,52 @@ const parseYtDlpProgressLine = (line = "") => {
   };
 };
 
+
+const parseMajorVersion = (value = "") => {
+  const match = String(value || "").match(/v?(\d+)/);
+  return match ? Number(match[1]) : 0;
+};
+
+const getYtDlpJsRuntimeArgs = () => {
+  const runtime = String(process.env.YTDLP_JS_RUNTIME || "node").trim().toLowerCase();
+  if (runtime === "off" || runtime === "none" || runtime === "0") return [];
+
+  const nodeMajor = parseMajorVersion(process.version);
+  const selected = runtime || "node";
+  if (selected === "node" && nodeMajor < 22) {
+    console.warn(`[yt-dlp] Node ${process.version} is below yt-dlp 2026.06.09 minimum for JS runtime; skipping --js-runtimes node`);
+    return [];
+  }
+
+  return ["--js-runtimes", selected, "--remote-components", "ejs:github", "--extractor-retries", "3"];
+};
+
+
+const getYoutubeExtractorArgsValue = () => {
+  const clients = String(process.env.YTDLP_YOUTUBE_PLAYER_CLIENTS || "mweb,web_safari,tv_embedded,android,default")
+    .split(/[,+]/)
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .join(",");
+  const parts = [];
+  if (clients) parts.push(`player_client=${clients}`);
+  const poToken = String(process.env.YTDLP_YOUTUBE_PO_TOKEN || "").trim();
+  if (poToken) parts.push(`po_token=${poToken}`);
+  return parts.length ? `youtube:${parts.join(";")}` : "";
+};
+
+const pushYoutubeExtractorArgs = (args = []) => {
+  const value = getYoutubeExtractorArgsValue();
+  if (!value) return args;
+  const index = args.indexOf("--extractor-args");
+  if (index >= 0 && typeof args[index + 1] === "string") {
+    args[index + 1] = value;
+  } else {
+    args.push("--extractor-args", value);
+  }
+  return args;
+};
+
 const buildYtDlpFallbackArgs = (args = []) => {
   const next = Array.isArray(args) ? [...args] : [];
   if (!next.length) return next;
@@ -7089,12 +7204,7 @@ const buildYtDlpFallbackArgs = (args = []) => {
   const isUrlLike = typeof url === "string" && (url.startsWith("http://") || url.startsWith("https://") || url.startsWith("ytsearch:"));
   const urlArg = isUrlLike ? next.pop() : null;
 
-  const extractorIndex = next.indexOf("--extractor-args");
-  if (extractorIndex >= 0 && typeof next[extractorIndex + 1] === "string") {
-    next[extractorIndex + 1] = "youtube:player_client=tv_embedded,android";
-  } else {
-    next.push("--extractor-args", "youtube:player_client=tv_embedded,android");
-  }
+  pushYoutubeExtractorArgs(next);
 
   if (!next.includes("--force-ipv4")) {
     next.push("--force-ipv4");
@@ -7103,9 +7213,7 @@ const buildYtDlpFallbackArgs = (args = []) => {
   for (let i = 0; i < next.length - 1; i++) {
     if (next[i] === "-f" && typeof next[i + 1] === "string") {
       const selector = next[i + 1];
-      if (selector.includes("bestaudio")) {
-        next[i + 1] = "bestaudio[protocol^=http]/best[protocol^=http]/bestaudio/best";
-      }
+      next[i + 1] = "bestaudio[protocol^=http]/best[protocol^=http]/bestaudio/best/worst";
       break;
     }
   }
@@ -7119,7 +7227,7 @@ const runYtDlpDownload = ({ args, id, onProgress }) =>
     const isWin = process.platform === "win32";
     const cmd = isWin ? "python" : "yt-dlp";
     const spawnArgs = isWin ? ["-m", "yt_dlp", ...args] : args;
-    const proc = spawn(cmd, spawnArgs, { stdio: ["ignore", "pipe", "pipe"] });
+    const proc = spawn(cmd, spawnArgs, { stdio: ["ignore", "pipe", "pipe"], cwd: JOBS_DIR });
     let logs = "";
     let stdoutBuffer = "";
     const handleLine = (line) => {
@@ -7189,12 +7297,12 @@ const runPythonDownload = ({ url, id, baseLogs = "" }) =>
       JOBS_DIR,
       id,
     ];
-    if (existsSync(COOKIES_PATH)) {
+    if (shouldUseYtDlpCookies() && existsSync(COOKIES_PATH)) {
       scriptArgs.push(COOKIES_PATH);
     }
 
     const pyCmd = process.platform === "win32" ? "python" : "python3";
-    const py = spawn(pyCmd, scriptArgs, { stdio: ["ignore", "pipe", "pipe"] });
+    const py = spawn(pyCmd, scriptArgs, { stdio: ["ignore", "pipe", "pipe"], cwd: JOBS_DIR });
 
     py.stdout.on("data", (d) => {
       const s = d.toString();
@@ -7505,18 +7613,19 @@ const convertSingle = async (payload = {}) => {
     if (ffmpegPath) {
       args.push("--ffmpeg-location", ffmpegPath);
     }
-    if (existsSync(COOKIES_PATH)) {
-      args.push("--cookies", COOKIES_PATH);
-    }
-    args.push("--js-runtimes", "node");
-    args.push("--remote-components", "ejs:github");
+    args.push(...getYtDlpJsRuntimeArgs());
+    pushYoutubeExtractorArgs(args);
     if (noPlaylist) args.push("--no-playlist");
     args.push("-o", outTpl);
 
     emitProgress({ stage: "downloading", message: "Menyiapkan unduhan", percent: 15 });
 
     const sanitizedAbrForDownload = isVideoFormat ? undefined : targetAbr || Number(abr) || undefined;
-    const baseAudioSelector = atmos ? "bestaudio[channels>2]/bestaudio/best" : "bestaudio/best";
+    // Prefer audio-only, but keep broad fallbacks so YouTube videos with unusual/limited formats
+    // do not fail immediately with "Requested format is not available".
+    const baseAudioSelector = atmos
+      ? "bestaudio[channels>2]/bestaudio/best/worst"
+      : "bestaudio/best/worst";
 
     if (isVideoFormat) {
       const selector = buildVideoFormatSelector(fmt, targetVideoQuality);
@@ -7529,7 +7638,7 @@ const convertSingle = async (payload = {}) => {
         args.push("--merge-output-format", "mkv");
       }
     } else if (fmt === "m4a") {
-      args.push("-f", "bestaudio[ext=m4a]/bestaudio/best");
+      args.push("-f", "bestaudio[ext=m4a]/bestaudio/best/worst");
     } else if (fmt === "alac") {
       args.push("-f", baseAudioSelector);
       args.push("-x", "--audio-format", "alac");
@@ -7607,14 +7716,23 @@ const convertSingle = async (payload = {}) => {
         logs = downloadResult.logs || "";
       } catch (err) {
         const baseLogs = err.logs || "";
-        if (isVideoFormat) {
-          if (coverPath) try { await fsp.unlink(coverPath); } catch { }
-          const videoError = new Error(err.message || "Gagal mengunduh");
-          videoError.logs = (baseLogs || "").slice(-8000);
-          throw videoError;
+        const errorCategory = categorizeYtDlpError(baseLogs || err?.message || "");
+        const shouldRetryWithFallbackArgs = /Requested format is not available|HTTP Error 400|HTTP Error 403|Forbidden|Sign in|cookies|confirm your age|precondition|This video is unavailable/i.test(baseLogs || "") || isCookieRetryCategory(errorCategory);
+        if (isCookieRetryCategory(errorCategory)) {
+          const cookieRetry = await appendServerCookiesArgs(args);
+          if (cookieRetry.used) {
+            try {
+              emitProgress({ stage: "downloading", message: "Mencoba cookies server", percent: mapDownloadPercent(17) });
+              downloadResult = await runYtDlpDownload({ args: cookieRetry.args, id, onProgress: handleDownloadProgress });
+              logs = downloadResult.logs || baseLogs;
+              await updateCookiesHealth({ health: "valid", lastErrorCategory: null }).catch(() => {});
+            } catch (cookieErr) {
+              logs = cookieErr?.logs || logs || baseLogs;
+              await updateCookiesHealth({ health: "expired", lastErrorCategory: categorizeYtDlpError(logs) }).catch(() => {});
+            }
+          }
         }
-        const shouldRetryWithFallbackArgs = /Requested format is not available|HTTP Error 400|HTTP Error 403|Forbidden|Sign in|cookies|confirm your age|precondition|This video is unavailable/i.test(baseLogs || "");
-        if (shouldRetryWithFallbackArgs) {
+        if (!downloadResult && shouldRetryWithFallbackArgs) {
           try {
             emitProgress({ stage: "downloading", message: "Mencoba mode kompatibilitas", percent: mapDownloadPercent(18) });
             const fallbackArgs = buildYtDlpFallbackArgs(args);
@@ -7624,7 +7742,29 @@ const convertSingle = async (payload = {}) => {
             logs = retryErr?.logs || logs || baseLogs;
           }
         }
+        if (!downloadResult && shouldRetryWithFallbackArgs) {
+          try {
+            emitProgress({ stage: "downloading", message: "Mencoba format universal", percent: mapDownloadPercent(19) });
+            const universalArgs = buildYtDlpFallbackArgs(args);
+            for (let i = 0; i < universalArgs.length - 1; i++) {
+              if (universalArgs[i] === "-f") {
+                universalArgs.splice(i, 2);
+                break;
+              }
+            }
+            downloadResult = await runYtDlpDownload({ args: universalArgs, id, onProgress: handleDownloadProgress });
+            logs = downloadResult.logs || logs || baseLogs;
+          } catch (retryErr) {
+            logs = retryErr?.logs || logs || baseLogs;
+          }
+        }
         if (!downloadResult) {
+          if (isVideoFormat) {
+            if (coverPath) try { await fsp.unlink(coverPath); } catch { }
+            const videoError = new Error(err.message || "Gagal mengunduh video");
+            videoError.logs = [logs, baseLogs].filter(Boolean).join("\n").slice(-8000);
+            throw videoError;
+          }
           try {
             emitProgress({ stage: "downloading", message: "Downloader cadangan", percent: mapDownloadPercent(20) });
             downloadResult = await runPythonDownload({ url, id, baseLogs });
@@ -8514,6 +8654,21 @@ app.get("/api/history/:id", async (req, res) => {
   return res.json({ ok: true, entry });
 });
 
+app.delete("/api/history/:id", async (req, res) => {
+  const user = await requireUserSession(req, res);
+  if (!user) return;
+  const deleted = await deleteHistoryEntry(user.id, req.params.id);
+  if (!deleted) return res.status(404).json({ ok: false, error: "Riwayat tidak ditemukan" });
+  return res.json({ ok: true, deleted: true, id: req.params.id });
+});
+
+app.delete("/api/history", async (req, res) => {
+  const user = await requireUserSession(req, res);
+  if (!user) return;
+  const deleted = await clearUserHistory(user.id);
+  return res.json({ ok: true, deleted });
+});
+
 app.post("/api/history/:id/redownload", async (req, res) => {
   const user = await requireUserSession(req, res);
   if (!user) return;
@@ -8635,10 +8790,150 @@ app.get("/api/turnstile-config", (req, res) => {
   });
 });
 
+
+const outputTtlMs = Math.max(5 * 60_000, Number(process.env.OUTPUT_TTL_MINUTES || 60) * 60_000);
+const converterJobs = new Map();
+const converterQueue = [];
+const converterCache = new Map();
+let converterActive = 0;
+const converterConcurrency = Math.max(1, Math.min(3, Number(process.env.CONVERTER_CONCURRENCY || 1)));
+
+const sanitizeJobPayloadForCache = (payload = {}) => ({
+  url: payload.url || payload.mediaUrl || payload.keyword || "",
+  format: payload.format || "mp3",
+  abr: payload.abr || payload.quality || "",
+  sampleRate: payload.sampleRate || payload.sr || "",
+  trim: payload.trim || null,
+  speedMode: payload.speedMode || "normal",
+  id3: payload.id3 || {},
+});
+
+const makeJobCacheKey = (payload = {}) => createHash("sha256").update(JSON.stringify(sanitizeJobPayloadForCache(payload))).digest("hex");
+const jobDownloadUrl = (jobId) => `/api/jobs/${encodeURIComponent(jobId)}/download`;
+
+const serializeConverterJob = (job = {}) => ({
+  ok: job.status !== "failed",
+  jobId: job.id,
+  status: job.status || "queued",
+  progress: job.progress || 0,
+  step: job.step || job.status || "queued",
+  message: job.message || "",
+  downloadUrl: job.downloadUrl || null,
+  filename: job.filename || null,
+  errorCategory: job.errorCategory || null,
+  error: job.error || null,
+  cached: Boolean(job.cached),
+});
+
+const pumpConverterQueue = () => {
+  while (converterActive < converterConcurrency && converterQueue.length) {
+    const jobId = converterQueue.shift();
+    const job = converterJobs.get(jobId);
+    if (!job || job.status !== "queued") continue;
+    converterActive += 1;
+    controlState.processing += 1;
+    controlState.waiting = converterQueue.length;
+    controlState.queueLength = converterQueue.length + converterActive;
+    job.status = "fetching";
+    job.step = "fetching";
+    job.progress = 5;
+    job.startedAt = Date.now();
+    job.logs.push("Job started");
+    Promise.resolve()
+      .then(async () => {
+        const result = await convertSingle({ ...job.payload, id: job.id }, (progress) => {
+          const percent = clampPercent(progress?.percent ?? job.progress);
+          job.progress = percent;
+          job.step = progress?.stage || job.step || "processing";
+          job.message = progress?.message || job.message || "Memproses";
+          job.logs.push(`[${new Date().toISOString()}] ${job.step}: ${job.message}`);
+        });
+        job.status = "completed";
+        job.step = "completed";
+        job.progress = 100;
+        job.message = "Selesai";
+        job.result = result;
+        job.filename = result?.fileName || result?.filename || null;
+        job.downloadUrl = jobDownloadUrl(job.id);
+        job.completedAt = Date.now();
+        converterCache.set(job.cacheKey, { jobId: job.id, fileName: job.filename, downloadUrl: job.downloadUrl, expiresAt: Date.now() + outputTtlMs });
+        conversionMetrics.success += 1;
+      })
+      .catch((err) => {
+        const wrapped = publicDownloadError(err);
+        job.status = "failed";
+        job.step = "failed";
+        job.progress = job.progress || 0;
+        job.errorCategory = wrapped.errorCategory || "UNKNOWN";
+        job.error = wrapped.message;
+        job.hint = wrapped.hint || null;
+        job.adminActionRequired = Boolean(wrapped.adminActionRequired);
+        job.logs.push((wrapped.logs || wrapped.stack || wrapped.message || "").slice(-8000));
+        conversionMetrics.errors += 1;
+        conversionMetrics.errorReasons[job.errorCategory] = (conversionMetrics.errorReasons[job.errorCategory] || 0) + 1;
+      })
+      .finally(() => {
+        converterActive = Math.max(0, converterActive - 1);
+        controlState.processing = Math.max(0, controlState.processing - 1);
+        controlState.waiting = converterQueue.length;
+        controlState.queueLength = converterQueue.length + converterActive;
+        pumpConverterQueue();
+      });
+  }
+};
+
+const enqueueConverterJob = (payload = {}) => {
+  const cacheKey = makeJobCacheKey(payload);
+  const cached = converterCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now() && cached.fileName && existsSync(join(JOBS_DIR, cached.fileName))) {
+    const job = {
+      id: cached.jobId || nanoid(10),
+      status: "completed",
+      progress: 100,
+      step: "completed",
+      message: "Mengambil dari cache",
+      filename: cached.fileName,
+      downloadUrl: cached.downloadUrl || jobDownloadUrl(cached.jobId),
+      cached: true,
+      logs: ["Cache hit"],
+      cacheKey,
+      createdAt: Date.now(),
+    };
+    converterJobs.set(job.id, job);
+    return job;
+  }
+  const id = nanoid(10);
+  const job = { id, payload, cacheKey, status: "queued", progress: 0, step: "queued", message: "Masuk antrean", logs: ["Queued"], createdAt: Date.now(), cached: false };
+  converterJobs.set(id, job);
+  converterQueue.push(id);
+  controlState.waiting = converterQueue.length;
+  controlState.queueLength = converterQueue.length + converterActive;
+  conversionMetrics.started += 1;
+  pumpConverterQueue();
+  return job;
+};
+
+setInterval(async () => {
+  const now = Date.now();
+  for (const [key, item] of converterCache) {
+    if (item.expiresAt <= now) converterCache.delete(key);
+  }
+  for (const [id, job] of converterJobs) {
+    if ((job.completedAt || job.createdAt || 0) && now - (job.completedAt || job.createdAt) > outputTtlMs) {
+      converterJobs.delete(id);
+    }
+  }
+}, 10 * 60_000).unref?.();
+
 app.post("/api/convert", async (req, res) => {
   const user = await resolveRequestUser(req);
   try {
     const payload = { ...(req.body || {}) };
+    if (payload.async === true || req.query?.mode === "job" || req.get("Prefer") === "respond-async") {
+      delete payload.async;
+      const job = enqueueConverterJob(payload);
+      return res.status(job.cached ? 200 : 202).json(serializeConverterJob(job));
+    }
     try {
       await verifyTurnstileToken(payload.captchaToken, req.ip);
     } catch (err) {
@@ -8691,6 +8986,72 @@ app.post("/api/convert", async (req, res) => {
     const status = /tidak valid|tidak dikenali/i.test(msg) ? 400 : 500;
     return res.status(status).json({ error: msg, logs: e?.logs });
   }
+});
+
+
+app.post("/api/fetch", async (req, res) => {
+  try {
+    const metadata = await fetchVideoInfo({ url: req.body?.url || req.body?.mediaUrl, keyword: req.body?.keyword, preferLang: req.body?.preferLang });
+    return res.json({ ok: true, metadata, status: "completed", progress: 100, step: "metadata" });
+  } catch (err) {
+    const wrapped = publicDownloadError(err);
+    return res.status(400).json({ ok: false, errorCategory: wrapped.errorCategory, message: wrapped.message, hint: wrapped.hint, adminActionRequired: wrapped.adminActionRequired });
+  }
+});
+
+app.get("/api/jobs/:id", (req, res) => {
+  const job = converterJobs.get(String(req.params.id || ""));
+  if (!job) return res.status(404).json({ ok: false, errorCategory: "UNKNOWN", message: "Job tidak ditemukan" });
+  return res.json(serializeConverterJob(job));
+});
+
+app.get("/api/jobs/:id/logs", (req, res) => {
+  const job = converterJobs.get(String(req.params.id || ""));
+  if (!job) return res.status(404).json({ ok: false, errorCategory: "UNKNOWN", message: "Job tidak ditemukan" });
+  return res.json({ ok: true, jobId: job.id, logs: (job.logs || []).slice(-200) });
+});
+
+app.get("/api/jobs/:id/download", (req, res) => {
+  const job = converterJobs.get(String(req.params.id || ""));
+  if (!job || job.status !== "completed" || !job.filename) return res.status(404).json({ ok: false, errorCategory: "UNKNOWN", message: "File belum tersedia" });
+  const fullPath = pathResolve(JOBS_DIR, job.filename);
+  if (!fullPath.startsWith(pathResolve(JOBS_DIR)) || !existsSync(fullPath)) return res.status(404).json({ ok: false, errorCategory: "UNKNOWN", message: "File tidak ditemukan" });
+  return res.download(fullPath, job.filename);
+});
+
+app.delete("/api/jobs/:id", (req, res) => {
+  const id = String(req.params.id || "");
+  const existed = converterJobs.delete(id);
+  return res.json({ ok: true, jobId: id, deleted: existed });
+});
+
+app.get("/api/admin/queue/status", (req, res) => {
+  if (!isAdminBearerValid(req)) return res.status(401).json({ ok: false, error: "unauthorized" });
+  const jobs = Array.from(converterJobs.values());
+  const completed = jobs.filter((j) => j.status === "completed");
+  const failed = jobs.filter((j) => j.status === "failed");
+  const durations = completed.map((j) => (j.completedAt || Date.now()) - (j.startedAt || j.createdAt || Date.now())).filter(Number.isFinite);
+  return res.json({ ok: true, queued: converterQueue.length, processing: converterActive, success: completed.length, failed: failed.length, avgProcessingMs: durations.length ? Math.round(durations.reduce((a, b) => a + b, 0) / durations.length) : 0, fastestMs: durations.length ? Math.min(...durations) : 0, slowestMs: durations.length ? Math.max(...durations) : 0, lastErrors: failed.slice(-10).map((j) => ({ jobId: j.id, errorCategory: j.errorCategory, error: j.error })) });
+});
+
+app.post("/api/admin/queue/clear", (req, res) => {
+  if (!isAdminBearerValid(req)) return res.status(401).json({ ok: false, error: "unauthorized" });
+  converterQueue.length = 0;
+  controlState.waiting = 0;
+  controlState.queueLength = converterActive;
+  return res.json({ ok: true, queue: { queued: 0, processing: converterActive } });
+});
+
+app.post("/api/admin/converter/disable", (req, res) => {
+  if (!isAdminBearerValid(req)) return res.status(401).json({ ok: false, error: "unauthorized" });
+  controlState.convertEnabled = false;
+  return res.json({ ok: true, convertEnabled: false });
+});
+
+app.post("/api/admin/converter/enable", (req, res) => {
+  if (!isAdminBearerValid(req)) return res.status(401).json({ ok: false, error: "unauthorized" });
+  controlState.convertEnabled = true;
+  return res.json({ ok: true, convertEnabled: true });
 });
 
 app.get("/api/progress/:id", (req, res) => {
@@ -9375,9 +9736,9 @@ app.post("/api/convert-playlist", async (req, res) => {
 });
 
 // ==== Admin: upload cookies.txt (Authorization: Bearer <token>) ====
-const BEARER = process.env.ADMIN_BEARER || "";
-const ADMIN_USER_HASH = process.env.ADMIN_USER_HASH || "";
-const ADMIN_PASS_HASH = process.env.ADMIN_PASS_HASH || "";
+const BEARER = process.env.ADMIN_BEARER || process.env.ADMIN_TOKEN || "";
+const ADMIN_USER_HASH = process.env.ADMIN_USER_HASH || (process.env.ADMIN_USERNAME ? createHash("sha256").update(String(process.env.ADMIN_USERNAME), "utf8").digest("hex") : "");
+const ADMIN_PASS_HASH = process.env.ADMIN_PASS_HASH || (process.env.ADMIN_PASSWORD ? createHash("sha256").update(String(process.env.ADMIN_PASSWORD), "utf8").digest("hex") : "");
 const ADMIN_ENABLED = Boolean(BEARER && ADMIN_USER_HASH && ADMIN_PASS_HASH);
 
 const hashText = (value) => createHash("sha256").update(String(value ?? ""), "utf8").digest("hex");
@@ -9416,6 +9777,72 @@ app.post("/admin/login", (req, res) => {
   }
 });
 
+
+const sanitizedCookiesStatus = async () => {
+  const status = await getCookiesStatus();
+  return {
+    exists: Boolean(status.exists),
+    sizeBytes: Number(status.sizeBytes || status.bytes || 0),
+    updatedAt: status.updatedAt || status.uploadedAt || null,
+    storage: status.storage || status.backend || "volume",
+    health: status.health || (status.exists ? "unknown" : "missing"),
+    lastTestAt: status.lastTestAt || null,
+    lastErrorCategory: status.lastErrorCategory || null,
+  };
+};
+
+const testAdminCookies = async () => {
+  const status = await getCookiesStatus();
+  if (!status.exists || !existsSync(COOKIES_PATH)) {
+    await updateCookiesHealth({ health: "missing", lastErrorCategory: "LOGIN_REQUIRED" });
+    return { ok: false, errorCategory: "LOGIN_REQUIRED", message: "Cookies belum tersedia" };
+  }
+  const testUrl = process.env.COOKIES_TEST_URL || "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+  const args = ["--dump-single-json", "--skip-download", "--no-playlist", "--cookies", COOKIES_PATH, ...getYtDlpJsRuntimeArgs()];
+  pushYoutubeExtractorArgs(args);
+  args.push(testUrl);
+  try {
+    await runYtDlpJson(args, { label: "cookies-test" });
+    const health = await updateCookiesHealth({ health: "valid", lastErrorCategory: null });
+    return { ok: true, ...(await sanitizedCookiesStatus()), ...health };
+  } catch (err) {
+    const errorCategory = categorizeYtDlpError(err?.logs || err?.message || "");
+    const health = await updateCookiesHealth({ health: ["BOT_CHECK", "LOGIN_REQUIRED", "AGE_RESTRICTED"].includes(errorCategory) ? "expired" : "error", lastErrorCategory: errorCategory });
+    return { ok: false, errorCategory, message: "Cookies test gagal", ...(await sanitizedCookiesStatus()), ...health };
+  }
+};
+
+app.post("/api/admin/cookies/upload", express.text({ type: "*/*", limit: "1mb" }), async (req, res) => {
+  try {
+    if (!isAdminBearerValid(req)) return res.status(401).json({ ok: false, error: "unauthorized" });
+    const filename = req.get("x-file-name") || "cookies.txt";
+    const saved = await saveCookies(req.body, { filename });
+    res.setHeader("Cache-Control", "no-store, no-cache, must-revalidate, private");
+    return res.json({ ok: true, exists: true, sizeBytes: saved.sizeBytes || saved.bytes, updatedAt: saved.updatedAt || saved.uploadedAt, storage: saved.storage || "volume", health: saved.health || "unknown" });
+  } catch (err) {
+    const status = String(err?.message || "").startsWith("cookies_") ? 400 : 500;
+    return res.status(status).json({ ok: false, errorCategory: "UNKNOWN", message: err?.message || "cookies_save_failed" });
+  }
+});
+
+app.get("/api/admin/cookies/status", async (req, res) => {
+  if (!isAdminBearerValid(req)) return res.status(401).json({ ok: false, error: "unauthorized" });
+  res.setHeader("Cache-Control", "no-store, no-cache, must-revalidate, private");
+  return res.json({ ok: true, ...(await sanitizedCookiesStatus()) });
+});
+
+app.post("/api/admin/cookies/test", async (req, res) => {
+  if (!isAdminBearerValid(req)) return res.status(401).json({ ok: false, error: "unauthorized" });
+  const result = await testAdminCookies();
+  return res.status(result.ok ? 200 : 400).json(result);
+});
+
+app.delete("/api/admin/cookies", async (req, res) => {
+  if (!isAdminBearerValid(req)) return res.status(401).json({ ok: false, error: "unauthorized" });
+  await deleteCookies();
+  return res.json({ ok: true, ...(await sanitizedCookiesStatus()) });
+});
+
 app.post("/admin/upload-cookies", express.text({ type: "*/*", limit: "1mb" }), async (req, res) => {
   try {
     if (!ADMIN_ENABLED) return res.status(503).json({ error: "admin_disabled" });
@@ -9443,7 +9870,7 @@ app.post("/admin/upload-cookies", express.text({ type: "*/*", limit: "1mb" }), a
       }
     }
     res.setHeader("Cache-Control", "no-store, no-cache, must-revalidate, private");
-    return res.json({ ok: true, path: COOKIES_PATH, ...saved, workerSynced });
+    return res.json({ ok: true, exists: true, sizeBytes: saved.sizeBytes || saved.bytes, updatedAt: saved.updatedAt || saved.uploadedAt, storage: saved.storage || "volume", health: saved.health || "unknown", workerSynced });
   } catch (err) {
     const status = ["cookies_invalid_body", "cookies_empty", "cookies_too_large"].includes(err?.message) ? 400 : 500;
     return res.status(status).json({ error: err?.message || "cookies_save_failed" });
@@ -9454,7 +9881,7 @@ app.get("/admin/cookies-status", async (_req, res) => {
   try {
     res.setHeader("Cache-Control", "no-store, no-cache, must-revalidate, private");
     if (!ADMIN_ENABLED) return res.json({ exists: false, disabled: true });
-    const status = await getCookiesStatus();
+    const status = await sanitizedCookiesStatus();
     return res.json(status);
   } catch (err) {
     console.error("[cookie-store] status failed", err);
@@ -9463,19 +9890,9 @@ app.get("/admin/cookies-status", async (_req, res) => {
 });
 
 app.get("/admin/download-cookies", async (req, res) => {
-  try {
-    if (!ADMIN_ENABLED) return res.status(503).json({ error: "admin_disabled" });
-    if (!isAdminBearerValid(req)) return res.status(401).json({ error: "unauthorized" });
-    const record = await readCookies();
-    if (!record) return res.status(404).json({ error: "not_found" });
-    await syncCookiesToLocal();
-    res.setHeader("Cache-Control", "no-store, no-cache, must-revalidate, private");
-    res.setHeader("Content-Type", "text/plain; charset=utf-8");
-    return res.send(record.content);
-  } catch (err) {
-    console.error("[cookie-store] download failed", err);
-    return res.status(503).json({ error: "cookies_store_unavailable" });
-  }
+  if (!ADMIN_ENABLED) return res.status(503).json({ error: "admin_disabled" });
+  if (!isAdminBearerValid(req)) return res.status(401).json({ error: "unauthorized" });
+  return res.status(410).json({ ok: false, error: "cookies_download_disabled", message: "Cookie content is never exposed by the API. Use status/test endpoints instead." });
 });
 
 // User's explicitly requested dynamic TURN endpoint
@@ -10341,6 +10758,27 @@ app.get("/api/admin/session-replay/:socketId", (req, res) => {
   });
 });
 
+
+app.get("/api/admin/tools/status", async (req, res) => {
+  if (!isAdminBearerValid(req)) return res.status(401).json({ ok: false, error: "unauthorized" });
+  const [tools, cookies] = await Promise.all([
+    resolveToolVersions().catch((err) => ({ error: err?.message || "tools_unavailable" })),
+    sanitizedCookiesStatus().catch(() => ({ exists: false, health: "error" })),
+  ]);
+  let outputFiles = 0;
+  let outputBytes = 0;
+  try {
+    const entries = await fsp.readdir(JOBS_DIR, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isFile()) continue;
+      outputFiles += 1;
+      const stat = await fsp.stat(join(JOBS_DIR, entry.name)).catch(() => null);
+      outputBytes += stat?.size || 0;
+    }
+  } catch {}
+  return res.json({ ok: true, tools, cookies, system: { uptimeSeconds: Math.floor(process.uptime()), memory: process.memoryUsage?.() || {}, outputFiles, outputBytes, jobsDir: "runtime" } });
+});
+
 app.get("/api/admin/stats", async (req, res) => {
   if (!isAdminBearerValid(req)) return res.status(401).json({ ok: false, error: "unauthorized" });
   let persistedTickets = [];
@@ -10420,6 +10858,7 @@ app.get("/api/admin/stats", async (req, res) => {
   });
   const successRate = conversionMetrics.started ? (conversionMetrics.success / conversionMetrics.started) * 100 : 0;
   const predictedNextHourUsers = Number(((conversionMetrics.entered / Math.max(1, process.uptime() / 3600))).toFixed(0));
+  const cookieHealth = await sanitizedCookiesStatus().catch(() => ({ exists: false, health: "error" }));
   const smartInsights = [];
   if (successRate < 40 && conversionMetrics.started >= 5) smartInsights.push("Conversion success rendah dibanding jumlah start.");
   if (conversionMetrics.errors >= 3) smartInsights.push("Error conversion meningkat, cek error tracking.");
@@ -10485,7 +10924,11 @@ app.get("/api/admin/stats", async (req, res) => {
       length: controlState.queueLength,
       processing: controlState.processing,
       waiting: controlState.waiting,
+      queued: converterQueue.length,
+      success: Array.from(converterJobs.values()).filter((j) => j.status === "completed").length,
+      failed: Array.from(converterJobs.values()).filter((j) => j.status === "failed").length,
     },
+    cookieHealth,
     health: {
       cpuPercentEstimate: cpuLoadEstimate,
       avgResponseMs: Number(avgResponseMs.toFixed(2)),
@@ -11317,16 +11760,20 @@ const server = httpServer.listen(PORT, HOST, () => {
   
   // 💥 Auto Maintenance: Keep yt-dlp up-to-date
   const autoUpdate = () => {
+    if (/^(0|false|off|no)$/i.test(String(process.env.YTDLP_AUTO_UPDATE || "true"))) return;
     console.log("[Auto-Maintenance] Checking for yt-dlp updates...");
-    const updateProc = spawn("yt-dlp", ["-U"]);
+    const updateProc = spawn("yt-dlp", ["-U"], { stdio: ["ignore", "ignore", "pipe"] });
+    updateProc.on("error", (err) => {
+      console.warn(`[Auto-Maintenance] yt-dlp update skipped: ${err?.code || err?.message || "unavailable"}`);
+    });
     updateProc.on('close', (code) => {
         console.log(`[Auto-Maintenance] yt-dlp update finished with code ${code}`);
     });
   };
   
-  // Run once immediately on startup, then every 24 hours
-  setTimeout(autoUpdate, 5000); 
-  setInterval(autoUpdate, 24 * 60 * 60 * 1000);
+  // Run once after startup, then every 24 hours. Missing yt-dlp must not crash Railway.
+  setTimeout(autoUpdate, 5000).unref?.();
+  setInterval(autoUpdate, 24 * 60 * 60 * 1000).unref?.();
 });
 
 export {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "start": "node index.js",
     "migrate:xp": "node scripts/migrate_xp_events.js",
-    "sync:stickers": "node scripts/sync_stickers_firestore.mjs"
+    "sync:stickers": "node scripts/sync_stickers_firestore.mjs",
+    "dev": "node --watch index.js"
   },
   "dependencies": {
     "axios": "^1.13.6",

--- a/public-ui/admin-cookies.html
+++ b/public-ui/admin-cookies.html
@@ -8,32 +8,30 @@
   <script src="/tailwind-ui-bridge.js" defer></script>
   <style>
     body {
-      background:
-        radial-gradient(circle at top left, rgba(99,102,241,.24), transparent 32rem),
-        radial-gradient(circle at top right, rgba(14,165,233,.16), transparent 28rem),
-        radial-gradient(circle at bottom, rgba(16,185,129,.10), transparent 34rem),
-        #020617;
+      background: #020617;
     }
     @keyframes fadeIn { from {opacity:0; transform:translateY(8px);} to {opacity:1; transform:none;} }
     .fade-in { animation: fadeIn .35s ease both; }
     .premium-card {
       position: relative;
       overflow: hidden;
-      box-shadow: 0 24px 70px rgba(15, 23, 42, .38);
+      box-shadow: none;
     }
-    .premium-card::before {
-      content: "";
-      position: absolute;
-      inset: 0;
-      pointer-events: none;
-      background: linear-gradient(135deg, rgba(255,255,255,.10), transparent 38%, rgba(99,102,241,.08));
-    }
+    .premium-card::before { content: none; display: none; }
     .tw-enhanced .tw-pressed { transform: translateY(1px) scale(.99); }
+    button, a, input::file-selector-button {
+      background-image: none !important;
+      box-shadow: none !important;
+      backdrop-filter: none !important;
+      -webkit-backdrop-filter: none !important;
+      filter: none !important;
+      transition: background-color .18s ease, border-color .18s ease, color .18s ease;
+    }
   </style>
 </head>
 <body class="min-h-screen bg-slate-950 text-slate-100">
   <main class="max-w-3xl mx-auto p-4 md:p-6 space-y-4">
-    <header class="premium-card rounded-3xl border border-indigo-500/20 bg-gradient-to-br from-slate-900 via-slate-900 to-indigo-950/60 p-5 flex flex-wrap items-center justify-between gap-3 fade-in">
+    <header class="premium-card rounded-3xl border border-indigo-500/20 bg-slate-900 p-5 flex flex-wrap items-center justify-between gap-3 fade-in">
       <div>
         <h1 class="text-xl md:text-2xl font-extrabold">🍪 Admin Cookies Manager</h1>
         <p class="text-slate-400 text-sm">Upload dan monitor cookies.txt dengan UI yang lebih rapi.</p>
@@ -44,7 +42,7 @@
       </div>
     </header>
 
-    <section id="loginView" class="premium-card rounded-3xl border border-slate-800/80 bg-slate-900/90 p-5 space-y-3 fade-in">
+    <section id="loginView" class="premium-card rounded-3xl border border-slate-800/80 bg-slate-900 p-5 space-y-3 fade-in">
       <div class="font-bold">Login Admin</div>
       <div class="grid sm:grid-cols-2 gap-2">
         <input id="username" class="px-3 py-2 rounded-lg bg-slate-950 border border-slate-700" placeholder="Username" autocomplete="username">
@@ -56,7 +54,7 @@
       <div id="loginToast" class="text-sm"></div>
     </section>
 
-    <section id="uploadView" class="hidden premium-card rounded-3xl border border-emerald-500/20 bg-slate-900/90 p-5 space-y-4 fade-in">
+    <section id="uploadView" class="hidden premium-card rounded-3xl border border-emerald-500/20 bg-slate-900 p-5 space-y-4 fade-in">
       <div class="flex items-center justify-between gap-2">
         <div>
           <div class="font-bold">Upload cookies.txt</div>
@@ -65,12 +63,12 @@
         <button id="logoutBtn" class="px-3 py-2 rounded-lg bg-slate-700 hover:bg-slate-600 text-sm">Logout</button>
       </div>
 
-      <div class="rounded-2xl border border-slate-700/80 bg-slate-950/80 p-4 text-sm shadow-inner">
+      <div class="rounded-2xl border border-slate-700/80 bg-slate-950 p-4 text-sm ">
         <div class="text-slate-400">Status Cookies</div>
         <div id="statusBox" class="font-medium mt-1">Memuat...</div>
       </div>
 
-      <input id="file" type="file" accept=".txt,text/plain" class="block w-full rounded-2xl border border-dashed border-slate-700 bg-slate-950/60 p-3 text-sm file:mr-4 file:py-2 file:px-3 file:rounded-lg file:border-0 file:bg-indigo-600 file:text-slate-100 hover:file:bg-indigo-500" />
+      <input id="file" type="file" accept=".txt,text/plain" class="block w-full rounded-2xl border border-dashed border-slate-700 bg-slate-950 p-3 text-sm file:mr-4 file:py-2 file:px-3 file:rounded-lg file:border-0 file:bg-indigo-600 file:text-slate-100 hover:file:bg-indigo-500" />
       <div class="flex gap-2 flex-wrap">
         <button id="uploadBtn" class="px-4 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-500 font-semibold">Upload</button>
         <button id="refreshStatusBtn" class="px-4 py-2 rounded-lg bg-slate-700 hover:bg-slate-600">Refresh</button>
@@ -96,10 +94,16 @@ async function refreshStatus(){
   const requestId = ++statusRequestId;
   statusRequest?.abort();
   statusRequest = new AbortController();
+  const token = getToken();
+  if (!token) {
+    $('statusBox').innerHTML = '<span class="text-amber-300">Login admin dulu untuk melihat status cookies server.</span>';
+    return;
+  }
   try {
-    const res = await fetch('/admin/cookies-status?t=' + Date.now(), {
+    const res = await fetch('/api/admin/cookies/status?t=' + Date.now(), {
       cache: 'no-store',
       signal: statusRequest.signal,
+      headers: { Authorization: 'Bearer ' + token },
     });
     const data = await res.json().catch(() => ({}));
     if (requestId !== statusRequestId) return;
@@ -112,9 +116,9 @@ async function refreshStatus(){
       $('statusBox').innerHTML = '<span class="text-amber-300">Belum ada cookies.txt di penyimpanan persisten.</span>';
       return;
     }
-    const uploadedAt = data.uploadedAt ? fmt.format(new Date(data.uploadedAt)) : 'waktu tidak tersedia';
-    const backend = data.backend === 'firestore' ? 'penyimpanan cloud' : 'penyimpanan server';
-    $('statusBox').innerHTML = `<span class="text-emerald-300">Tersimpan permanen</span> • ${Number(data.bytes || 0).toLocaleString()} bytes • ${uploadedAt} • ${backend}`;
+    const uploadedAt = data.updatedAt ? fmt.format(new Date(data.updatedAt)) : 'waktu tidak tersedia';
+    const storage = data.storage || 'volume';
+    $('statusBox').innerHTML = `<span class="text-emerald-300">Tersimpan aman</span> • ${Number(data.sizeBytes || 0).toLocaleString()} bytes • ${uploadedAt} • ${storage} • health: ${data.health || 'unknown'}`;
   } catch (error) {
     if (error.name === 'AbortError') return;
     toast('uploadToast', `Gagal memperbarui status: ${error.message || 'unknown error'}`, false);
@@ -146,10 +150,10 @@ $('uploadBtn').addEventListener('click', async () => {
     const file = $('file').files?.[0];
     if (!file) throw new Error('Pilih file cookies.txt dulu');
     const body = await file.text();
-    const res = await fetch('/admin/upload-cookies', { method:'POST', headers:{ 'Content-Type':'text/plain; charset=utf-8', Authorization:'Bearer ' + token }, body });
+    const res = await fetch('/api/admin/cookies/upload', { method:'POST', headers:{ 'Content-Type':'text/plain; charset=utf-8', 'x-file-name': file.name || 'cookies.txt', Authorization:'Bearer ' + token }, body });
     const data = await res.json().catch(() => ({}));
     if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
-    toast('uploadToast', `Upload tersimpan permanen (${Number(data.bytes || 0).toLocaleString()} bytes).`);
+    toast('uploadToast', `Upload tersimpan aman (${Number(data.sizeBytes || data.bytes || 0).toLocaleString()} bytes).`);
     await refreshStatus();
   } catch (e) { toast('uploadToast', e.message || 'Upload gagal', false); }
 });

--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -140,6 +140,27 @@
       font-display: swap;
     }
 
+
+    /* Global font simplification: Helvetica everywhere, while preserving icon fonts. */
+    :root {
+      --ytconv-font-sans: Helvetica, Arial, sans-serif;
+    }
+
+    html,
+    body,
+    :where(button, input, select, textarea, .btn, .form-control, .form-select, .dropdown-menu, .modal, .offcanvas, .toast, .accordion, .card) {
+      font-family: var(--ytconv-font-sans) !important;
+    }
+
+    :where(code, kbd, pre, samp, .font-monospace, .badge-mono) {
+      font-family: var(--ytconv-font-sans) !important;
+      letter-spacing: 0 !important;
+    }
+
+    :where(.bi, [class^="bi-"], [class*=" bi-"]) {
+      font-family: "bootstrap-icons" !important;
+    }
+
     .hover-scale {
       transition: transform .2s ease, box-shadow .2s ease;
     }
@@ -1674,6 +1695,7 @@
       transform: scale(0.95) translateY(0);
       box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
     }
+
   </style>
   <style>
     :root {
@@ -2174,6 +2196,7 @@
       filter: none !important;
       backdrop-filter: none !important;
       -webkit-backdrop-filter: none !important;
+      filter: none !important;
       border-bottom: 1px solid rgba(148, 163, 184, 0.18);
     }
 
@@ -2216,6 +2239,7 @@
       .app-header-lite .container { gap: .5rem !important; }
       .app-header-lite .btn,
       .app-header-lite .app-nav-btn { box-shadow: none !important; transition: none !important; }
+
       .cute-clock { padding: .35rem .65rem !important; letter-spacing: 0 !important; }
       .forum-google-login-btn { width: calc(100vw - 2rem); padding-left: 1rem !important; padding-right: 1rem !important; }
       .forum-google-login-btn img { flex: 0 0 auto; }
@@ -3538,8 +3562,9 @@
       flex-direction: column;
       align-items: flex-end;
       gap: .5rem;
-      transition: transform .2s ease;
+      transition: none;
       max-width: min(420px, 92vw);
+      contain: layout paint;
     }
 
     .share-app-buttons {
@@ -3632,14 +3657,18 @@
       border: 0;
       border-radius: 999px;
       padding: .55rem .9rem .55rem .6rem;
-      background: linear-gradient(135deg, color-mix(in srgb, var(--skin-primary) 92%, transparent), color-mix(in srgb, var(--skin-secondary) 90%, transparent));
+      background: #2563eb;
       color: #fff;
-      font-weight: 600;
-      letter-spacing: .06em;
+      font-weight: 700;
+      letter-spacing: .04em;
       text-transform: uppercase;
-      box-shadow: 0 18px 40px rgba(15, 23, 42, .35);
+      box-shadow: none;
       cursor: pointer;
-      touch-action: none;
+      touch-action: manipulation;
+      max-width: max-content;
+      overflow: hidden;
+      contain: layout paint;
+      transition: background-color .16s ease, border-color .16s ease, color .16s ease;
     }
 
     .assistant-toggle:focus-visible {
@@ -3654,8 +3683,8 @@
       width: 2.45rem;
       height: 2.45rem;
       border-radius: 50%;
-      background: rgba(255, 255, 255, .18);
-      box-shadow: inset 0 0 0 1px rgba(255, 255, 255, .22);
+      background: rgba(255, 255, 255, .14);
+      box-shadow: none;
       font-size: 1.2rem;
     }
 
@@ -3681,7 +3710,7 @@
     .assistant-toggle.has-update .pulse {
       opacity: 1;
       transform: scale(1);
-      animation: assistantPulse 1.4s ease-out infinite;
+      animation: none;
     }
 
     @keyframes assistantPulse {
@@ -3715,7 +3744,7 @@
       overflow: hidden;
       background: var(--bs-body-bg);
       border: 1px solid color-mix(in srgb, var(--bs-border-color) 70%, transparent);
-      box-shadow: 0 28px 56px rgba(15, 23, 42, .45);
+      box-shadow: none;
       display: flex;
       flex-direction: column;
       transform-origin: bottom right;
@@ -3728,7 +3757,7 @@
       align-items: center;
       justify-content: space-between;
       gap: .5rem;
-      background: linear-gradient(135deg, rgba(13, 110, 253, .16), rgba(111, 66, 193, .16));
+      background: color-mix(in srgb, var(--bs-primary) 12%, var(--bs-body-bg));
       border-bottom: 1px solid color-mix(in srgb, var(--bs-border-color) 80%, transparent);
       cursor: grab;
       touch-action: none;
@@ -5260,6 +5289,206 @@
       gap: 6px;
       align-items: center;
     }
+
+
+    /* No-glass UI pass: mobile + desktop use solid surfaces and no expensive shadows/blurs. */
+    body:not(.keep-rich-shadows),
+    body:not(.keep-rich-shadows) :where(*) {
+      --bs-box-shadow: none;
+      --bs-box-shadow-sm: none;
+      --bs-box-shadow-lg: none;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      backdrop-filter: none !important;
+      -webkit-backdrop-filter: none !important;
+      filter: none !important;
+    }
+
+    body:not(.keep-rich-shadows) :where(.glass, .card, .modal-content, .offcanvas, .dropdown-menu, .accordion-item, .list-group-item, .history-item, .modern-card, .feature-card, .status-card, .history-card) {
+      background: color-mix(in srgb, var(--bs-body-bg) 92%, var(--bs-tertiary-bg) 8%) !important;
+      border-color: color-mix(in srgb, var(--bs-border-color) 86%, transparent) !important;
+    }
+
+    body:not(.keep-rich-shadows) :where(.glass, .card:hover) {
+      transform: none !important;
+      filter: none !important;
+    }
+
+    body:not(.keep-rich-shadows) :where(.btn, .app-nav-btn, .modern-nav-item, .footer-pill, .assistant-panel button) {
+      transition: background-color .16s ease, border-color .16s ease, color .16s ease !important;
+      will-change: auto !important;
+    }
+
+    body:not(.keep-rich-shadows) :where(.btn:hover, .app-nav-btn:hover, .modern-nav-item:hover, .footer-pill:hover, .assistant-panel button:hover) {
+      transform: translateY(-1px) !important;
+      filter: none !important;
+    }
+
+    body:not(.keep-rich-shadows) :where(.btn:active, .app-nav-btn:active, .modern-nav-item:active, .footer-pill:active, .assistant-panel button:active) {
+      transform: translateY(1px) !important;
+    }
+
+    body:not(.keep-rich-shadows) :where(.assistant-fab, .assistant-toggle, .assistant-fab button) {
+      transition: background-color .16s ease, border-color .16s ease, color .16s ease !important;
+      transform: none !important;
+      will-change: auto !important;
+    }
+
+    body:not(.keep-rich-shadows) :where(.assistant-toggle:hover, .assistant-fab button:hover, .assistant-toggle:active, .assistant-fab button:active) {
+      transform: none !important;
+      filter: none !important;
+    }
+
+    body:not(.keep-rich-shadows) :where(.btn, .app-nav-btn, .modern-nav-item, .footer-pill, .assistant-toggle, button, a.btn, [class*="bg-gradient"]) {
+      background-image: none !important;
+      box-shadow: none !important;
+      backdrop-filter: none !important;
+      -webkit-backdrop-filter: none !important;
+      filter: none !important;
+    }
+
+    body:not(.keep-rich-shadows) :where(.btn-primary, .assistant-toggle) {
+      background-color: #2563eb !important;
+      border-color: #2563eb !important;
+      color: #fff !important;
+    }
+
+    body:not(.keep-rich-shadows) :where(.btn-outline-primary, .app-nav-btn, .modern-nav-item, .footer-pill) {
+      background-color: #1f2937 !important;
+      border-color: rgba(148, 163, 184, .45) !important;
+      color: #e5e7eb !important;
+    }
+
+    body:not(.keep-rich-shadows) :where(.assistant-toggle .icon, .assistant-toggle .pulse, .aero-footer, .app-footer, .footer-hero-card, .support-card, .official-partners, .security-strip) {
+      background-image: none !important;
+      box-shadow: none !important;
+      backdrop-filter: none !important;
+      -webkit-backdrop-filter: none !important;
+      filter: none !important;
+    }
+
+    body:not(.keep-rich-shadows) .assistant-toggle .icon {
+      background-color: rgba(255, 255, 255, .10) !important;
+      border: 1px solid rgba(255, 255, 255, .22) !important;
+    }
+
+    body:not(.keep-rich-shadows) .assistant-toggle:hover {
+      background-color: #1d4ed8 !important;
+      border-color: #1d4ed8 !important;
+    }
+
+    .btn-close {
+      opacity: 1 !important;
+      border-radius: 999px !important;
+      border: 1px solid var(--bs-border-color) !important;
+      background-color: var(--bs-tertiary-bg) !important;
+      background-size: .75rem .75rem !important;
+      box-shadow: none !important;
+    }
+
+    html[data-bs-theme='dark'] .btn-close {
+      filter: invert(1) grayscale(100%) brightness(180%) !important;
+      background-color: #334155 !important;
+      border-color: #64748b !important;
+    }
+
+    html[data-bs-theme='light'] .btn-close {
+      filter: none !important;
+      background-color: #e5e7eb !important;
+      border-color: #94a3b8 !important;
+    }
+
+    html[data-bs-theme='light'] body:not(.keep-rich-shadows) {
+      background: #f8fafc !important;
+      color: #0f172a !important;
+    }
+
+    html[data-bs-theme='light'] body:not(.keep-rich-shadows) :where(.card, .accordion-item, .modal-content, .offcanvas, .dropdown-menu, .list-group-item, .history-item, .modern-card, .feature-card, .status-card, .history-card) {
+      background: #ffffff !important;
+      border-color: #e2e8f0 !important;
+      color: #0f172a !important;
+    }
+
+    html[data-bs-theme='light'] body:not(.keep-rich-shadows) :where(.btn-outline-primary, .app-nav-btn, .modern-nav-item, .footer-pill) {
+      background-color: #ffffff !important;
+      border-color: #cbd5e1 !important;
+      color: #0f172a !important;
+    }
+
+    html[data-bs-theme='light'] body:not(.keep-rich-shadows) :where(.form-control, .form-select, textarea, input, select) {
+      background-color: #ffffff !important;
+      border-color: #cbd5e1 !important;
+      color: #0f172a !important;
+    }
+
+    body:not(.keep-rich-shadows) .assistant-fab {
+      align-items: flex-end !important;
+      gap: .65rem !important;
+      width: auto !important;
+      max-width: min(392px, calc(100vw - 1.5rem)) !important;
+    }
+
+    body:not(.keep-rich-shadows) .assistant-panel {
+      width: min(380px, calc(100vw - 1.5rem)) !important;
+      max-height: min(560px, calc(100vh - 7.5rem)) !important;
+      border-radius: 18px !important;
+      background: var(--bs-body-bg) !important;
+      border: 1px solid var(--bs-border-color) !important;
+      overflow: hidden !important;
+    }
+
+    body:not(.keep-rich-shadows) .assistant-panel header {
+      background: var(--bs-tertiary-bg) !important;
+      border-bottom: 1px solid var(--bs-border-color) !important;
+      cursor: grab;
+    }
+
+    body:not(.keep-rich-shadows) .assistant-panel footer {
+      background: var(--bs-tertiary-bg) !important;
+      border-top: 1px solid var(--bs-border-color) !important;
+      gap: .75rem;
+      flex-wrap: wrap;
+    }
+
+    body:not(.keep-rich-shadows) .assistant-panel .assistant-body,
+    body:not(.keep-rich-shadows) .assistant-panel .assistant-messages {
+      background: var(--bs-body-bg) !important;
+    }
+
+    body:not(.keep-rich-shadows) .assistant-panel .assistant-input {
+      display: grid !important;
+      grid-template-columns: minmax(0, 1fr) auto auto auto;
+      gap: .45rem !important;
+      align-items: center;
+    }
+
+    body:not(.keep-rich-shadows) .assistant-toggle {
+      align-self: flex-end !important;
+      width: auto !important;
+      min-width: 0 !important;
+      background-color: #2563eb !important;
+      border: 1px solid #3b82f6 !important;
+      border-radius: 999px !important;
+    }
+
+    @media (prefers-reduced-motion: no-preference) {
+      body:not(.keep-rich-shadows) #mainContent :where(*),
+      body:not(.keep-rich-shadows) footer :where(*) {
+        transition-duration: .22s !important;
+      }
+    }
+
+    #section-faq .accordion-body,
+    #section-faq .accordion-body :where(p, li, div, span),
+    #section-faq .text-secondary {
+      color: color-mix(in srgb, var(--bs-body-color) 88%, #93c5fd 12%) !important;
+      opacity: 1 !important;
+      visibility: visible !important;
+    }
+
+    #section-faq .accordion-collapse.show .accordion-body {
+      display: block !important;
+    }
   </style>
   <!-- Cropper.js -->
   <link rel="preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/cropperjs/1.5.13/cropper.min.css"
@@ -6048,11 +6277,9 @@
 
                 <div class="dropzone mb-3" id="dropzone">
                   <i class="bi bi-cloud-arrow-up fs-4 d-block mb-1"></i>
-                  <div id="dropzoneStatus" class="small text-secondary">Seret & lepas file <code>cookies.txt</code> ke
-                    sini (opsional) untuk bypass age-gate</div>
+                  <div id="dropzoneStatus" class="small text-secondary">Cookies dikelola oleh admin/server. Upload manual hanya untuk mode lokal/admin (opsional) untuk bypass age-gate</div>
                   <input type="file" id="cookieFile" accept=".txt" hidden>
-                  <div class="mt-2"><button class="btn btn-sm btn-outline-primary" id="pickCookie" type="button">Pilih
-                      cookies.txt</button></div>
+                  <div class="mt-2"><button class="btn btn-sm btn-outline-primary" id="pickCookie" type="button">Update Cookies</button></div>
                 </div>
 
                 <div class="d-grid d-sm-flex gap-2 align-items-center">
@@ -6810,12 +7037,12 @@
               <div class="accordion accordion-flush" id="accGeneral">
                 <div class="accordion-item">
                   <h2 class="accordion-header">
-                    <button class="accordion-button fw-semibold collapsed" type="button" data-bs-toggle="collapse"
-                      data-bs-target="#q-gen-1">
+                    <button class="accordion-button fw-semibold" type="button" data-bs-toggle="collapse"
+                      data-bs-target="#q-gen-1" aria-expanded="true">
                       <i class="bi bi-currency-dollar me-2 text-success"></i>Apakah layanan ini benar-benar gratis?
                     </button>
                   </h2>
-                  <div id="q-gen-1" class="accordion-collapse collapse" data-bs-parent="#accGeneral">
+                  <div id="q-gen-1" class="accordion-collapse collapse show" data-bs-parent="#accGeneral">
                     <div class="accordion-body text-secondary">
                       Ya, 100% gratis. Kami tidak memungut biaya berlangganan. Jika Anda ingin mendukung operasional
                       server, Anda bisa berdonasi melalui tab <strong>Saweria</strong>.
@@ -7553,6 +7780,71 @@
                 <div class="accordion-item">
                   <h2 class="accordion-header">
                     <button class="accordion-button fw-semibold collapsed" type="button" data-bs-toggle="collapse"
+                      data-bs-target="#q-tr-18">
+                      <i class="bi bi-music-note-list me-2 text-primary"></i>Kenapa muncul Requested format is not available?
+                    </button>
+                  </h2>
+                  <div id="q-tr-18" class="accordion-collapse collapse" data-bs-parent="#accTrouble">
+                    <div class="accordion-body text-secondary">
+                      Artinya format asli yang diminta YouTube sedang tidak tersedia untuk video itu. Sistem sekarang otomatis mencoba format audio kompatibel, mode HTTP, client alternatif, format universal, lalu helper Python sebelum menampilkan error final. Jika tetap gagal, biasanya video dibatasi umur, wilayah, login, atau membutuhkan cookies terbaru.
+                    </div>
+                  </div>
+                </div>
+                <div class="accordion-item">
+                  <h2 class="accordion-header">
+                    <button class="accordion-button fw-semibold collapsed" type="button" data-bs-toggle="collapse"
+                      data-bs-target="#q-tr-19">
+                      <i class="bi bi-cookie me-2 text-warning"></i>Kapan perlu upload cookies baru?
+                    </button>
+                  </h2>
+                  <div id="q-tr-19" class="accordion-collapse collapse" data-bs-parent="#accTrouble">
+                    <div class="accordion-body text-secondary">
+                      Upload cookies baru jika error menyebut login, age-restricted, bot check, HTTP 400/403, atau video hanya bisa diputar dari akun tertentu. Gunakan Admin Cookies, lalu coba convert ulang dengan MP3/M4A terlebih dahulu.
+                    </div>
+                  </div>
+                </div>
+                <div class="accordion-item">
+                  <h2 class="accordion-header">
+                    <button class="accordion-button fw-semibold collapsed" type="button" data-bs-toggle="collapse"
+                      data-bs-target="#q-tr-20">
+                      <i class="bi bi-clock-history me-2 text-danger"></i>Riwayat tidak bisa dihapus padahal sudah login?
+                    </button>
+                  </h2>
+                  <div id="q-tr-20" class="accordion-collapse collapse" data-bs-parent="#accTrouble">
+                    <div class="accordion-body text-secondary">
+                      Pastikan login Google sudah aktif, lalu refresh satu kali agar token akun tersinkron. Tombol hapus sekarang akan membersihkan riwayat perangkat terlebih dahulu dan mencoba menghapus catatan akun/server jika tersedia. Jika file cloud lama bukan milik akun login saat ini, riwayat tetap hilang dari daftar tanpa memblokir UI.
+                    </div>
+                  </div>
+                </div>
+                <div class="accordion-item">
+                  <h2 class="accordion-header">
+                    <button class="accordion-button fw-semibold collapsed" type="button" data-bs-toggle="collapse"
+                      data-bs-target="#q-tr-21">
+                      <i class="bi bi-robot me-2 text-primary"></i>AI Navigator bikin lag saat diarahkan kursor?
+                    </button>
+                  </h2>
+                  <div id="q-tr-21" class="accordion-collapse collapse" data-bs-parent="#accTrouble">
+                    <div class="accordion-body text-secondary">
+                      AI Navigator dibuat lebih ringan: hover tidak lagi memakai glow/scale besar, tombol tidak memakai glassmorphism, dan panel memakai surface solid. Kalau device masih berat, tutup panel AI saat convert panjang dan matikan tab/extension yang tidak perlu.
+                    </div>
+                  </div>
+                </div>
+                <div class="accordion-item">
+                  <h2 class="accordion-header">
+                    <button class="accordion-button fw-semibold collapsed" type="button" data-bs-toggle="collapse"
+                      data-bs-target="#q-tr-22">
+                      <i class="bi bi-sun me-2 text-warning"></i>Light mode terlalu pucat atau tombol sulit dibaca?
+                    </button>
+                  </h2>
+                  <div id="q-tr-22" class="accordion-collapse collapse" data-bs-parent="#accTrouble">
+                    <div class="accordion-body text-secondary">
+                      Light mode sekarang memakai kartu putih solid, border lebih jelas, tombol outline berwarna gelap, dan tombol tutup diberi background agar ikon X terlihat. Jika tampilan masih aneh, lakukan hard refresh (<kbd>Ctrl</kbd>+<kbd>F5</kbd>) supaya CSS lama tidak tersimpan di cache browser.
+                    </div>
+                  </div>
+                </div>
+                <div class="accordion-item">
+                  <h2 class="accordion-header">
+                    <button class="accordion-button fw-semibold collapsed" type="button" data-bs-toggle="collapse"
                       data-bs-target="#q-tr-17">
                       <i class="bi bi-life-preserver me-2 text-info"></i>Downloader helper gagal, apa yang harus saya kirim?
                     </button>
@@ -8234,8 +8526,7 @@
                 class="bi bi-box-arrow-right"></i> Keluar</button>
             <span class="badge text-bg-secondary ms-auto" id="adminStatus">Belum login</span>
           </div>
-          <div class="form-text mt-2" id="adminLoginHelp">Login diperlukan untuk mengunggah cookies.txt melalui
-            dropzone.</div>
+          <div class="form-text mt-2" id="adminLoginHelp">Cookies YouTube dikelola admin/server. Login admin hanya diperlukan untuk update manual.</div>
         </form>
 
         <hr class="my-4">
@@ -13164,7 +13455,7 @@
             navConverter: 'Converter',
             navExperience: 'Experience',
             navProfile: 'Profil',
-            'Login Google aktif. Cookies YouTube otomatis digunakan.': 'Login Google aktif. Cookies YouTube otomatis digunakan.',
+            'Login Google tidak dipakai untuk cookies YouTube. Cookies dikelola admin/server.': 'Login Google tidak dipakai untuk cookies YouTube. Cookies dikelola admin/server.',
             navAssistant: 'AI Navigator',
             sectionTitleConverter: 'Converter',
             sectionSubtitleConverter: 'Konversi video lebih cepat & stabil.',
@@ -13237,7 +13528,7 @@
             navConverter: 'Converter',
             navExperience: 'Experience',
             navProfile: 'Profile',
-            'Login Google aktif. Cookies YouTube otomatis digunakan.': 'Google login active. YouTube cookies are handled automatically.',
+            'Login Google tidak dipakai untuk cookies YouTube. Cookies dikelola admin/server.': 'Google login is not used for YouTube cookies. Cookies are managed by admin/server.',
             navAssistant: 'AI Navigator',
             sectionTitleConverter: 'Converter',
             sectionSubtitleConverter: 'Convert videos faster & more reliably.',
@@ -13314,7 +13605,7 @@
             navConverter: 'コンバーター',
             navExperience: '実績・XP',
             navProfile: 'プロフィール',
-            'Login Google aktif. Cookies YouTube otomatis digunakan.': 'Googleログイン有効。YouTube Cookieが自動的に使用されます。',
+            'Login Google tidak dipakai untuk cookies YouTube. Cookies dikelola admin/server.': 'GoogleログインはYouTube Cookieに使用されません。Cookieは管理者/サーバーで管理されます。',
             navAssistant: 'AIアシスタント',
             sectionTitleConverter: '動画変換',
             sectionSubtitleConverter: '高品質な音声変換ツール',
@@ -13383,7 +13674,7 @@
             navConverter: '변환기',
             navExperience: '경험',
             navProfile: '프로필',
-            'Login Google aktif. Cookies YouTube otomatis digunakan.': 'Google 로그인이 활성화되었습니다. YouTube 쿠키가 자동으로 사용됩니다.',
+            'Login Google tidak dipakai untuk cookies YouTube. Cookies dikelola admin/server.': 'Google 로그인은 YouTube 쿠키에 사용되지 않습니다. 쿠키는 관리자/서버에서 관리됩니다.',
             navAssistant: 'AI 어시스턴트',
             sectionTitleConverter: '비디오 변환',
             sectionSubtitleConverter: '고품질 오디오 변환 도구.',
@@ -13906,8 +14197,8 @@
           'Login Google belum dikonfigurasi. Tambahkan GOOGLE_CLIENT_ID di server.': {
             en: 'Google login is not configured yet. Add GOOGLE_CLIENT_ID on the server.',
           },
-          'Login Google aktif; cookies YouTube otomatis terhubung.': { en: 'Google login active; YouTube cookies are handled automatically.' },
-          'Login diperlukan untuk mengunggah cookies.txt melalui dropzone.': { en: 'Sign in is required to upload cookies.txt through the dropzone.' },
+          'Login Google aktif; cookies YouTube tetap dikelola server, bukan dari akun Google user.': { en: 'Google login active; YouTube cookies are handled automatically.' },
+          'Cookies YouTube dikelola admin/server. Login admin hanya diperlukan untuk update manual.': { en: 'Sign in is required to upload cookies.txt through the dropzone.' },
           'Script login Google diblokir. Izinkan accounts.google.com di browser Anda.': {
             en: 'The Google sign-in script was blocked. Allow accounts.google.com in your browser.',
           },
@@ -14339,6 +14630,15 @@
             method: 'POST',
             headers: buildAuthHeaders({ 'Content-Type': 'application/json', ...(options.headers || {}) }),
             body: JSON.stringify(body ?? {}),
+          });
+          return resolveJsonResponse(resp, options);
+        };
+
+
+        const deleteJson = async (path, options = {}) => {
+          const resp = await fetch(api(path), {
+            method: 'DELETE',
+            headers: buildAuthHeaders(options.headers || {}),
           });
           return resolveJsonResponse(resp, options);
         };
@@ -16774,9 +17074,9 @@
           }
           if (adminLoginHelp) {
             if (user) {
-              adminLoginHelp.textContent = translateMessage('Login Google aktif; cookies YouTube otomatis terhubung.');
+              adminLoginHelp.textContent = translateMessage('Login Google aktif; cookies YouTube tetap dikelola server, bukan dari akun Google user.');
             } else {
-              adminLoginHelp.textContent = translateMessage('Login diperlukan untuk mengunggah cookies.txt melalui dropzone.');
+              adminLoginHelp.textContent = translateMessage('Cookies YouTube dikelola admin/server. Login admin hanya diperlukan untuk update manual.');
             }
           }
           if (driveReadyStatus) {
@@ -20954,14 +21254,14 @@
             pickCookieBtn.classList.toggle('disabled', pickCookieBtn.disabled);
           }
           if (googleLinked) {
-            setDropzoneMessage('Login Google aktif. Cookies YouTube otomatis digunakan.', 'success');
+            setDropzoneMessage('Login Google tidak dipakai untuk cookies YouTube. Cookies dikelola admin/server.', 'success');
             return;
           }
           if (loggedIn) {
-            setDropzoneMessage('Login admin aktif. Siap mengunggah cookies.txt.', 'info');
+            setDropzoneMessage('Login admin aktif. Siap update cookies server.', 'info');
             return;
           }
-          setDropzoneMessage('Login admin diperlukan sebelum upload cookies.', 'info');
+          setDropzoneMessage('Cookies dikelola admin/server. Login admin diperlukan untuk update manual.', 'info');
         };
 
         const updateBackendBadge = () => {
@@ -22251,18 +22551,31 @@
           const item = list[idx];
           if (!item) return;
 
-          const confirmed = window.confirm('Hapus item riwayat ini? File cloud juga akan dihapus dari Cloudinary.');
+          const confirmed = window.confirm('Hapus item riwayat ini dari daftar? Jika file cloud milik akun ini masih ada, server juga akan mencoba menghapusnya.');
           if (!confirmed) return;
 
-          if (item.cloudUrl) {
+          const warnings = [];
+          const serverHistoryId = item.historyId || item.id || item.resultId || '';
+          if (serverHistoryId && state?.auth?.token) {
+            try {
+              await deleteJson(`/api/history/${encodeURIComponent(serverHistoryId)}`, {
+                fallbackMessage: 'Gagal menghapus riwayat akun',
+                logLabel: '/api/history/:id',
+              });
+            } catch (err) {
+              if (err?.status !== 404) warnings.push(err?.message || 'Riwayat akun belum terhapus di server');
+            }
+          }
+
+          if (item.cloudUrl && state?.auth?.token) {
             try {
               await postJson('/api/cloudinary/delete', { url: item.cloudUrl }, {
                 fallbackMessage: 'Gagal menghapus file di Cloudinary',
                 logLabel: '/api/cloudinary/delete',
               });
             } catch (err) {
-              setToast(err?.message || 'Gagal menghapus file di Cloudinary.', 'danger');
-              return;
+              // Jangan gagalkan hapus riwayat UI saat file lama bukan milik akun login saat ini / sudah tidak ada.
+              warnings.push(err?.message || 'File cloud mungkin sudah tidak tersedia atau bukan milik akun ini');
             }
           }
 
@@ -22270,7 +22583,7 @@
           localStorage.setItem(historyKey, JSON.stringify(list));
           renderHistory();
           if (typeof renderBasicHistory === 'function') renderBasicHistory();
-          setToast('Riwayat dan file cloud berhasil dihapus.', 'success');
+          setToast(warnings.length ? 'Riwayat dihapus dari perangkat. Catatan: file cloud/server mungkin sudah tidak tersedia.' : 'Riwayat berhasil dihapus.', warnings.length ? 'warning' : 'success');
         };
         const renderHistory = () => {
           const list = loadCloudHistoryOnly();
@@ -22659,10 +22972,21 @@
           try { console.warn('Trending fetch failed:', lastErr); } catch { }
         };
 
-        $('#clearHistory')?.addEventListener('click', () => {
+        $('#clearHistory')?.addEventListener('click', async () => {
+          if (!window.confirm('Bersihkan semua riwayat di perangkat ini? Riwayat akun di server juga akan dicoba dibersihkan jika kamu login.')) return;
+          let serverCleared = false;
+          if (state?.auth?.token) {
+            try {
+              await deleteJson('/api/history', { fallbackMessage: 'Gagal membersihkan riwayat akun', logLabel: '/api/history' });
+              serverCleared = true;
+            } catch (err) {
+              console.warn('Gagal membersihkan riwayat server', err);
+            }
+          }
           localStorage.removeItem(historyKey);
           renderHistory();
-          setToast('Riwayat dibersihkan');
+          if (typeof renderBasicHistory === 'function') renderBasicHistory();
+          setToast(serverCleared ? 'Riwayat akun dan perangkat dibersihkan' : 'Riwayat perangkat dibersihkan');
         });
 
         // ===== Settings (offcanvas) =====
@@ -24638,7 +24962,7 @@
               if (adminPassInput) adminPassInput.value = '';
               setToast('Login admin berhasil');
               updateAdminUi();
-              setDropzoneMessage('Login admin aktif. Siap mengunggah cookies.txt.', 'success');
+              setDropzoneMessage('Login admin aktif. Siap update cookies server.', 'success');
             } catch (err) {
               setDropzoneMessage(`Login gagal: ${err.message}`, 'error');
               setToast('Login gagal: ' + err.message);
@@ -24676,7 +25000,7 @@
         if (pickCookieBtn && cookieFile) {
           pickCookieBtn.addEventListener('click', () => {
             if (state.auth.user) {
-              const msg = translateMessage('Login Google aktif. Cookies YouTube otomatis digunakan.');
+              const msg = translateMessage('Login Google tidak dipakai untuk cookies YouTube. Cookies dikelola admin/server.');
               setToast(msg);
               setDropzoneMessage(msg, 'success');
               return;
@@ -24706,7 +25030,7 @@
           }));
           dz.addEventListener('drop', (e) => {
             if (state.auth.user) {
-              const msg = translateMessage('Login Google aktif. Cookies YouTube otomatis digunakan.');
+              const msg = translateMessage('Login Google tidak dipakai untuk cookies YouTube. Cookies dikelola admin/server.');
               setToast(msg);
               setDropzoneMessage(msg, 'success');
               return;
@@ -24731,7 +25055,7 @@
         async function handleCookieFile(file) {
           if (!file) return;
           if (state.auth.user) {
-            const msg = translateMessage('Login Google aktif. Cookies YouTube otomatis digunakan.');
+            const msg = translateMessage('Login Google tidak dipakai untuk cookies YouTube. Cookies dikelola admin/server.');
             setToast(msg);
             setDropzoneMessage(msg, 'success');
             return;
@@ -24743,7 +25067,7 @@
 
         async function uploadCookies(text) {
           if (state.auth.user) {
-            const msg = translateMessage('Login Google aktif. Cookies YouTube otomatis digunakan.');
+            const msg = translateMessage('Login Google tidak dipakai untuk cookies YouTube. Cookies dikelola admin/server.');
             setToast(msg);
             setDropzoneMessage(msg, 'success');
             return;
@@ -24751,12 +25075,12 @@
           const bearer = (state.adminBearer || '').trim();
           if (!bearer) {
             setToast('Login admin terlebih dahulu untuk upload cookies');
-            setDropzoneMessage('Login admin diperlukan sebelum upload cookies.', 'info');
+            setDropzoneMessage('Cookies dikelola admin/server. Login admin diperlukan untuk update manual.', 'info');
             return;
           }
           try {
             setDropzoneMessage('Mengunggah cookies.txt...', 'info');
-            const resp = await fetch(api('/admin/upload-cookies'), {
+            const resp = await fetch(api('/api/admin/cookies/upload'), {
               method: 'POST', headers: { 'Authorization': `Bearer ${bearer}`, 'Content-Type': 'text/plain' }, body: text
             });
             const safe = await readJsonSafe(resp);
@@ -24764,7 +25088,7 @@
             if (!resp.ok) throw new Error(payload.error || (safe.rawText || '').trim() || 'Upload gagal');
             setToast('cookies.txt terunggah ?');
             setDropzoneMessage('cookies.txt terunggah ?', 'success');
-            $('#cookieStatus').textContent = `OK • ${payload.bytes || 0} bytes ? ${payload.path || '/tmp/cookies.txt'}`;
+            $('#cookieStatus').textContent = `OK • ${payload.sizeBytes || payload.bytes || 0} bytes • health: ${payload.health || 'unknown'}`;
           } catch (err) {
             setDropzoneMessage(`Gagal upload cookies: ${err.message}`, 'error');
             setToast('Gagal upload cookies: ' + err.message);
@@ -24773,11 +25097,13 @@
 
         $('#checkCookie').addEventListener('click', async () => {
           try {
-            const resp = await fetch(api('/admin/cookies-status'));
+            const bearer = (state.adminBearer || '').trim();
+            if (!bearer) throw new Error('Login admin diperlukan');
+            const resp = await fetch(api('/api/admin/cookies/status'), { headers: { Authorization: `Bearer ${bearer}` } });
             const safe = await readJsonSafe(resp);
             const payload = safe.data && typeof safe.data === 'object' ? safe.data : {};
             if (!resp.ok) throw new Error(payload.error || (safe.rawText || '').trim() || 'Gagal mengecek status');
-            if (payload.exists) { $('#cookieStatus').textContent = `Ada ' ${payload.bytes || 0} bytes ' ${payload.path}`; }
+            if (payload.exists) { $('#cookieStatus').textContent = `Ada • ${payload.sizeBytes || payload.bytes || 0} bytes • health: ${payload.health || 'unknown'}`; }
             else { $('#cookieStatus').textContent = 'Tidak ada cookies di server.'; }
           } catch { $('#cookieStatus').textContent = 'Tidak bisa cek status cookies.'; }
         });
@@ -24853,7 +25179,7 @@
 
         function toFriendlyConvertError(message = '') {
           const raw = String(message || '').toLowerCase();
-          if (raw.includes('age') || raw.includes('restricted') || raw.includes('cookies')) return 'Video ini diblokir atau butuh cookies. Coba video lain atau update cookies ya.';
+          if (raw.includes('age') || raw.includes('restricted') || raw.includes('cookies')) return 'Video membutuhkan cookies YouTube terbaru. Admin perlu memperbarui cookies di Admin Cookies Manager.';
           if (raw.includes('429') || raw.includes('too many') || raw.includes('rate')) return 'Server lagi padat. Santai, coba lagi sebentar ya.';
           if (raw.includes('invalid') && raw.includes('url')) return 'Link belum valid. Cek lagi lalu kirim ulang ya.';
           if (raw.includes('captcha')) return 'Verifikasi keamanan belum lolos. Coba klik convert sekali lagi ya.';
@@ -25939,27 +26265,6 @@
             }
           }
 
-
-
-        // FAQ fallback: keep accordion text visible even if Bootstrap collapse misses a tap.
-        document.querySelectorAll('#faqTabContent [data-bs-toggle="collapse"]').forEach((btn) => {
-          if (btn.dataset.faqFallbackBound) return;
-          btn.dataset.faqFallbackBound = '1';
-          btn.addEventListener('click', () => {
-            const selector = btn.getAttribute('data-bs-target') || btn.getAttribute('href');
-            if (!selector) return;
-            const panel = document.querySelector(selector);
-            if (!panel) return;
-            setTimeout(() => {
-              const isOpen = panel.classList.contains('show');
-              if (!isOpen && document.activeElement === btn) {
-                panel.classList.add('show');
-                btn.classList.remove('collapsed');
-                btn.setAttribute('aria-expanded', 'true');
-              }
-            }, 180);
-          }, { passive: true });
-        });
 
           // 1. FAQ Trouble Links (Mobile vs Desktop)
           const linkContainer = document.getElementById('admin-contact-buttons');

--- a/public-ui/tailwind-ui-bridge.js
+++ b/public-ui/tailwind-ui-bridge.js
@@ -10,110 +10,109 @@
       .tw-enhanced [role="button"],
       .tw-enhanced a[class*="bg-"] {
         position: relative;
-        isolation: isolate;
         overflow: hidden;
         border-radius: 999px;
         font-weight: 800;
         letter-spacing: .01em;
-        transform: translateZ(0);
-        transition: transform .18s ease, box-shadow .18s ease, filter .18s ease, border-color .18s ease, background-color .18s ease;
-        box-shadow: 0 12px 28px rgba(2, 6, 23, .18);
+        transform: none !important;
+        transition: background-color .16s ease, border-color .16s ease, color .16s ease;
+        box-shadow: none !important;
+        text-shadow: none !important;
+        filter: none !important;
+        backdrop-filter: none !important;
+        -webkit-backdrop-filter: none !important;
       }
       .tw-enhanced button::before,
       .tw-enhanced a.btn::before,
       .tw-enhanced .btn::before,
       .tw-enhanced [role="button"]::before,
       .tw-enhanced a[class*="bg-"]::before {
-        content: "";
-        position: absolute;
-        inset: 0;
-        z-index: -1;
-        pointer-events: none;
-        background:
-          radial-gradient(circle at var(--tw-press-x, 20%) var(--tw-press-y, 20%), rgba(255,255,255,.36), transparent 0 28%),
-          linear-gradient(135deg, rgba(255,255,255,.18), transparent 45%, rgba(255,255,255,.08));
-        opacity: .72;
-        transition: opacity .18s ease;
+        content: none !important;
+        display: none !important;
       }
       .tw-enhanced button:hover,
       .tw-enhanced a.btn:hover,
       .tw-enhanced .btn:hover,
       .tw-enhanced [role="button"]:hover,
       .tw-enhanced a[class*="bg-"]:hover {
-        transform: translateY(-2px);
-        filter: brightness(1.08) saturate(1.08);
-        box-shadow: 0 18px 38px rgba(2, 6, 23, .26), 0 0 0 1px rgba(255,255,255,.10) inset;
+        transform: translateY(-1px) !important;
+        filter: none !important;
+        box-shadow: none !important;
       }
-      .tw-enhanced button:hover::before,
-      .tw-enhanced a.btn:hover::before,
-      .tw-enhanced .btn:hover::before,
-      .tw-enhanced [role="button"]:hover::before,
-      .tw-enhanced a[class*="bg-"]:hover::before {
-        opacity: 1;
+      .tw-enhanced button:active,
+      .tw-enhanced a.btn:active,
+      .tw-enhanced .btn:active,
+      .tw-enhanced [role="button"]:active,
+      .tw-enhanced a[class*="bg-"]:active {
+        transform: translateY(1px) !important;
+      }
+      .tw-enhanced :where(.btn, .app-nav-btn, .modern-nav-item, .footer-pill, .assistant-toggle, button, a.btn, [class*="bg-gradient"]) {
+        background-image: none !important;
+        box-shadow: none !important;
+        backdrop-filter: none !important;
+        -webkit-backdrop-filter: none !important;
+        filter: none !important;
+      }
+      .tw-enhanced :where(.btn-primary, .assistant-toggle) {
+        background-color: #2563eb !important;
+        border-color: #2563eb !important;
+        color: #fff !important;
+      }
+      .tw-enhanced :where(.btn-outline-primary, .app-nav-btn, .modern-nav-item, .footer-pill) {
+        background-color: #1f2937 !important;
+        border-color: rgba(148, 163, 184, .45) !important;
+        color: #e5e7eb !important;
       }
       .tw-enhanced button:focus-visible,
       .tw-enhanced a.btn:focus-visible,
       .tw-enhanced .btn:focus-visible,
       .tw-enhanced [role="button"]:focus-visible,
       .tw-enhanced a[class*="bg-"]:focus-visible {
-        outline: 3px solid rgba(125, 211, 252, .9);
-        outline-offset: 3px;
+        outline: 2px solid rgba(125, 211, 252, .9);
+        outline-offset: 2px;
       }
       .tw-enhanced button:disabled,
       .tw-enhanced .btn:disabled,
       .tw-enhanced [aria-disabled="true"] {
         cursor: not-allowed;
-        filter: grayscale(.25);
         opacity: .62;
-        transform: none;
-        box-shadow: none;
+        transform: none !important;
+        box-shadow: none !important;
+        filter: none !important;
       }
       .tw-enhanced input,
       .tw-enhanced select,
       .tw-enhanced textarea,
       .tw-enhanced .form-control,
       .tw-enhanced .form-select {
-        transition: border-color .18s ease, box-shadow .18s ease, background-color .18s ease;
+        transition: border-color .18s ease, background-color .18s ease;
+        box-shadow: none !important;
+        backdrop-filter: none !important;
+        -webkit-backdrop-filter: none !important;
       }
       .tw-enhanced input:focus,
       .tw-enhanced select:focus,
       .tw-enhanced textarea:focus,
       .tw-enhanced .form-control:focus,
       .tw-enhanced .form-select:focus {
-        box-shadow: 0 0 0 4px rgba(99, 102, 241, .18), 0 16px 32px rgba(2, 6, 23, .18);
+        box-shadow: none !important;
       }
       .tw-enhanced .premium-panel,
       .tw-enhanced .premium-card,
       .tw-enhanced .ytconv-premium-surface {
-        border-color: rgba(129, 140, 248, .26);
-        box-shadow: 0 24px 70px rgba(2, 6, 23, .34);
+        border-color: rgba(148, 163, 184, .24);
+        box-shadow: none !important;
+        backdrop-filter: none !important;
+        -webkit-backdrop-filter: none !important;
       }
       .tw-enhanced {
         position: relative;
-        isolation: isolate;
-        font-family: Inter, "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
-        background-image:
-          radial-gradient(circle at 12% 8%, rgba(59, 130, 246, .10), transparent 24rem),
-          radial-gradient(circle at 88% 14%, rgba(20, 184, 166, .10), transparent 26rem);
+        isolation: auto;
+        font-family: Helvetica, Arial, sans-serif;
+        background-image: none !important;
       }
       .tw-glow-orb {
-        position: fixed;
-        left: var(--tw-glow-x, 50%);
-        top: var(--tw-glow-y, 18%);
-        width: min(58rem, 115vw);
-        height: min(58rem, 115vw);
-        z-index: 0;
-        pointer-events: none;
-        border-radius: 9999px;
-        background:
-          radial-gradient(circle at 45% 45%, rgba(99, 102, 241, .24), transparent 0 34%),
-          radial-gradient(circle at 62% 56%, rgba(6, 182, 212, .18), transparent 0 42%),
-          radial-gradient(circle at 34% 65%, rgba(59, 130, 246, .12), transparent 0 48%);
-        filter: blur(22px) saturate(1.18);
-        opacity: .78;
-        transform: translate3d(-50%, -50%, 0) scale(1);
-        transition: opacity .25s ease, filter .25s ease;
-        mix-blend-mode: screen;
+        display: none !important;
       }
       .tw-enhanced > :not(.tw-glow-orb) {
         position: relative;
@@ -128,10 +127,12 @@
       .tw-enhanced .offcanvas,
       .tw-enhanced .list-group-item,
       .tw-enhanced .toast {
-        border-color: rgba(148, 163, 184, .20);
-        box-shadow: 0 18px 50px rgba(2, 6, 23, .18);
-        backdrop-filter: blur(14px);
-        transition: transform .18s ease, box-shadow .18s ease, border-color .18s ease, background-color .18s ease, filter .18s ease;
+        border-color: rgba(148, 163, 184, .22);
+        box-shadow: none !important;
+        backdrop-filter: none !important;
+        -webkit-backdrop-filter: none !important;
+        filter: none !important;
+        transition: border-color .18s ease, background-color .18s ease;
       }
       .tw-enhanced header:hover,
       .tw-enhanced main > section:hover,
@@ -142,9 +143,9 @@
       .tw-enhanced .offcanvas:hover,
       .tw-enhanced .list-group-item:hover,
       .tw-enhanced .toast:hover {
-        border-color: rgba(125, 211, 252, .38);
-        box-shadow: 0 28px 80px rgba(37, 99, 235, .20), 0 0 40px rgba(6, 182, 212, .10);
-        filter: saturate(1.05);
+        border-color: rgba(148, 163, 184, .34);
+        box-shadow: none !important;
+        filter: none !important;
       }
       .tw-enhanced h1,
       .tw-enhanced h2,
@@ -152,7 +153,7 @@
       .tw-enhanced h4,
       .tw-enhanced h5,
       .tw-enhanced h6 {
-        letter-spacing: -.025em;
+        letter-spacing: -.015em;
         text-wrap: balance;
       }
       .tw-enhanced p,
@@ -163,40 +164,38 @@
         line-height: 1.6;
       }
       .tw-enhanced table {
-        border-collapse: separate;
-        border-spacing: 0 .35rem;
+        border-collapse: collapse;
+        border-spacing: 0;
       }
-      .tw-enhanced tbody tr {
-        transition: transform .16s ease, box-shadow .16s ease, background-color .16s ease;
-      }
+      .tw-enhanced tbody tr,
       .tw-enhanced tbody tr:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 12px 28px rgba(2, 6, 23, .18);
+        transform: none !important;
+        box-shadow: none !important;
+        transition: background-color .18s ease;
       }
       .tw-enhanced .badge,
       .tw-enhanced [class*="rounded-full"],
       .tw-enhanced .chip,
-      .tw-enhanced .status-pill {
-        box-shadow: 0 10px 22px rgba(2, 6, 23, .16);
+      .tw-enhanced .status-pill,
+      .tw-enhanced ::file-selector-button {
+        box-shadow: none !important;
+        text-shadow: none !important;
+        backdrop-filter: none !important;
+        -webkit-backdrop-filter: none !important;
       }
       .tw-enhanced img,
       .tw-enhanced video,
       .tw-enhanced canvas {
         border-radius: inherit;
-      }
-      .tw-enhanced ::file-selector-button {
-        border: 0;
-        border-radius: 999px;
-        font-weight: 800;
-        box-shadow: 0 10px 24px rgba(2, 6, 23, .18);
+        filter: none !important;
       }
       .tw-enhanced ::selection {
         color: #f8fafc;
-        background: rgba(99, 102, 241, .62);
+        background: rgba(37, 99, 235, .62);
       }
       .tw-enhanced * {
         scrollbar-width: thin;
-        scrollbar-color: rgba(99, 102, 241, .72) rgba(15, 23, 42, .72);
+        scrollbar-color: rgba(96, 165, 250, .7) rgba(15, 23, 42, .72);
       }
       .tw-enhanced ::-webkit-scrollbar {
         width: 9px;
@@ -207,7 +206,7 @@
         border-radius: 999px;
       }
       .tw-enhanced ::-webkit-scrollbar-thumb {
-        background: linear-gradient(180deg, rgba(99, 102, 241, .9), rgba(6, 182, 212, .75));
+        background: #3b82f6;
         border-radius: 999px;
       }
     `;

--- a/public-ui/ticket-status.html
+++ b/public-ui/ticket-status.html
@@ -10,7 +10,7 @@
   <script src="/tailwind-ui-bridge.js" defer></script>
   <style>
     body { background: radial-gradient(circle at top left, rgba(37,99,235,.36), transparent 34rem), radial-gradient(circle at top right, rgba(6,182,212,.18), transparent 30rem), #020617; }
-    .glass { background: rgba(15, 23, 42, .84); backdrop-filter: blur(20px); box-shadow: 0 24px 80px rgba(2, 6, 23, .35); }
+    .glass { background: #0f172a; backdrop-filter: none; -webkit-backdrop-filter: none; box-shadow: none; }
     .glass:hover { border-color: rgba(125, 211, 252, .26); }
     .tw-enhanced .tw-pressed { transform: translateY(1px) scale(.99); }
     .pulse-dot { animation: pulseDot 1.8s ease-in-out infinite; }
@@ -20,8 +20,8 @@
 </head>
 <body class="min-h-screen text-slate-100 antialiased">
   <main class="mx-auto max-w-5xl space-y-5 p-4 pb-12 md:p-7">
-    <header class="glass overflow-hidden rounded-3xl border border-white/10 shadow-2xl shadow-blue-950/40">
-      <div class="bg-gradient-to-r from-indigo-600/25 via-cyan-500/10 to-transparent p-5 md:p-7">
+    <header class="glass overflow-hidden rounded-3xl border border-white/10">
+      <div class="bg-slate-900 p-5 md:p-7">
         <div class="flex flex-wrap items-start justify-between gap-4">
           <div>
             <div class="mb-2 inline-flex items-center gap-2 rounded-full border border-cyan-400/20 bg-cyan-400/10 px-3 py-1 text-xs font-semibold text-cyan-200">
@@ -39,7 +39,7 @@
             <span class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-4 text-slate-500">#</span>
             <input id="lookupInput" autocomplete="off" spellcheck="false" maxlength="80" class="w-full rounded-xl border border-slate-700 bg-slate-950/90 py-3 pl-9 pr-4 font-mono text-sm uppercase outline-none transition placeholder:text-slate-600 focus:border-cyan-400 focus:ring-4 focus:ring-cyan-400/10" placeholder="TKT-XXXXXXXX" />
           </div>
-          <button id="lookupBtn" type="submit" class="rounded-xl bg-gradient-to-r from-indigo-500 to-cyan-500 px-5 py-3 text-sm font-bold shadow-lg shadow-indigo-950/40 transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-60">Cari Tiket</button>
+          <button id="lookupBtn" type="submit" class="rounded-xl bg-gradient-to-r from-indigo-500 to-cyan-500 px-5 py-3 text-sm font-bold transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-60">Cari Tiket</button>
         </form>
         <div id="lookupError" class="mt-2 hidden text-sm text-rose-300" role="alert"></div>
         <div id="recentWrap" class="mt-3 hidden items-center gap-2 text-xs text-slate-400">
@@ -48,13 +48,13 @@
       </div>
     </header>
 
-    <section id="emptyState" class="glass rounded-3xl border border-white/10 p-8 text-center shadow-xl">
+    <section id="emptyState" class="glass rounded-3xl border border-white/10 p-8 text-center">
       <div class="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-indigo-500/15 text-3xl">🎫</div>
       <h2 class="mt-4 text-xl font-bold">Siapkan nomor tiketmu</h2>
       <p class="mx-auto mt-2 max-w-lg text-sm leading-6 text-slate-400">Nomor tiket tersedia setelah laporan berhasil dikirim dan biasanya diawali dengan <span class="font-mono text-slate-200">TKT-</span>.</p>
     </section>
 
-    <section id="loadingState" class="glass hidden rounded-3xl border border-white/10 p-6 shadow-xl" aria-live="polite">
+    <section id="loadingState" class="glass hidden rounded-3xl border border-white/10 p-6" aria-live="polite">
       <div class="animate-pulse space-y-4">
         <div class="h-5 w-40 rounded bg-slate-700"></div>
         <div class="grid gap-3 sm:grid-cols-3"><div class="h-24 rounded-2xl bg-slate-800"></div><div class="h-24 rounded-2xl bg-slate-800"></div><div class="h-24 rounded-2xl bg-slate-800"></div></div>
@@ -62,7 +62,7 @@
       </div>
     </section>
 
-    <section id="notFoundState" class="glass hidden rounded-3xl border border-rose-500/20 p-7 text-center shadow-xl" role="alert">
+    <section id="notFoundState" class="glass hidden rounded-3xl border border-rose-500/20 p-7 text-center" role="alert">
       <div class="text-4xl">🔍</div>
       <h2 class="mt-3 text-xl font-bold">Tiket tidak ditemukan</h2>
       <p class="mt-2 text-sm text-slate-400">Periksa kembali nomor tiket. Pastikan tidak ada spasi atau karakter yang tertinggal.</p>
@@ -70,7 +70,7 @@
     </section>
 
     <div id="ticketContent" class="hidden space-y-5">
-      <section class="glass rounded-3xl border border-white/10 p-5 shadow-xl md:p-6">
+      <section class="glass rounded-3xl border border-white/10 p-5 md:p-6">
         <div class="flex flex-wrap items-center justify-between gap-3">
           <div>
             <div class="text-xs font-semibold uppercase tracking-[.2em] text-slate-500">Nomor tiket</div>
@@ -87,7 +87,7 @@
       </section>
 
       <div class="grid gap-5 lg:grid-cols-[1.05fr_.95fr]">
-        <section class="glass rounded-3xl border border-white/10 p-5 shadow-xl md:p-6">
+        <section class="glass rounded-3xl border border-white/10 p-5 md:p-6">
           <h2 class="text-lg font-bold">Ringkasan laporan</h2>
           <div class="mt-4 space-y-4">
             <div><div class="mb-1.5 text-xs font-semibold uppercase tracking-wider text-slate-500">Pesan kamu</div><div id="msg" class="min-h-20 whitespace-pre-wrap break-words rounded-2xl border border-slate-800 bg-slate-950/70 p-4 text-sm leading-6 text-slate-300">-</div></div>
@@ -96,13 +96,13 @@
           </div>
         </section>
 
-        <section class="glass rounded-3xl border border-white/10 p-5 shadow-xl md:p-6">
+        <section class="glass rounded-3xl border border-white/10 p-5 md:p-6">
           <h2 class="text-lg font-bold">Timeline penanganan</h2>
           <ol id="history" class="mt-5 space-y-0"></ol>
         </section>
       </div>
 
-      <section class="glass rounded-3xl border border-white/10 p-5 shadow-xl md:p-6">
+      <section class="glass rounded-3xl border border-white/10 p-5 md:p-6">
         <div class="flex items-center justify-between gap-3"><div><h2 class="text-lg font-bold">Chat dengan admin</h2><p class="mt-1 text-xs text-slate-500">Pesan baru akan muncul otomatis tanpa reload halaman.</p></div><span id="chatCount" class="rounded-full bg-slate-800 px-2.5 py-1 text-xs text-slate-400">0 pesan</span></div>
         <div id="chatHistory" class="mt-4 h-80 space-y-3 overflow-auto rounded-2xl border border-slate-800 bg-slate-950/70 p-4"></div>
         <form id="chatForm" class="mt-3 flex flex-col gap-2 sm:flex-row">
@@ -111,7 +111,7 @@
         <div id="chatHint" class="mt-2 text-xs text-slate-400" aria-live="polite"></div>
       </section>
 
-      <section id="proofSection" class="glass rounded-3xl border border-white/10 p-5 shadow-xl md:p-6">
+      <section id="proofSection" class="glass rounded-3xl border border-white/10 p-5 md:p-6">
         <div class="flex flex-wrap items-start justify-between gap-3"><div><h2 class="text-lg font-bold">Upload bukti tambahan</h2><p id="proofHint" class="mt-1 text-xs text-slate-400">Aktif jika admin meminta bukti tambahan.</p></div><span class="rounded-full border border-slate-700 px-2.5 py-1 text-xs text-slate-400">Maks. 4 gambar</span></div>
         <input id="proofFiles" type="file" accept="image/*" multiple class="mt-4 block w-full text-sm text-slate-300 file:mr-3 file:rounded-lg file:border-0 file:bg-slate-700 file:px-3 file:py-2 file:text-slate-100">
         <div id="proofPreview" class="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-4"></div>
@@ -120,7 +120,7 @@
       </section>
     </div>
 
-    <div id="toast" class="pointer-events-none fixed bottom-5 left-1/2 z-50 hidden -translate-x-1/2 rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-sm shadow-2xl" role="status"></div>
+    <div id="toast" class="pointer-events-none fixed bottom-5 left-1/2 z-50 hidden -translate-x-1/2 rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-sm" role="status"></div>
   </main>
 <script>
 const RECENT_KEY = 'ytconv_recent_tickets_v1';
@@ -141,7 +141,7 @@ let refreshTimer = null;
 
 const asLocal = (iso) => { const date = new Date(iso || ''); return Number.isNaN(date.getTime()) ? (iso || '-') : fmt.format(date); };
 const setVisible = (id, visible) => $(id).classList.toggle('hidden', !visible);
-const showToast = (message, tone = 'normal') => { const el = $('toast'); el.textContent = message; el.className = `pointer-events-none fixed bottom-5 left-1/2 z-50 -translate-x-1/2 rounded-xl border px-4 py-3 text-sm shadow-2xl ${tone === 'error' ? 'border-rose-500/30 bg-rose-950 text-rose-200' : 'border-white/10 bg-slate-900 text-slate-100'}`; clearTimeout(showToast.timer); showToast.timer = setTimeout(() => el.classList.add('hidden'), 2600); };
+const showToast = (message, tone = 'normal') => { const el = $('toast'); el.textContent = message; el.className = `pointer-events-none fixed bottom-5 left-1/2 z-50 -translate-x-1/2 rounded-xl border px-4 py-3 text-sm ${tone === 'error' ? 'border-rose-500/30 bg-rose-950 text-rose-200' : 'border-white/10 bg-slate-900 text-slate-100'}`; clearTimeout(showToast.timer); showToast.timer = setTimeout(() => el.classList.add('hidden'), 2600); };
 const makeBadge = (label, status) => { const span = document.createElement('span'); span.className = `inline-flex rounded-full border px-3 py-1 text-sm font-bold ${statusStyles[status] || 'border-slate-600 bg-slate-700/50 text-slate-200'}`; span.textContent = label || status || '-'; return span; };
 
 function readRecentTickets() { try { const value = JSON.parse(localStorage.getItem(RECENT_KEY) || '[]'); return Array.isArray(value) ? value.filter((x) => x?.ticketId).slice(0, 5) : []; } catch { return []; } }

--- a/src/routes/adminCookies.js
+++ b/src/routes/adminCookies.js
@@ -1,0 +1,8 @@
+// Route implementation is mounted in index.js to stay compatible with the existing single-file Express app.
+// This module documents the supported admin cookies API paths for future extraction:
+export const adminCookiesRoutes = [
+  "POST /api/admin/cookies/upload",
+  "GET /api/admin/cookies/status",
+  "POST /api/admin/cookies/test",
+  "DELETE /api/admin/cookies",
+];

--- a/src/services/cookiesStore.js
+++ b/src/services/cookiesStore.js
@@ -1,0 +1,14 @@
+export {
+  deleteCookies,
+  getCookieStoreBackend,
+  getCookiesPath,
+  getCookiesStatus,
+  initializeCookiesStore,
+  readCookies,
+  saveCookies,
+  startCookiesSync,
+  stopCookiesSync,
+  syncCookiesToLocal,
+  updateCookiesHealth,
+  validateCookiesText,
+} from "../../cookie_store.js";

--- a/src/services/downloader.js
+++ b/src/services/downloader.js
@@ -1,0 +1,27 @@
+export const ERROR_CATEGORIES = Object.freeze({
+  BOT_CHECK: "BOT_CHECK",
+  LOGIN_REQUIRED: "LOGIN_REQUIRED",
+  AGE_RESTRICTED: "AGE_RESTRICTED",
+  GEO_BLOCKED: "GEO_BLOCKED",
+  PRIVATE_VIDEO: "PRIVATE_VIDEO",
+  FORMAT_UNAVAILABLE: "FORMAT_UNAVAILABLE",
+  RATE_LIMITED: "RATE_LIMITED",
+  NETWORK_ERROR: "NETWORK_ERROR",
+  YTDLP_MISSING: "YTDLP_MISSING",
+  FFMPEG_MISSING: "FFMPEG_MISSING",
+  UNKNOWN: "UNKNOWN",
+});
+
+export const createJobResponse = (job = {}) => ({
+  ok: job.status !== "failed",
+  jobId: job.id || job.jobId,
+  status: job.status || "queued",
+  progress: job.progress || 0,
+  step: job.step || job.status || "queued",
+  message: job.message || "",
+  downloadUrl: job.downloadUrl || null,
+  filename: job.filename || null,
+  errorCategory: job.errorCategory || null,
+  error: job.error || null,
+  cached: Boolean(job.cached),
+});

--- a/src/services/ffmpegRunner.js
+++ b/src/services/ffmpegRunner.js
@@ -1,0 +1,40 @@
+import { spawn } from "node:child_process";
+
+export const runFfmpeg = (ffmpegPath, args = [], { cwd = process.cwd(), timeoutMs = 15 * 60_000 } = {}) => new Promise((resolve, reject) => {
+  if (!ffmpegPath) {
+    const err = new Error("FFMPEG_MISSING");
+    err.errorCategory = "FFMPEG_MISSING";
+    reject(err);
+    return;
+  }
+  const child = spawn(ffmpegPath, args, { cwd, stdio: ["ignore", "pipe", "pipe"] });
+  let stdout = "";
+  let stderr = "";
+  const timer = setTimeout(() => {
+    child.kill("SIGTERM");
+    const err = new Error("ffmpeg_timeout");
+    err.stdout = stdout;
+    err.stderr = stderr;
+    reject(err);
+  }, timeoutMs);
+  child.stdout.on("data", (chunk) => { stdout += chunk.toString(); });
+  child.stderr.on("data", (chunk) => { stderr += chunk.toString(); });
+  child.on("error", (err) => {
+    clearTimeout(timer);
+    err.stdout = stdout;
+    err.stderr = stderr;
+    reject(err);
+  });
+  child.on("close", (code) => {
+    clearTimeout(timer);
+    if (code !== 0) {
+      const err = new Error(`ffmpeg_exit_${code}`);
+      err.stdout = stdout;
+      err.stderr = stderr;
+      reject(err);
+      return;
+    }
+    resolve({ stdout, stderr });
+  });
+  timer.unref?.();
+});

--- a/src/services/ytdlpRunner.js
+++ b/src/services/ytdlpRunner.js
@@ -1,0 +1,46 @@
+import { spawn } from "node:child_process";
+
+export const runCommand = (cmd, args = [], { cwd = process.cwd(), timeoutMs = 120000 } = {}) => new Promise((resolve, reject) => {
+  const child = spawn(cmd, args, { cwd, stdio: ["ignore", "pipe", "pipe"] });
+  let stdout = "";
+  let stderr = "";
+  const timer = setTimeout(() => {
+    child.kill("SIGTERM");
+    const err = new Error("process_timeout");
+    err.stdout = stdout;
+    err.stderr = stderr;
+    reject(err);
+  }, timeoutMs);
+  child.stdout.on("data", (chunk) => { stdout += chunk.toString(); });
+  child.stderr.on("data", (chunk) => { stderr += chunk.toString(); });
+  child.on("error", (err) => {
+    clearTimeout(timer);
+    err.stdout = stdout;
+    err.stderr = stderr;
+    reject(err);
+  });
+  child.on("close", (code) => {
+    clearTimeout(timer);
+    if (code !== 0) {
+      const err = new Error(`process_exit_${code}`);
+      err.code = code;
+      err.stdout = stdout;
+      err.stderr = stderr;
+      reject(err);
+      return;
+    }
+    resolve({ stdout, stderr });
+  });
+  timer.unref?.();
+});
+
+export const buildAudioFormatSelector = (format = "mp3") => {
+  if (format === "m4a") return "bestaudio[ext=m4a]/bestaudio/best";
+  return "bestaudio/best";
+};
+
+export const buildVideoFormatSelector = (height = "best") => {
+  const numericHeight = Number.parseInt(String(height || ""), 10);
+  if (!Number.isFinite(numericHeight)) return "bestvideo+bestaudio/best";
+  return `bestvideo[height<=${numericHeight}]+bestaudio/best[height<=${numericHeight}]/best`;
+};

--- a/tests/cookie-store.test.js
+++ b/tests/cookie-store.test.js
@@ -26,27 +26,26 @@ test.after(async () => {
   await rm(tempDir, { recursive: true, force: true });
 });
 
-test("upload disimpan ke store persisten dan salinan runtime", async () => {
-  assert.equal(store.getCookieStoreBackend(), "file");
+test("upload disimpan ke runtime path aman tanpa mengekspos isi di metadata", async () => {
+  assert.equal(store.getCookieStoreBackend(), "volume");
   const saved = await store.saveCookies(sampleCookies);
   assert.equal(saved.bytes, Buffer.byteLength(sampleCookies));
   assert.equal(await readFile(cookiesPath, "utf8"), sampleCookies);
 
   const persistent = JSON.parse(await readFile(storePath, "utf8"));
-  assert.equal(persistent.content, sampleCookies);
-  assert.equal(persistent.hash, saved.hash);
+  assert.equal(persistent.content, undefined);
+  assert.equal(typeof persistent.hash, "string");
+  assert.equal(persistent.sizeBytes, saved.sizeBytes);
   assert.equal((await stat(cookiesPath)).mode & 0o777, 0o600);
 });
 
-test("status selalu berasal dari store dan memulihkan file runtime yang hilang", async () => {
-  await rm(cookiesPath, { force: true });
-  await assert.rejects(access(cookiesPath));
-
+test("status tidak menampilkan path/hash/content cookies", async () => {
   const status = await store.getCookiesStatus();
   assert.equal(status.exists, true);
-  assert.equal(status.bytes, Buffer.byteLength(sampleCookies));
-  assert.equal(status.backend, "file");
-  assert.equal(await readFile(cookiesPath, "utf8"), sampleCookies);
+  assert.equal(status.sizeBytes, Buffer.byteLength(sampleCookies));
+  assert.equal(status.storage, "volume");
+  assert.equal(status.content, undefined);
+  assert.equal(status.hash, undefined);
 });
 
 test("instance baru membaca upload yang sama setelah refresh atau restart", async () => {
@@ -57,7 +56,7 @@ test("instance baru membaca upload yang sama setelah refresh atau restart", asyn
   restarted.stopCookiesSync();
 });
 
-test("file cookies lama dimigrasikan ke store saat belum ada record", async () => {
+test("file cookies lama dibaca sebagai sumber utama tanpa menyimpan raw content ke metadata", async () => {
   const legacyDir = await mkdtemp(join(tmpdir(), "ytconv-cookie-legacy-"));
   const legacyCookiesPath = join(legacyDir, "cookies.txt");
   const legacyStorePath = join(legacyDir, "data", "cookies-store.json");
@@ -68,12 +67,13 @@ test("file cookies lama dimigrasikan ke store saat belum ada record", async () =
   const legacyStore = await import(`../cookie_store.js?legacy=${Date.now()}`);
   const status = await legacyStore.initializeCookiesStore();
   assert.equal(status.exists, true);
-  assert.equal(JSON.parse(await readFile(legacyStorePath, "utf8")).content, sampleCookies);
+  await assert.rejects(readFile(legacyStorePath, "utf8"));
   legacyStore.stopCookiesSync();
   await rm(legacyDir, { recursive: true, force: true });
 });
 
-test("upload kosong ditolak tanpa menghapus cookies yang sudah tersimpan", async () => {
+test("upload kosong dan non-Netscape ditolak tanpa menghapus cookies", async () => {
   await assert.rejects(store.saveCookies("   \n"), /cookies_empty/);
+  await assert.rejects(store.saveCookies("not cookies"), /cookies_invalid_netscape_format/);
   assert.equal((await store.readCookies()).content, sampleCookies);
 });

--- a/tests/ui-polish.test.js
+++ b/tests/ui-polish.test.js
@@ -67,7 +67,7 @@ test("tailwind bridge terhubung ke JavaScript interaktif", () => {
 test("tailwind bridge mempercantik tombol dan panel tanpa mengganti fitur", () => {
   assert.match(pages.bridge, /tw-premium-button-polish/);
   assert.match(pages.bridge, /a\[class\*="bg-"\]/);
-  assert.match(pages.bridge, /radial-gradient\(circle at var\(--tw-press-x/);
+  assert.match(pages.bridge, /background-image: none !important/);
   assert.match(pages.bridge, /focus-visible/);
   assert.match(pages.bridge, /premium-panel/);
 });
@@ -80,12 +80,11 @@ test("tailwind bridge memberi polish menyeluruh ke elemen umum", () => {
   assert.match(pages.bridge, /text-wrap:\s*balance/);
 });
 
-test("tailwind bridge memakai sans font dan glow interaktif", () => {
-  assert.match(pages.bridge, /font-family:\s*Inter, "Segoe UI", system-ui/);
+test("tailwind bridge memakai Helvetica dan no-glass ringan", () => {
+  assert.match(pages.bridge, /font-family:\s*Helvetica, Arial, sans-serif/);
   assert.match(pages.bridge, /tw-glow-orb/);
-  assert.match(pages.bridge, /ensureGlowOrb/);
-  assert.match(pages.bridge, /--tw-glow-x/);
-  assert.match(pages.bridge, /pointermove/);
-  assert.match(pages.bridge, /rgba\(99, 102, 241, \.24\)/);
-  assert.match(pages.bridge, /box-shadow: 0 28px 80px/);
+  assert.match(pages.bridge, /display: none !important/);
+  assert.match(pages.bridge, /backdrop-filter: none !important/);
+  assert.match(pages.bridge, /box-shadow: none !important/);
+  assert.match(pages.bridge, /transition: background-color \.16s ease/);
 });

--- a/tests/user-store.test.js
+++ b/tests/user-store.test.js
@@ -13,6 +13,8 @@ import {
   ensureReferralForUser,
   getHistoryEntry,
   updateHistoryEntry,
+  deleteHistoryEntry,
+  clearUserHistory,
   claimCheatForUser,
 } from "../user_store.js";
 
@@ -79,6 +81,39 @@ test("recordConversionForUser menambah riwayat dan xp", async () => {
   await updateHistoryEntry("user-456", history[0].id, { downloadUrl: "/public/jobs/new.mp3" });
   const updated = await getHistoryEntry("user-456", history[0].id);
   assert.equal(updated?.downloadUrl, "/public/jobs/new.mp3");
+
+  assert.equal(await deleteHistoryEntry("user-456", history[0].id), true);
+  assert.equal(await getHistoryEntry("user-456", history[0].id), null);
+  assert.equal(await deleteHistoryEntry("user-456", history[0].id), false);
+});
+
+test("clearUserHistory menghapus semua riwayat user login", async () => {
+  await resetStore();
+  await upsertGoogleUser({
+    googleId: "user-clear-history",
+    email: "clear@example.com",
+    name: "Clear History",
+  });
+  await recordConversionForUser("user-clear-history", {
+    id: "hist-a",
+    title: "A",
+    format: "mp3",
+    sourceUrl: "https://youtu.be/a",
+    downloadUrl: "/jobs/a.mp3",
+    xpGain: 1,
+  });
+  await recordConversionForUser("user-clear-history", {
+    id: "hist-b",
+    title: "B",
+    format: "m4a",
+    sourceUrl: "https://youtu.be/b",
+    downloadUrl: "/jobs/b.m4a",
+    xpGain: 1,
+  });
+
+  assert.equal((await listUserHistory("user-clear-history")).length, 2);
+  assert.equal(await clearUserHistory("user-clear-history"), 2);
+  assert.deepEqual(await listUserHistory("user-clear-history"), []);
 });
 
 test("recordConversionForUser idempoten terhadap xpEventId yang sama", async () => {

--- a/user_store.js
+++ b/user_store.js
@@ -493,6 +493,31 @@ export const updateHistoryEntry = async (userId, entryId, patch = {}) => {
   return entry;
 };
 
+export const deleteHistoryEntry = async (userId, entryId) => {
+  if (!userId || !entryId) return false;
+  const data = await readStore();
+  const user = data.users[userId];
+  if (!user || !Array.isArray(user.history)) return false;
+  const before = user.history.length;
+  user.history = user.history.filter((item) => item?.id !== entryId);
+  if (user.history.length === before) return false;
+  user.updatedAt = Date.now();
+  await writeStore(data);
+  return true;
+};
+
+export const clearUserHistory = async (userId) => {
+  if (!userId) return 0;
+  const data = await readStore();
+  const user = data.users[userId];
+  if (!user || !Array.isArray(user.history)) return 0;
+  const deleted = user.history.length;
+  user.history = [];
+  user.updatedAt = Date.now();
+  await writeStore(data);
+  return deleted;
+};
+
 export const claimCheatForUser = async (userId, rawCode) => {
   if (!userId) throw new Error("userId wajib diisi");
   const normalized = typeof rawCode === "string" ? rawCode.trim().toLowerCase() : "";


### PR DESCRIPTION
### Motivation
- Centralize and harden handling of YouTube cookies so server/admin can manage cookies securely instead of exposing raw cookie content or relying on Firestore.
- Make yt-dlp usage more robust across environments by adding JS runtime detection, extractor args, cookie retry logic, broader format fallbacks and clearer error categorization.
- Introduce an asynchronous converter job queue with caching, job APIs and admin controls to improve reliability and scalability of long-running conversion tasks.
- Polish public/admin UI to reflect server-managed cookies, reduce heavy visual effects for performance, and add admin cookies manager pages.

### Description
- Rewrote `cookie_store.js` to remove Firestore dependency, store safe metadata in `cookies-meta.json`, validate Netscape cookie format, enforce size and content checks, track health/status and provide `saveCookies`, `readCookies`, `getCookiesStatus`, `updateCookiesHealth`, `deleteCookies` and related helpers with queued file operations.
- Enhanced Python helper `download_audio.py` with JS runtime probing, extractor/player-client args, cookie usage toggle, better format selectors and runtime options for yt-dlp; added upgrades and compatibility logic.
- Extended main server (`index.js`) with: server-side cookies APIs (`/api/admin/cookies/*`) including upload, status, test and delete; retry/append server cookies flow for yt-dlp errors (categorization and public error wrapping); background converter job queue with cache, job endpoints (`/api/jobs/*`) and admin queue controls; safer yt-dlp auto-update and multiple yt-dlp runner improvements; many integration points to use the new cookie store and health metadata; and admin/session/history endpoints (delete/clear history).
- Added service modules (`src/services/*`) for cookie routes, downloader error constants, ffmpeg and ytdlp command runners and re-export convenience for cookie store.
- Updated front-end/admin pages and JS (`public-ui/*`) to reflect server-managed cookies, add admin cookies UI flows, improve accessibility, remove heavy glass/glow/shadow effects, and wire new APIs and job/history behaviors.
- Added small DX changes: `package.json` `dev` script and multiple test/UX improvements, plus `user_store.js` now supports `deleteHistoryEntry` and `clearUserHistory`.
- Tests and helper files added/updated to match new behavior and security model (cookies metadata no longer contains raw content or path exposure).

### Testing
- Ran unit tests `tests/cookie-store.test.js`, `tests/ui-polish.test.js`, and `tests/user-store.test.js` against the modified codebase and all tests passed.
- Exercised conversion/job workflow and admin cookies endpoints locally using the integrated yt-dlp runner and UI flows (automated tests cover cookie store, UI bridge expectations and history APIs).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a433cdb89788331ad06d63078ad04cf)