### PR TITLE
Improve yt-dlp fallback strategies and add robust Firebase Google login fallbacks/UI

### DIFF
--- a/download_audio.py
+++ b/download_audio.py
@@ -164,7 +164,7 @@ def download_with_ytdlp(
 
     template = os.path.join(out_dir, f"{out_basename}.%(ext)s")
     base_opts = {
-        "format": "bestaudio/best",
+        "format": "ba/bestaudio/best/worst",
         "outtmpl": template,
         "restrictfilenames": False,
         "noplaylist": True,
@@ -191,8 +191,11 @@ def download_with_ytdlp(
     tv_opts = dict(base_opts)
     tv_opts["extractor_args"] = {"youtube": {"player_client": ["mweb", "web_safari", "tv_embedded", "android"]}}
 
+    audio_opts = dict(compat_opts)
+    audio_opts["format"] = "ba/bestaudio/best/worst"
+
     relaxed_opts = dict(compat_opts)
-    relaxed_opts["format"] = "best"
+    relaxed_opts["format"] = "best/worst"
 
     http_opts = dict(relaxed_opts)
     http_opts["format"] = "bestaudio[protocol^=http]/best[protocol^=http]/bestaudio/best/worst"
@@ -200,9 +203,13 @@ def download_with_ytdlp(
     universal_opts = dict(tv_opts)
     universal_opts.pop("format", None)
 
+    no_runtime_opts = dict(universal_opts)
+    no_runtime_opts.pop("js_runtimes", None)
+    no_runtime_opts.pop("remote_components", None)
+
     last_exc: Optional[Exception] = None
     upgrade_tried = False
-    attempts = [base_opts, compat_opts, tv_opts, relaxed_opts, http_opts, universal_opts]
+    attempts = [base_opts, compat_opts, tv_opts, audio_opts, relaxed_opts, http_opts, universal_opts, no_runtime_opts]
     for opts in attempts:
         try:
             with YoutubeDL(opts) as ydl:  # type: ignore[misc]

--- a/index.html
+++ b/index.html
@@ -5105,6 +5105,12 @@
         <i class="bi bi-grid-3x3-gap"></i>
         <span class="ms-2">Menu fitur</span>
       </button>
+      <a class="btn btn-danger d-inline-flex align-items-center ms-2" id="converterGuideBtn"
+        href="https://ytconvguide.vercel.app/" target="_blank" rel="noopener noreferrer"
+        aria-label="Buka Panduan Error converter">
+        <i class="bi bi-life-preserver"></i>
+        <span class="ms-2">Panduan Error</span>
+      </a>
       <button class="app-nav-btn d-inline-flex ms-2" type="button" id="ytMusicBtn" aria-label="Buka YT Music">
         <i class="bi bi-youtube"></i>
         <span class="ms-2">YT Music</span>
@@ -8178,12 +8184,15 @@
               <p class="text-secondary mb-4" style="max-width: 300px;">Diskusi seru, berbagi gambar, dan stiker dengan
                 warga lainnya.</p>
 
-              <button id="forumGoogleLoginBtn"
+              <button id="forumGoogleLoginBtn" type="button"
                 class="btn btn-light rounded-pill py-3 px-5 fw-bold d-flex align-items-center gap-3 shadow-lg hover-scale">
                 <img src="https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg" width="24" height="24"
                   alt="G">
                 <span>Masuk dengan Google</span>
               </button>
+              <div id="forumLoginFallback" class="small text-secondary mt-3" role="status" aria-live="polite">
+                Kalau tombol tidak merespons, tekan lagi untuk mode redirect.
+              </div>
             </div>
           </div>
 
@@ -10811,17 +10820,10 @@
 
           loginBtn.addEventListener('click', async () => {
             try {
-              const m = await waitForFirebase();
-              const { auth, signInWithPopup, signInWithRedirect, GoogleAuthProvider } = m;
+              await waitForFirebase();
               loginBtn.disabled = true;
-              loginBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>...';
-              const provider = new GoogleAuthProvider();
-              provider.setCustomParameters({ prompt: 'select_account' });
-              try {
-                await signInWithPopup(auth, provider);
-              } catch {
-                await signInWithRedirect(auth, provider);
-              }
+              loginBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>Membuka Google...';
+              await startFirebaseGoogleLogin({ status: (msg) => { loginBtn.innerHTML = `<span class="spinner-border spinner-border-sm me-2"></span>${msg}`; } });
             } catch {
               if (typeof window.setToast === 'function') window.setToast('Login gagal.', 'danger');
             } finally {
@@ -16451,6 +16453,85 @@
           }
         }
 
+        function prefersGoogleRedirectLogin() {
+          const ua = navigator.userAgent || '';
+          const isMobile = /Android|iPhone|iPad|iPod|IEMobile|Opera Mini/i.test(ua);
+          const isInApp = /FBAN|FBAV|Instagram|Line|TikTok|Twitter|WebView|wv\)/i.test(ua);
+          const isStandalone = window.matchMedia?.('(display-mode: standalone)')?.matches || navigator.standalone;
+          return Boolean(isMobile || isInApp || isStandalone);
+        }
+
+        async function startFirebaseGoogleLogin({ preferRedirect = prefersGoogleRedirectLogin(), status, pendingKey = '' } = {}) {
+          const setStatus = typeof status === 'function' ? status : () => { };
+          const modules = window.firebaseModules || await new Promise((resolve, reject) => {
+            let attempts = 0;
+            const timer = window.setInterval(() => {
+              attempts += 1;
+              if (window.firebaseModules?.auth) {
+                window.clearInterval(timer);
+                resolve(window.firebaseModules);
+              } else if (attempts > 40) {
+                window.clearInterval(timer);
+                reject(new Error('Firebase auth belum siap.'));
+              }
+            }, 250);
+          });
+
+          const { auth, signInWithPopup, signInWithRedirect, GoogleAuthProvider } = modules;
+          if (!auth || !GoogleAuthProvider || (!signInWithPopup && !signInWithRedirect)) {
+            throw new Error('Login Google belum siap di browser ini.');
+          }
+
+          const provider = new GoogleAuthProvider();
+          provider.setCustomParameters({ prompt: 'select_account' });
+
+          if (preferRedirect) {
+            if (!signInWithRedirect) throw new Error('Mode redirect Google tidak tersedia.');
+            if (pendingKey) sessionStorage.setItem(pendingKey, 'true');
+            setStatus('Mengalihkan ke Google Sign-In...');
+            await signInWithRedirect(auth, provider);
+            return null;
+          }
+
+          if (signInWithPopup) {
+            try {
+              setStatus('Membuka popup Google...');
+              return await signInWithPopup(auth, provider);
+            } catch (popupErr) {
+              console.warn('Popup Google gagal, pakai redirect', popupErr);
+            }
+          }
+
+          if (!signInWithRedirect) throw new Error('Popup diblokir dan mode redirect tidak tersedia.');
+          if (pendingKey) sessionStorage.setItem(pendingKey, 'true');
+          setStatus('Popup diblokir. Mengalihkan ke Google Sign-In...');
+          await signInWithRedirect(auth, provider);
+          return null;
+        }
+
+        function appendFirebaseGoogleFallback(container, id, label = 'Masuk mode mobile') {
+          if (!container || container.querySelector(`#${id}`)) return;
+          container.insertAdjacentHTML('beforeend', `
+            <button type="button" class="btn btn-link btn-sm text-decoration-none mt-2 px-0" id="${id}">
+              ${label}
+            </button>
+          `);
+          const btn = container.querySelector(`#${id}`);
+          if (!btn) return;
+          btn.addEventListener('click', async () => {
+            btn.disabled = true;
+            btn.textContent = 'Mengalihkan ke Google...';
+            try {
+              await startFirebaseGoogleLogin({ preferRedirect: true, status: (msg) => { btn.textContent = msg; } });
+            } catch (err) {
+              console.error('Fallback login gagal', err);
+              btn.disabled = false;
+              btn.textContent = label;
+              setToast(err?.message || translateMessage('Login gagal'));
+            }
+          });
+        }
+
         function renderGoogleFallback(messageKey) {
           if (!googleSignInButton) return;
           const message = translateMessage(
@@ -16468,8 +16549,17 @@
           const fallbackBtn = googleSignInButton.querySelector('#googleFallbackAction');
           if (fallbackBtn && !fallbackBtn.dataset.bound) {
             fallbackBtn.dataset.bound = 'true';
-            fallbackBtn.addEventListener('click', () => {
-              setToast(message);
+            fallbackBtn.addEventListener('click', async () => {
+              fallbackBtn.disabled = true;
+              fallbackBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>Mengalihkan ke Google...';
+              try {
+                await startFirebaseGoogleLogin({ preferRedirect: true });
+              } catch (err) {
+                console.error('Google fallback login gagal', err);
+                fallbackBtn.disabled = false;
+                fallbackBtn.innerHTML = `<i class="bi bi-google"></i><span>${translateMessage('Masuk dengan Google')}</span>`;
+                setToast(err?.message || message);
+              }
             });
           }
         }
@@ -16580,6 +16670,7 @@
               text: 'signin_with',
               shape: 'pill',
             });
+            appendFirebaseGoogleFallback(googleSignInButton, 'googleMobileFallbackAction');
           }
 
           const googleSignInForum = document.getElementById('googleSignInForum');
@@ -16604,6 +16695,7 @@
               shape: 'pill',
               width: '300'
             });
+            appendFirebaseGoogleFallback(profileGoogleLoginBtn, 'profileMobileFallbackAction');
           }
         }
 
@@ -28030,10 +28122,13 @@
               <h3 class="fw-bold mb-2 text-white" style="letter-spacing: -0.5px;">Gabung Forum</h3>
               <p class="text-secondary mb-4" style="max-width: 300px;">Diskusi seru, berbagi gambar, dan stiker dengan warga lainnya.</p>
               
-              <button id="forumGoogleLoginBtn" class="btn btn-light rounded-pill py-3 px-5 fw-bold d-flex align-items-center gap-3 shadow-lg hover-scale">
+              <button id="forumGoogleLoginBtn" type="button" class="btn btn-light rounded-pill py-3 px-5 fw-bold d-flex align-items-center gap-3 shadow-lg hover-scale">
                   <img src="https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg" width="24" height="24" alt="G">
                   <span>Masuk dengan Google</span>
-              </button>`;
+              </button>
+              <div id="forumLoginFallback" class="small text-secondary mt-3" role="status" aria-live="polite">
+                Kalau tombol tidak merespons, tekan lagi untuk mode redirect.
+              </div>`;
             const newBtn = document.getElementById('forumGoogleLoginBtn');
             if (newBtn) newBtn.addEventListener('click', handleLoginClick);
           }
@@ -28859,33 +28954,50 @@
             });
           }
 
-          async function handleLoginClick() {
-            // ... (Keep existing login logic mostly same but ensure new UI is handled)
+          function setForumLoginFallback(message, variant = 'secondary') {
+            const fallback = document.getElementById('forumLoginFallback');
+            if (!fallback) return;
+            fallback.className = `small text-${variant} mt-3`;
+            fallback.textContent = message;
+          }
+
+          function resetForumLoginButton() {
             const btn = document.getElementById('forumGoogleLoginBtn');
             if (!btn) return;
-            if (!window.firebaseModules || !window.firebaseModules.auth) return;
-            const { auth, signInWithPopup, GoogleAuthProvider, signInWithRedirect } = window.firebaseModules;
-            btn.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>...';
+            btn.disabled = false;
+            btn.innerHTML = '<img src="https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg" width="24" height="24" alt="G"><span>Masuk dengan Google</span>';
+          }
+
+          async function handleLoginClick() {
+            const btn = document.getElementById('forumGoogleLoginBtn');
+            if (!btn) return;
+            if (!window.firebaseModules || !window.firebaseModules.auth) {
+              setForumLoginFallback('Login sedang dimuat. Tunggu sebentar lalu tekan lagi.', 'warning');
+              return;
+            }
+
+            btn.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>Membuka Google...';
             btn.disabled = true;
+            setForumLoginFallback(prefersGoogleRedirectLogin()
+              ? 'Mode mobile aktif. Mengalihkan ke Google Sign-In...'
+              : 'Jika popup tidak muncul, sistem otomatis memakai mode redirect.', 'info');
+
             try {
-              const provider = new GoogleAuthProvider();
-              provider.setCustomParameters({ prompt: 'select_account' });
-              try {
-                const result = await signInWithPopup(auth, provider);
-                if (result && result.user) {
-                  setToast('Login berhasil!', 'success');
-                  sessionStorage.removeItem('forum_login_pending');
-                  forumLoginOverlay.classList.remove('d-flex');
-                  forumLoginOverlay.classList.add('d-none');
-                }
-              } catch (popupErr) {
-                sessionStorage.setItem('forum_login_pending', 'true');
-                await signInWithRedirect(auth, provider);
+              const result = await startFirebaseGoogleLogin({
+                pendingKey: 'forum_login_pending',
+                status: (msg) => setForumLoginFallback(msg, 'info'),
+              });
+              if (result && result.user) {
+                setToast('Login berhasil!', 'success');
+                sessionStorage.removeItem('forum_login_pending');
+                forumLoginOverlay.classList.remove('d-flex');
+                forumLoginOverlay.classList.add('d-none');
               }
             } catch (error) {
-              console.error(error);
-              btn.innerHTML = 'Login Google';
-              btn.disabled = false;
+              console.error('Forum login failed', error);
+              sessionStorage.removeItem('forum_login_pending');
+              setForumLoginFallback(error?.message || 'Login belum bisa dibuka. Muat ulang halaman atau izinkan popup/redirect Google.', 'danger');
+              resetForumLoginButton();
             }
           }
 

--- a/index.js
+++ b/index.js
@@ -7232,6 +7232,49 @@ const pushYoutubeExtractorArgs = (args = []) => {
   return args;
 };
 
+const replaceYtDlpFormatSelector = (args = [], selector = "") => {
+  const next = Array.isArray(args) ? [...args] : [];
+  const url = next[next.length - 1];
+  const isUrlLike = typeof url === "string" && /^(https?:|ytsearch|ytmsearch)/i.test(url);
+  const urlArg = isUrlLike ? next.pop() : null;
+  let replaced = false;
+  for (let i = 0; i < next.length - 1; i++) {
+    if (next[i] === "-f" && typeof next[i + 1] === "string") {
+      if (selector) next[i + 1] = selector;
+      else next.splice(i, 2);
+      replaced = true;
+      break;
+    }
+  }
+  if (!replaced && selector) next.push("-f", selector);
+  if (urlArg) next.push(urlArg);
+  return next;
+};
+
+const removeYtDlpJsRuntimeArgs = (args = []) => {
+  const next = [];
+  const source = Array.isArray(args) ? args : [];
+  for (let i = 0; i < source.length; i++) {
+    const item = source[i];
+    if (["--js-runtimes", "--remote-components", "--extractor-retries"].includes(item)) {
+      i += 1;
+      continue;
+    }
+    next.push(item);
+  }
+  return next;
+};
+
+const dedupeYtDlpArgPlans = (plans = []) => {
+  const seen = new Set();
+  return plans.filter((plan) => {
+    const key = JSON.stringify(plan.args || []);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+};
+
 const buildYtDlpFallbackArgs = (args = []) => {
   const next = Array.isArray(args) ? [...args] : [];
   if (!next.length) return next;
@@ -7769,29 +7812,22 @@ const convertSingle = async (payload = {}) => {
           }
         }
         if (!downloadResult && shouldRetryWithFallbackArgs) {
-          try {
-            emitProgress({ stage: "downloading", message: "Mencoba mode kompatibilitas", percent: mapDownloadPercent(18) });
-            const fallbackArgs = buildYtDlpFallbackArgs(args);
-            downloadResult = await runYtDlpDownload({ args: fallbackArgs, id, onProgress: handleDownloadProgress });
-            logs = downloadResult.logs || baseLogs;
-          } catch (retryErr) {
-            logs = retryErr?.logs || logs || baseLogs;
-          }
-        }
-        if (!downloadResult && shouldRetryWithFallbackArgs) {
-          try {
-            emitProgress({ stage: "downloading", message: "Mencoba format universal", percent: mapDownloadPercent(19) });
-            const universalArgs = buildYtDlpFallbackArgs(args);
-            for (let i = 0; i < universalArgs.length - 1; i++) {
-              if (universalArgs[i] === "-f") {
-                universalArgs.splice(i, 2);
-                break;
-              }
+          const retryPlans = dedupeYtDlpArgPlans([
+            { label: "mode kompatibilitas", percent: 18, args: buildYtDlpFallbackArgs(args) },
+            { label: "audio universal", percent: 19, args: replaceYtDlpFormatSelector(buildYtDlpFallbackArgs(args), "ba/bestaudio/best/worst") },
+            { label: "format otomatis", percent: 20, args: replaceYtDlpFormatSelector(buildYtDlpFallbackArgs(args), "") },
+            { label: "format otomatis tanpa JS runtime", percent: 21, args: removeYtDlpJsRuntimeArgs(replaceYtDlpFormatSelector(buildYtDlpFallbackArgs(args), "")) },
+          ]);
+
+          for (const plan of retryPlans) {
+            if (downloadResult) break;
+            try {
+              emitProgress({ stage: "downloading", message: `Mencoba ${plan.label}`, percent: mapDownloadPercent(plan.percent) });
+              downloadResult = await runYtDlpDownload({ args: plan.args, id, onProgress: handleDownloadProgress });
+              logs = downloadResult.logs || logs || baseLogs;
+            } catch (retryErr) {
+              logs = retryErr?.logs || logs || baseLogs;
             }
-            downloadResult = await runYtDlpDownload({ args: universalArgs, id, onProgress: handleDownloadProgress });
-            logs = downloadResult.logs || logs || baseLogs;
-          } catch (retryErr) {
-            logs = retryErr?.logs || logs || baseLogs;
           }
         }
         if (!downloadResult) {

--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -5707,6 +5707,12 @@
         <i class="bi bi-grid-3x3-gap"></i>
         <span class="ms-2">Menu fitur</span>
       </button>
+      <a class="btn btn-danger d-inline-flex align-items-center ms-2" id="converterGuideBtn"
+        href="https://ytconvguide.vercel.app/" target="_blank" rel="noopener noreferrer"
+        aria-label="Buka Panduan Error converter">
+        <i class="bi bi-life-preserver"></i>
+        <span class="ms-2">Panduan Error</span>
+      </a>
       <button class="app-nav-btn d-inline-flex ms-2" type="button" id="ytMusicBtn" aria-label="Buka YT Music">
         <i class="bi bi-youtube"></i>
         <span class="ms-2">YT Music</span>


### PR DESCRIPTION
### Motivation

- Make media downloads more resilient by expanding and reordering yt-dlp format and runtime fallback attempts to handle common errors like unavailable formats or HTTP 4xx responses.  
- Reduce duplicate retry attempts and allow a no-JS-runtime fallback for environments where JS runtime or remote components cause failures.  
- Improve forum/login UX for mobile/in-app environments and popup-blocking browsers by providing clear fallback UI and a redirect-based Google Sign-In path.

### Description

- Update `download_with_ytdlp` in `download_audio.py` to change base `format` selectors, add `audio_opts` and `no_runtime_opts`, and extend the `attempts` list to try additional option sets including a no-JS-runtime fallback.  
- Add helper functions in `index.js`: `replaceYtDlpFormatSelector`, `removeYtDlpJsRuntimeArgs`, and `dedupeYtDlpArgPlans`, and refactor the yt-dlp retry logic into deduplicated labeled retry plans that try compatibility, audio-universal, automatic format, and no-JS-runtime variants.  
- Add frontend UI improvements in `index.html` and `public-ui/index.html`: insert a `Panduan Error` guide button, make forum Google login buttons explicitly `type="button"`, add a small fallback status element (`#forumLoginFallback`), and wire the forum login flows to the new `startFirebaseGoogleLogin` helper.  
- Implement client-side Google login helpers in the main UI script: `prefersGoogleRedirectLogin`, `startFirebaseGoogleLogin`, `appendFirebaseGoogleFallback`, `setForumLoginFallback`, and `resetForumLoginButton`, and update event handlers to use these helpers and show status to the user while trying popup vs redirect methods.

### Testing

- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52230495988331bb9d58999efc9054)