### PR TITLE
Add Deno as default yt-dlp JS runtime; improve yt-dlp fallbacks, error messages, and Google login UX

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
 FROM node:20-slim
 
-# Install ffmpeg, Python, yt-dlp, and PyTube
+# Install ffmpeg, Python, yt-dlp, PyTube, and Deno for yt-dlp JavaScript challenges.
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ffmpeg curl ca-certificates python3 python3-pip \
-  && python3 -m pip install --no-cache-dir --break-system-packages yt-dlp pytube \
+  && apt-get install -y --no-install-recommends ffmpeg curl unzip ca-certificates python3 python3-pip \
+  && curl -fsSL https://deno.land/install.sh | sh \
+  && install -m 0755 /root/.deno/bin/deno /usr/local/bin/deno \
+  && python3 -m pip install --no-cache-dir --break-system-packages "yt-dlp[default]" pytube \
   && rm -rf /var/lib/apt/lists/*
+
+ENV YTDLP_JS_RUNTIME=deno
 
 WORKDIR /app
 COPY package*.json ./

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -35,7 +35,7 @@ Use `/data` for persistent Railway volume data:
 - `CACHE_DIR=/data/ytconv/cache`
 - `TEMP_DIR=/tmp/ytconv-jobs`
 
-`YTDLP_PATH`, `FFMPEG_PATH`, and `FFPROBE_PATH` may be empty if binaries are on `PATH`. Configure `YTDLP_JS_RUNTIME=node` for the supported yt-dlp JavaScript runtime.
+`YTDLP_PATH`, `FFMPEG_PATH`, and `FFPROBE_PATH` may be empty if binaries are on `PATH`. Configure `YTDLP_JS_RUNTIME=deno` (default in Docker) for yt-dlp JavaScript challenge solving; use `auto` to fall back to Node >= 22 when Deno is unavailable.
 
 ## Security and abuse controls
 

--- a/download_audio.py
+++ b/download_audio.py
@@ -46,11 +46,21 @@ def get_youtube_extractor_args() -> Dict[str, Dict[str, list[str]]]:
 
 
 def get_js_runtime_options() -> Dict[str, object]:
-    runtime = os.environ.get("YTDLP_JS_RUNTIME", "node").strip().lower()
+    runtime = os.environ.get("YTDLP_JS_RUNTIME", "deno").strip().lower()
     if runtime in {"", "off", "none", "0"}:
         return {}
 
-    if runtime == "node":
+    selected = runtime
+    if runtime == "auto":
+        if shutil.which("deno"):
+            selected = "deno"
+        else:
+            selected = "node"
+
+    if selected == "deno" and not shutil.which("deno"):
+        selected = "node"
+
+    if selected == "node":
         node_bin = shutil.which("node")
         if not node_bin:
             print("node runtime not found; yt_dlp JS runtime disabled", file=sys.stderr)
@@ -65,8 +75,8 @@ def get_js_runtime_options() -> Dict[str, object]:
             return {}
 
     return {
-        "js_runtimes": {runtime: {}},
-        "remote_components": ["ejs:github"],
+        "js_runtimes": {selected: {}},
+        "remote_components": ["ejs:npm"],
         "extractor_retries": 3,
     }
 
@@ -164,7 +174,7 @@ def download_with_ytdlp(
 
     template = os.path.join(out_dir, f"{out_basename}.%(ext)s")
     base_opts = {
-        "format": "bestaudio/best",
+        "format": "ba/bestaudio/best/worst",
         "outtmpl": template,
         "restrictfilenames": False,
         "noplaylist": True,
@@ -191,8 +201,11 @@ def download_with_ytdlp(
     tv_opts = dict(base_opts)
     tv_opts["extractor_args"] = {"youtube": {"player_client": ["mweb", "web_safari", "tv_embedded", "android"]}}
 
+    audio_opts = dict(compat_opts)
+    audio_opts["format"] = "ba/bestaudio/best/worst"
+
     relaxed_opts = dict(compat_opts)
-    relaxed_opts["format"] = "best"
+    relaxed_opts["format"] = "best/worst"
 
     http_opts = dict(relaxed_opts)
     http_opts["format"] = "bestaudio[protocol^=http]/best[protocol^=http]/bestaudio/best/worst"
@@ -200,9 +213,13 @@ def download_with_ytdlp(
     universal_opts = dict(tv_opts)
     universal_opts.pop("format", None)
 
+    no_runtime_opts = dict(universal_opts)
+    no_runtime_opts.pop("js_runtimes", None)
+    no_runtime_opts.pop("remote_components", None)
+
     last_exc: Optional[Exception] = None
     upgrade_tried = False
-    attempts = [base_opts, compat_opts, tv_opts, relaxed_opts, http_opts, universal_opts]
+    attempts = [base_opts, compat_opts, tv_opts, audio_opts, relaxed_opts, http_opts, universal_opts, no_runtime_opts]
     for opts in attempts:
         try:
             with YoutubeDL(opts) as ydl:  # type: ignore[misc]

--- a/index.html
+++ b/index.html
@@ -5105,6 +5105,12 @@
         <i class="bi bi-grid-3x3-gap"></i>
         <span class="ms-2">Menu fitur</span>
       </button>
+      <a class="btn btn-danger d-none d-lg-inline-flex align-items-center ms-2" id="converterGuideBtn"
+        href="https://ytconvguide.vercel.app/" target="_blank" rel="noopener noreferrer"
+        aria-label="Buka Panduan Error converter">
+        <i class="bi bi-life-preserver"></i>
+        <span class="ms-2">Panduan Error</span>
+      </a>
       <button class="app-nav-btn d-inline-flex ms-2" type="button" id="ytMusicBtn" aria-label="Buka YT Music">
         <i class="bi bi-youtube"></i>
         <span class="ms-2">YT Music</span>
@@ -7823,6 +7829,14 @@
               <i class="bi bi-chevron-right modern-nav-arrow"></i>
             </button>
 
+            <!-- Panduan Error (mobile feature menu) -->
+            <a class="modern-nav-item d-lg-none" href="https://ytconvguide.vercel.app/" target="_blank"
+              rel="noopener noreferrer" aria-label="Buka Panduan Error converter">
+              <div class="modern-nav-icon"><i class="bi bi-life-preserver"></i></div>
+              <span class="modern-nav-label">Panduan Error</span>
+              <i class="bi bi-box-arrow-up-right modern-nav-arrow"></i>
+            </a>
+
             <!-- Divider -->
             <hr class="my-2 border-secondary-subtle opacity-25">
 
@@ -8178,12 +8192,15 @@
               <p class="text-secondary mb-4" style="max-width: 300px;">Diskusi seru, berbagi gambar, dan stiker dengan
                 warga lainnya.</p>
 
-              <button id="forumGoogleLoginBtn"
+              <button id="forumGoogleLoginBtn" type="button"
                 class="btn btn-light rounded-pill py-3 px-5 fw-bold d-flex align-items-center gap-3 shadow-lg hover-scale">
                 <img src="https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg" width="24" height="24"
                   alt="G">
                 <span>Masuk dengan Google</span>
               </button>
+              <div id="forumLoginFallback" class="small text-secondary mt-3" role="status" aria-live="polite">
+                Kalau tombol tidak merespons, tekan lagi untuk mode redirect.
+              </div>
             </div>
           </div>
 
@@ -10811,17 +10828,10 @@
 
           loginBtn.addEventListener('click', async () => {
             try {
-              const m = await waitForFirebase();
-              const { auth, signInWithPopup, signInWithRedirect, GoogleAuthProvider } = m;
+              await waitForFirebase();
               loginBtn.disabled = true;
-              loginBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>...';
-              const provider = new GoogleAuthProvider();
-              provider.setCustomParameters({ prompt: 'select_account' });
-              try {
-                await signInWithPopup(auth, provider);
-              } catch {
-                await signInWithRedirect(auth, provider);
-              }
+              loginBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>Membuka Google...';
+              await startFirebaseGoogleLogin({ status: (msg) => { loginBtn.innerHTML = `<span class="spinner-border spinner-border-sm me-2"></span>${msg}`; } });
             } catch {
               if (typeof window.setToast === 'function') window.setToast('Login gagal.', 'danger');
             } finally {
@@ -16451,6 +16461,85 @@
           }
         }
 
+        function prefersGoogleRedirectLogin() {
+          const ua = navigator.userAgent || '';
+          const isMobile = /Android|iPhone|iPad|iPod|IEMobile|Opera Mini/i.test(ua);
+          const isInApp = /FBAN|FBAV|Instagram|Line|TikTok|Twitter|WebView|wv\)/i.test(ua);
+          const isStandalone = window.matchMedia?.('(display-mode: standalone)')?.matches || navigator.standalone;
+          return Boolean(isMobile || isInApp || isStandalone);
+        }
+
+        async function startFirebaseGoogleLogin({ preferRedirect = prefersGoogleRedirectLogin(), status, pendingKey = '' } = {}) {
+          const setStatus = typeof status === 'function' ? status : () => { };
+          const modules = window.firebaseModules || await new Promise((resolve, reject) => {
+            let attempts = 0;
+            const timer = window.setInterval(() => {
+              attempts += 1;
+              if (window.firebaseModules?.auth) {
+                window.clearInterval(timer);
+                resolve(window.firebaseModules);
+              } else if (attempts > 40) {
+                window.clearInterval(timer);
+                reject(new Error('Firebase auth belum siap.'));
+              }
+            }, 250);
+          });
+
+          const { auth, signInWithPopup, signInWithRedirect, GoogleAuthProvider } = modules;
+          if (!auth || !GoogleAuthProvider || (!signInWithPopup && !signInWithRedirect)) {
+            throw new Error('Login Google belum siap di browser ini.');
+          }
+
+          const provider = new GoogleAuthProvider();
+          provider.setCustomParameters({ prompt: 'select_account' });
+
+          if (preferRedirect) {
+            if (!signInWithRedirect) throw new Error('Mode redirect Google tidak tersedia.');
+            if (pendingKey) sessionStorage.setItem(pendingKey, 'true');
+            setStatus('Mengalihkan ke Google Sign-In...');
+            await signInWithRedirect(auth, provider);
+            return null;
+          }
+
+          if (signInWithPopup) {
+            try {
+              setStatus('Membuka popup Google...');
+              return await signInWithPopup(auth, provider);
+            } catch (popupErr) {
+              console.warn('Popup Google gagal, pakai redirect', popupErr);
+            }
+          }
+
+          if (!signInWithRedirect) throw new Error('Popup diblokir dan mode redirect tidak tersedia.');
+          if (pendingKey) sessionStorage.setItem(pendingKey, 'true');
+          setStatus('Popup diblokir. Mengalihkan ke Google Sign-In...');
+          await signInWithRedirect(auth, provider);
+          return null;
+        }
+
+        function appendFirebaseGoogleFallback(container, id, label = 'Masuk mode mobile') {
+          if (!container || container.querySelector(`#${id}`)) return;
+          container.insertAdjacentHTML('beforeend', `
+            <button type="button" class="btn btn-link btn-sm text-decoration-none mt-2 px-0" id="${id}">
+              ${label}
+            </button>
+          `);
+          const btn = container.querySelector(`#${id}`);
+          if (!btn) return;
+          btn.addEventListener('click', async () => {
+            btn.disabled = true;
+            btn.textContent = 'Mengalihkan ke Google...';
+            try {
+              await startFirebaseGoogleLogin({ preferRedirect: true, status: (msg) => { btn.textContent = msg; } });
+            } catch (err) {
+              console.error('Fallback login gagal', err);
+              btn.disabled = false;
+              btn.textContent = label;
+              setToast(err?.message || translateMessage('Login gagal'));
+            }
+          });
+        }
+
         function renderGoogleFallback(messageKey) {
           if (!googleSignInButton) return;
           const message = translateMessage(
@@ -16468,8 +16557,17 @@
           const fallbackBtn = googleSignInButton.querySelector('#googleFallbackAction');
           if (fallbackBtn && !fallbackBtn.dataset.bound) {
             fallbackBtn.dataset.bound = 'true';
-            fallbackBtn.addEventListener('click', () => {
-              setToast(message);
+            fallbackBtn.addEventListener('click', async () => {
+              fallbackBtn.disabled = true;
+              fallbackBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>Mengalihkan ke Google...';
+              try {
+                await startFirebaseGoogleLogin({ preferRedirect: true });
+              } catch (err) {
+                console.error('Google fallback login gagal', err);
+                fallbackBtn.disabled = false;
+                fallbackBtn.innerHTML = `<i class="bi bi-google"></i><span>${translateMessage('Masuk dengan Google')}</span>`;
+                setToast(err?.message || message);
+              }
             });
           }
         }
@@ -16580,6 +16678,7 @@
               text: 'signin_with',
               shape: 'pill',
             });
+            appendFirebaseGoogleFallback(googleSignInButton, 'googleMobileFallbackAction');
           }
 
           const googleSignInForum = document.getElementById('googleSignInForum');
@@ -16604,6 +16703,7 @@
               shape: 'pill',
               width: '300'
             });
+            appendFirebaseGoogleFallback(profileGoogleLoginBtn, 'profileMobileFallbackAction');
           }
         }
 
@@ -28030,10 +28130,13 @@
               <h3 class="fw-bold mb-2 text-white" style="letter-spacing: -0.5px;">Gabung Forum</h3>
               <p class="text-secondary mb-4" style="max-width: 300px;">Diskusi seru, berbagi gambar, dan stiker dengan warga lainnya.</p>
               
-              <button id="forumGoogleLoginBtn" class="btn btn-light rounded-pill py-3 px-5 fw-bold d-flex align-items-center gap-3 shadow-lg hover-scale">
+              <button id="forumGoogleLoginBtn" type="button" class="btn btn-light rounded-pill py-3 px-5 fw-bold d-flex align-items-center gap-3 shadow-lg hover-scale">
                   <img src="https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg" width="24" height="24" alt="G">
                   <span>Masuk dengan Google</span>
-              </button>`;
+              </button>
+              <div id="forumLoginFallback" class="small text-secondary mt-3" role="status" aria-live="polite">
+                Kalau tombol tidak merespons, tekan lagi untuk mode redirect.
+              </div>`;
             const newBtn = document.getElementById('forumGoogleLoginBtn');
             if (newBtn) newBtn.addEventListener('click', handleLoginClick);
           }
@@ -28859,33 +28962,50 @@
             });
           }
 
-          async function handleLoginClick() {
-            // ... (Keep existing login logic mostly same but ensure new UI is handled)
+          function setForumLoginFallback(message, variant = 'secondary') {
+            const fallback = document.getElementById('forumLoginFallback');
+            if (!fallback) return;
+            fallback.className = `small text-${variant} mt-3`;
+            fallback.textContent = message;
+          }
+
+          function resetForumLoginButton() {
             const btn = document.getElementById('forumGoogleLoginBtn');
             if (!btn) return;
-            if (!window.firebaseModules || !window.firebaseModules.auth) return;
-            const { auth, signInWithPopup, GoogleAuthProvider, signInWithRedirect } = window.firebaseModules;
-            btn.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>...';
+            btn.disabled = false;
+            btn.innerHTML = '<img src="https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg" width="24" height="24" alt="G"><span>Masuk dengan Google</span>';
+          }
+
+          async function handleLoginClick() {
+            const btn = document.getElementById('forumGoogleLoginBtn');
+            if (!btn) return;
+            if (!window.firebaseModules || !window.firebaseModules.auth) {
+              setForumLoginFallback('Login sedang dimuat. Tunggu sebentar lalu tekan lagi.', 'warning');
+              return;
+            }
+
+            btn.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>Membuka Google...';
             btn.disabled = true;
+            setForumLoginFallback(prefersGoogleRedirectLogin()
+              ? 'Mode mobile aktif. Mengalihkan ke Google Sign-In...'
+              : 'Jika popup tidak muncul, sistem otomatis memakai mode redirect.', 'info');
+
             try {
-              const provider = new GoogleAuthProvider();
-              provider.setCustomParameters({ prompt: 'select_account' });
-              try {
-                const result = await signInWithPopup(auth, provider);
-                if (result && result.user) {
-                  setToast('Login berhasil!', 'success');
-                  sessionStorage.removeItem('forum_login_pending');
-                  forumLoginOverlay.classList.remove('d-flex');
-                  forumLoginOverlay.classList.add('d-none');
-                }
-              } catch (popupErr) {
-                sessionStorage.setItem('forum_login_pending', 'true');
-                await signInWithRedirect(auth, provider);
+              const result = await startFirebaseGoogleLogin({
+                pendingKey: 'forum_login_pending',
+                status: (msg) => setForumLoginFallback(msg, 'info'),
+              });
+              if (result && result.user) {
+                setToast('Login berhasil!', 'success');
+                sessionStorage.removeItem('forum_login_pending');
+                forumLoginOverlay.classList.remove('d-flex');
+                forumLoginOverlay.classList.add('d-none');
               }
             } catch (error) {
-              console.error(error);
-              btn.innerHTML = 'Login Google';
-              btn.disabled = false;
+              console.error('Forum login failed', error);
+              sessionStorage.removeItem('forum_login_pending');
+              setForumLoginFallback(error?.message || 'Login belum bisa dibuka. Muat ulang halaman atau izinkan popup/redirect Google.', 'danger');
+              resetForumLoginButton();
             }
           }
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 import express from "express";
 import compression from "compression";
 import cors from "cors";
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readdirSync } from "node:fs";
 import { promises as fsp } from "node:fs";
 import { createServer, request as httpRequest } from "node:http";
@@ -3089,13 +3089,14 @@ const runYtDlpAttempt = (command, args, { label }) =>
 
 const categorizeYtDlpError = (value = "") => {
   const raw = String(value || "");
+  if (/429|too many requests|rate.?limit/i.test(raw)) return "RATE_LIMITED";
   if (/sign in to confirm|not a bot|bot check|use --cookies|cookies-from-browser|confirm you(?:\'|’)re not a bot/i.test(raw)) return "BOT_CHECK";
   if (/login required|sign in|private video|members-only|account/i.test(raw)) return "LOGIN_REQUIRED";
   if (/age[- ]?restricted|confirm your age|age restriction/i.test(raw)) return "AGE_RESTRICTED";
   if (/not available in your country|geo|region/i.test(raw)) return "GEO_BLOCKED";
   if (/private video/i.test(raw)) return "PRIVATE_VIDEO";
-  if (/requested format is not available|no video formats|only images are available|format/i.test(raw)) return "FORMAT_UNAVAILABLE";
-  if (/429|too many requests|rate.?limit/i.test(raw)) return "RATE_LIMITED";
+  if (/JS runtimes:\s*none|No supported JavaScript runtime|JavaScript runtime could be found|js runtime/i.test(raw)) return "JS_RUNTIME_MISSING";
+  if (/requested format is not available|no video formats|only images are available|Use --list-formats/i.test(raw)) return "FORMAT_UNAVAILABLE";
   if (/ffmpeg/i.test(raw)) return "FFMPEG_MISSING";
   if (/yt-dlp tidak bisa dijalankan|yt-dlp.*not found|no such file/i.test(raw)) return "YTDLP_MISSING";
   if (/network|timed?out|econn|enotfound|http error 5\d\d/i.test(raw)) return "NETWORK_ERROR";
@@ -3124,13 +3125,26 @@ const publicDownloadError = (err) => {
   const logs = err?.logs || err?.message || "";
   const category = err?.errorCategory || categorizeYtDlpError(logs);
   const needsAdminCookies = ["BOT_CHECK", "LOGIN_REQUIRED", "AGE_RESTRICTED"].includes(category);
-  const message = needsAdminCookies
-    ? "Video membutuhkan cookies YouTube terbaru. Admin perlu memperbarui cookies di Admin Cookies Manager."
-    : (err?.message || "Gagal memproses video");
+  const messages = {
+    RATE_LIMITED: "YouTube sedang membatasi koneksi dari server ini. Coba lagi nanti, kurangi percobaan berulang, atau gunakan server/IP lain.",
+    BOT_CHECK: "YouTube meminta verifikasi bot dari koneksi server. Cookies login tidak diterima atau sudah kedaluwarsa.",
+    LOGIN_REQUIRED: "YouTube meminta login. Cookies login tidak diterima atau sudah tidak berlaku.",
+    AGE_RESTRICTED: "Video membutuhkan verifikasi umur. Admin perlu memperbarui cookies YouTube yang valid.",
+    JS_RUNTIME_MISSING: "JavaScript runtime yt-dlp belum tersedia. Pasang Deno/EJS atau set YTDLP_JS_RUNTIME yang valid.",
+    FORMAT_UNAVAILABLE: "Format YouTube yang tersedia berubah atau tidak bisa dibaca. Sistem sudah mencoba format fallback; coba lagi nanti atau pakai Panduan Error.",
+  };
+  const message = messages[category] || err?.message || "Gagal memproses video";
+  const hints = {
+    RATE_LIMITED: "Server/IP kemungkinan terkena rate limit YouTube. Hindari retry bertubi-tubi; pindah IP/server jika 429 tetap muncul.",
+    BOT_CHECK: "Admin: upload cookies Netscape baru dari sesi incognito YouTube, tutup sesi setelah ekspor, lalu jalankan Test Cookies.",
+    LOGIN_REQUIRED: "Admin: perbarui cookies YouTube dari sesi login yang masih valid dan pastikan format Netscape LF.",
+    AGE_RESTRICTED: "Admin: gunakan cookies akun cadangan yang sudah lolos verifikasi umur.",
+    JS_RUNTIME_MISSING: "Deploy image terbaru yang memasang Deno dan yt-dlp[default], atau set YTDLP_JS_RUNTIME=deno.",
+  };
   const wrapped = new Error(message);
   wrapped.errorCategory = category;
-  wrapped.adminActionRequired = needsAdminCookies;
-  wrapped.hint = needsAdminCookies ? "Admin: buka Admin Cookies Manager, upload cookies Netscape terbaru, lalu jalankan Test Cookies." : undefined;
+  wrapped.adminActionRequired = Boolean(needsAdminCookies || category === "RATE_LIMITED" || category === "JS_RUNTIME_MISSING");
+  wrapped.hint = hints[category];
   wrapped.logs = logs;
   return wrapped;
 };
@@ -7192,18 +7206,38 @@ const parseMajorVersion = (value = "") => {
   return match ? Number(match[1]) : 0;
 };
 
+const commandExistsSync = (cmd = "") => {
+  if (!cmd) return false;
+  const result = spawnSync(cmd, ["--version"], { stdio: "ignore" });
+  return !result.error;
+};
+
 const getYtDlpJsRuntimeArgs = () => {
-  const runtime = String(process.env.YTDLP_JS_RUNTIME || "node").trim().toLowerCase();
+  const runtime = String(process.env.YTDLP_JS_RUNTIME || "deno").trim().toLowerCase();
   if (runtime === "off" || runtime === "none" || runtime === "0") return [];
 
   const nodeMajor = parseMajorVersion(process.version);
-  const selected = runtime || "node";
+  let selected = runtime || "deno";
+  if (selected === "auto") {
+    if (commandExistsSync("deno")) selected = "deno";
+    else if (nodeMajor >= 22) selected = "node";
+    else selected = "";
+  }
+
+  if (selected === "deno" && !commandExistsSync("deno")) {
+    if (nodeMajor >= 22) selected = "node";
+    else {
+      console.warn("[yt-dlp] Deno is not installed and Node is below yt-dlp JS runtime minimum; skipping --js-runtimes");
+      return [];
+    }
+  }
   if (selected === "node" && nodeMajor < 22) {
     console.warn(`[yt-dlp] Node ${process.version} is below yt-dlp 2026.06.09 minimum for JS runtime; skipping --js-runtimes node`);
     return [];
   }
+  if (!selected) return [];
 
-  return ["--js-runtimes", selected, "--remote-components", "ejs:github", "--extractor-retries", "3"];
+  return ["--js-runtimes", selected, "--remote-components", "ejs:npm", "--extractor-retries", "3"];
 };
 
 
@@ -7230,6 +7264,49 @@ const pushYoutubeExtractorArgs = (args = []) => {
     args.push("--extractor-args", value);
   }
   return args;
+};
+
+const replaceYtDlpFormatSelector = (args = [], selector = "") => {
+  const next = Array.isArray(args) ? [...args] : [];
+  const url = next[next.length - 1];
+  const isUrlLike = typeof url === "string" && /^(https?:|ytsearch|ytmsearch)/i.test(url);
+  const urlArg = isUrlLike ? next.pop() : null;
+  let replaced = false;
+  for (let i = 0; i < next.length - 1; i++) {
+    if (next[i] === "-f" && typeof next[i + 1] === "string") {
+      if (selector) next[i + 1] = selector;
+      else next.splice(i, 2);
+      replaced = true;
+      break;
+    }
+  }
+  if (!replaced && selector) next.push("-f", selector);
+  if (urlArg) next.push(urlArg);
+  return next;
+};
+
+const removeYtDlpJsRuntimeArgs = (args = []) => {
+  const next = [];
+  const source = Array.isArray(args) ? args : [];
+  for (let i = 0; i < source.length; i++) {
+    const item = source[i];
+    if (["--js-runtimes", "--remote-components", "--extractor-retries"].includes(item)) {
+      i += 1;
+      continue;
+    }
+    next.push(item);
+  }
+  return next;
+};
+
+const dedupeYtDlpArgPlans = (plans = []) => {
+  const seen = new Set();
+  return plans.filter((plan) => {
+    const key = JSON.stringify(plan.args || []);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
 };
 
 const buildYtDlpFallbackArgs = (args = []) => {
@@ -7742,6 +7819,7 @@ const convertSingle = async (payload = {}) => {
 
     let logs = "";
     let downloadResult = null;
+    let lastDownloadErrorCategory = "";
 
     // Untuk Spotify: metadata dari spotDL, download dari YouTube Music/YouTube via yt-dlp
     // Preview URL hanya untuk metadata, tidak digunakan untuk download
@@ -7753,6 +7831,7 @@ const convertSingle = async (payload = {}) => {
       } catch (err) {
         const baseLogs = err.logs || "";
         const errorCategory = categorizeYtDlpError(baseLogs || err?.message || "");
+        lastDownloadErrorCategory = errorCategory;
         const shouldRetryWithFallbackArgs = /Requested format is not available|HTTP Error 400|HTTP Error 403|Forbidden|Sign in|cookies|confirm your age|precondition|This video is unavailable/i.test(baseLogs || "") || isCookieRetryCategory(errorCategory);
         if (isCookieRetryCategory(errorCategory)) {
           const cookieRetry = await appendServerCookiesArgs(args);
@@ -7769,32 +7848,33 @@ const convertSingle = async (payload = {}) => {
           }
         }
         if (!downloadResult && shouldRetryWithFallbackArgs) {
-          try {
-            emitProgress({ stage: "downloading", message: "Mencoba mode kompatibilitas", percent: mapDownloadPercent(18) });
-            const fallbackArgs = buildYtDlpFallbackArgs(args);
-            downloadResult = await runYtDlpDownload({ args: fallbackArgs, id, onProgress: handleDownloadProgress });
-            logs = downloadResult.logs || baseLogs;
-          } catch (retryErr) {
-            logs = retryErr?.logs || logs || baseLogs;
-          }
-        }
-        if (!downloadResult && shouldRetryWithFallbackArgs) {
-          try {
-            emitProgress({ stage: "downloading", message: "Mencoba format universal", percent: mapDownloadPercent(19) });
-            const universalArgs = buildYtDlpFallbackArgs(args);
-            for (let i = 0; i < universalArgs.length - 1; i++) {
-              if (universalArgs[i] === "-f") {
-                universalArgs.splice(i, 2);
-                break;
-              }
+          const retryPlans = dedupeYtDlpArgPlans([
+            { label: "mode kompatibilitas", percent: 18, args: buildYtDlpFallbackArgs(args) },
+            { label: "audio universal", percent: 19, args: replaceYtDlpFormatSelector(buildYtDlpFallbackArgs(args), "ba/bestaudio/best/worst") },
+            { label: "format otomatis", percent: 20, args: replaceYtDlpFormatSelector(buildYtDlpFallbackArgs(args), "") },
+            { label: "format otomatis tanpa JS runtime", percent: 21, args: removeYtDlpJsRuntimeArgs(replaceYtDlpFormatSelector(buildYtDlpFallbackArgs(args), "")) },
+          ]);
+
+          for (const plan of retryPlans) {
+            if (downloadResult) break;
+            try {
+              emitProgress({ stage: "downloading", message: `Mencoba ${plan.label}`, percent: mapDownloadPercent(plan.percent) });
+              downloadResult = await runYtDlpDownload({ args: plan.args, id, onProgress: handleDownloadProgress });
+              logs = downloadResult.logs || logs || baseLogs;
+            } catch (retryErr) {
+              logs = retryErr?.logs || logs || baseLogs;
+              lastDownloadErrorCategory = categorizeYtDlpError(logs);
             }
-            downloadResult = await runYtDlpDownload({ args: universalArgs, id, onProgress: handleDownloadProgress });
-            logs = downloadResult.logs || logs || baseLogs;
-          } catch (retryErr) {
-            logs = retryErr?.logs || logs || baseLogs;
           }
         }
         if (!downloadResult) {
+          if (["RATE_LIMITED", "BOT_CHECK"].includes(lastDownloadErrorCategory)) {
+            if (coverPath) try { await fsp.unlink(coverPath); } catch { }
+            const restrictedError = new Error(err.message || "YouTube membatasi koneksi server");
+            restrictedError.logs = [logs, baseLogs].filter(Boolean).join("\n").slice(-8000);
+            restrictedError.errorCategory = lastDownloadErrorCategory;
+            throw restrictedError;
+          }
           if (isVideoFormat) {
             if (coverPath) try { await fsp.unlink(coverPath); } catch { }
             const videoError = new Error(err.message || "Gagal mengunduh video");

--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -5707,6 +5707,12 @@
         <i class="bi bi-grid-3x3-gap"></i>
         <span class="ms-2">Menu fitur</span>
       </button>
+      <a class="btn btn-danger d-none d-lg-inline-flex align-items-center ms-2" id="converterGuideBtn"
+        href="https://ytconvguide.vercel.app/" target="_blank" rel="noopener noreferrer"
+        aria-label="Buka Panduan Error converter">
+        <i class="bi bi-life-preserver"></i>
+        <span class="ms-2">Panduan Error</span>
+      </a>
       <button class="app-nav-btn d-inline-flex ms-2" type="button" id="ytMusicBtn" aria-label="Buka YT Music">
         <i class="bi bi-youtube"></i>
         <span class="ms-2">YT Music</span>
@@ -8554,6 +8560,14 @@
               <span class="modern-nav-label">Bantuan</span>
               <i class="bi bi-chevron-right modern-nav-arrow"></i>
             </button>
+
+            <!-- Panduan Error (mobile feature menu) -->
+            <a class="modern-nav-item d-lg-none" href="https://ytconvguide.vercel.app/" target="_blank"
+              rel="noopener noreferrer" aria-label="Buka Panduan Error converter">
+              <div class="modern-nav-icon"><i class="bi bi-life-preserver"></i></div>
+              <span class="modern-nav-label">Panduan Error</span>
+              <i class="bi bi-box-arrow-up-right modern-nav-arrow"></i>
+            </a>
 
             <!-- Divider -->
             <hr class="my-2 border-secondary-subtle opacity-25">

--- a/src/lib/env.js
+++ b/src/lib/env.js
@@ -138,7 +138,7 @@ export const loadEnv = (rawEnv = process.env) => {
     INTERNAL_API_KEY: str(rawEnv.INTERNAL_API_KEY),
     INTERNAL_REQUEST_TIMEOUT_MS: int(rawEnv.INTERNAL_REQUEST_TIMEOUT_MS, 15_000, { min: 500, max: 120_000 }),
 
-    YTDLP_JS_RUNTIME: str(rawEnv.YTDLP_JS_RUNTIME, "node"),
+    YTDLP_JS_RUNTIME: str(rawEnv.YTDLP_JS_RUNTIME, "deno"),
     YTDLP_PATH: str(rawEnv.YTDLP_PATH),
     FFMPEG_PATH: str(rawEnv.FFMPEG_PATH),
     FFPROBE_PATH: str(rawEnv.FFPROBE_PATH),


### PR DESCRIPTION
### Motivation
- Provide a preinstalled JavaScript runtime (Deno) in the Docker image so yt-dlp can solve JavaScript extractor challenges reliably. 
- Make JS runtime selection and yt-dlp retry logic more robust to reduce failed downloads and clarify actionable errors. 
- Improve user experience for forum/Google sign-in with popup/redirect fallbacks and clearer UI feedback. 

### Description
- Docker: install Deno, add `unzip`, install `yt-dlp[default]`/`pytube`, and set `YTDLP_JS_RUNTIME=deno` in the image; also expose app startup unchanged. 
- Environment/docs: change default `YTDLP_JS_RUNTIME` to `deno` and update `docs/ENVIRONMENT.md` to document `deno` default and `auto` fallback behavior. 
- Python side (`download_audio.py`): default to `deno`, add `auto` selection and fallback to `node` if needed, switch remote components to `ejs:npm`, refine format selectors and add an explicit no-JS-runtime attempt in the extractor attempts order. 
- Node/server (`index.js` and `src/lib/env.js`): default `YTDLP_JS_RUNTIME` to `deno`, add `commandExistsSync` and improved runtime selection (including `auto`), implement helpers to manipulate yt-dlp arg plans (`replaceYtDlpFormatSelector`, `removeYtDlpJsRuntimeArgs`, `dedupeYtDlpArgPlans`), expand yt-dlp retry plans, enhance error categorization (add `JS_RUNTIME_MISSING`, reorder rate-limit detection), and produce clearer public/admin error messages and hints. 
- UI (`index.html`, `public-ui/index.html`): add a "Panduan Error" (error guide) button/link, improve forum login overlay with spinner/status text and a small fallback hint, and add a robust Firebase/Google sign-in fallback flow (`startFirebaseGoogleLogin`, `appendFirebaseGoogleFallback`) that prefers redirect mode on mobile/in-app contexts. 

### Testing
- Ran the project's JavaScript test and lint commands (`npm test`, `npm run lint`) and they completed without failures. 
- Performed a local Docker build (`docker build .`) to verify Deno and yt-dlp installation steps in the `Dockerfile` complete successfully. 
- Performed a lightweight smoke start of the server to confirm startup logs and that the enhanced yt-dlp/runtime selection paths are exercised during a sample conversion attempt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52230495988331bb9d58999efc9054)