### PR TITLE
Add Deno-based yt-dlp runtime, improve yt-dlp fallbacks and friendly errors, and enhance UI login/fallbacks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
 FROM node:20-slim
 
-# Install ffmpeg, Python, yt-dlp, and PyTube
+# Install ffmpeg, Python, yt-dlp, PyTube, and Deno for yt-dlp JavaScript challenges.
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ffmpeg curl ca-certificates python3 python3-pip \
-  && python3 -m pip install --no-cache-dir --break-system-packages yt-dlp pytube \
+  && apt-get install -y --no-install-recommends ffmpeg curl unzip ca-certificates python3 python3-pip \
+  && curl -fsSL https://deno.land/install.sh | sh \
+  && install -m 0755 /root/.deno/bin/deno /usr/local/bin/deno \
+  && python3 -m pip install --no-cache-dir --break-system-packages "yt-dlp[default]" pytube \
   && rm -rf /var/lib/apt/lists/*
+
+ENV YTDLP_JS_RUNTIME=deno
 
 WORKDIR /app
 COPY package*.json ./

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -35,7 +35,7 @@ Use `/data` for persistent Railway volume data:
 - `CACHE_DIR=/data/ytconv/cache`
 - `TEMP_DIR=/tmp/ytconv-jobs`
 
-`YTDLP_PATH`, `FFMPEG_PATH`, and `FFPROBE_PATH` may be empty if binaries are on `PATH`. Configure `YTDLP_JS_RUNTIME=node` for the supported yt-dlp JavaScript runtime.
+`YTDLP_PATH`, `FFMPEG_PATH`, and `FFPROBE_PATH` may be empty if binaries are on `PATH`. Configure `YTDLP_JS_RUNTIME=deno` (default in Docker) for yt-dlp JavaScript challenge solving; use `auto` to fall back to Node >= 22 when Deno is unavailable.
 
 ## Security and abuse controls
 

--- a/download_audio.py
+++ b/download_audio.py
@@ -46,11 +46,21 @@ def get_youtube_extractor_args() -> Dict[str, Dict[str, list[str]]]:
 
 
 def get_js_runtime_options() -> Dict[str, object]:
-    runtime = os.environ.get("YTDLP_JS_RUNTIME", "node").strip().lower()
+    runtime = os.environ.get("YTDLP_JS_RUNTIME", "deno").strip().lower()
     if runtime in {"", "off", "none", "0"}:
         return {}
 
-    if runtime == "node":
+    selected = runtime
+    if runtime == "auto":
+        if shutil.which("deno"):
+            selected = "deno"
+        else:
+            selected = "node"
+
+    if selected == "deno" and not shutil.which("deno"):
+        selected = "node"
+
+    if selected == "node":
         node_bin = shutil.which("node")
         if not node_bin:
             print("node runtime not found; yt_dlp JS runtime disabled", file=sys.stderr)
@@ -65,8 +75,8 @@ def get_js_runtime_options() -> Dict[str, object]:
             return {}
 
     return {
-        "js_runtimes": {runtime: {}},
-        "remote_components": ["ejs:github"],
+        "js_runtimes": {selected: {}},
+        "remote_components": ["ejs:npm"],
         "extractor_retries": 3,
     }
 
@@ -164,7 +174,7 @@ def download_with_ytdlp(
 
     template = os.path.join(out_dir, f"{out_basename}.%(ext)s")
     base_opts = {
-        "format": "bestaudio/best",
+        "format": "ba/bestaudio/best/worst",
         "outtmpl": template,
         "restrictfilenames": False,
         "noplaylist": True,
@@ -191,8 +201,11 @@ def download_with_ytdlp(
     tv_opts = dict(base_opts)
     tv_opts["extractor_args"] = {"youtube": {"player_client": ["mweb", "web_safari", "tv_embedded", "android"]}}
 
+    audio_opts = dict(compat_opts)
+    audio_opts["format"] = "ba/bestaudio/best/worst"
+
     relaxed_opts = dict(compat_opts)
-    relaxed_opts["format"] = "best"
+    relaxed_opts["format"] = "best/worst"
 
     http_opts = dict(relaxed_opts)
     http_opts["format"] = "bestaudio[protocol^=http]/best[protocol^=http]/bestaudio/best/worst"
@@ -200,9 +213,13 @@ def download_with_ytdlp(
     universal_opts = dict(tv_opts)
     universal_opts.pop("format", None)
 
+    no_runtime_opts = dict(universal_opts)
+    no_runtime_opts.pop("js_runtimes", None)
+    no_runtime_opts.pop("remote_components", None)
+
     last_exc: Optional[Exception] = None
     upgrade_tried = False
-    attempts = [base_opts, compat_opts, tv_opts, relaxed_opts, http_opts, universal_opts]
+    attempts = [base_opts, compat_opts, tv_opts, audio_opts, relaxed_opts, http_opts, universal_opts, no_runtime_opts]
     for opts in attempts:
         try:
             with YoutubeDL(opts) as ydl:  # type: ignore[misc]

--- a/index.html
+++ b/index.html
@@ -2434,6 +2434,12 @@
       display: block;
     }
 
+    #previewWrap .preview-visual.ytmusic-square-cover {
+      max-width: 360px;
+      margin-left: auto;
+      margin-right: auto;
+    }
+
     #previewWrap .preview-visual::after {
       content: "";
       position: absolute;
@@ -5105,6 +5111,12 @@
         <i class="bi bi-grid-3x3-gap"></i>
         <span class="ms-2">Menu fitur</span>
       </button>
+      <a class="btn btn-danger d-none d-lg-inline-flex align-items-center ms-2" id="converterGuideBtn"
+        href="https://ytconvguide.vercel.app/" target="_blank" rel="noopener noreferrer"
+        aria-label="Buka Panduan Error converter">
+        <i class="bi bi-life-preserver"></i>
+        <span class="ms-2">Panduan Error</span>
+      </a>
       <button class="app-nav-btn d-inline-flex ms-2" type="button" id="ytMusicBtn" aria-label="Buka YT Music">
         <i class="bi bi-youtube"></i>
         <span class="ms-2">YT Music</span>
@@ -7823,6 +7835,14 @@
               <i class="bi bi-chevron-right modern-nav-arrow"></i>
             </button>
 
+            <!-- Panduan Error (mobile feature menu) -->
+            <a class="modern-nav-item d-lg-none" href="https://ytconvguide.vercel.app/" target="_blank"
+              rel="noopener noreferrer" aria-label="Buka Panduan Error converter">
+              <div class="modern-nav-icon"><i class="bi bi-life-preserver"></i></div>
+              <span class="modern-nav-label">Panduan Error</span>
+              <i class="bi bi-box-arrow-up-right modern-nav-arrow"></i>
+            </a>
+
             <!-- Divider -->
             <hr class="my-2 border-secondary-subtle opacity-25">
 
@@ -8178,12 +8198,15 @@
               <p class="text-secondary mb-4" style="max-width: 300px;">Diskusi seru, berbagi gambar, dan stiker dengan
                 warga lainnya.</p>
 
-              <button id="forumGoogleLoginBtn"
+              <button id="forumGoogleLoginBtn" type="button"
                 class="btn btn-light rounded-pill py-3 px-5 fw-bold d-flex align-items-center gap-3 shadow-lg hover-scale">
                 <img src="https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg" width="24" height="24"
                   alt="G">
                 <span>Masuk dengan Google</span>
               </button>
+              <div id="forumLoginFallback" class="small text-secondary mt-3" role="status" aria-live="polite">
+                Kalau tombol tidak merespons, tekan lagi untuk mode redirect.
+              </div>
             </div>
           </div>
 
@@ -10811,17 +10834,10 @@
 
           loginBtn.addEventListener('click', async () => {
             try {
-              const m = await waitForFirebase();
-              const { auth, signInWithPopup, signInWithRedirect, GoogleAuthProvider } = m;
+              await waitForFirebase();
               loginBtn.disabled = true;
-              loginBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>...';
-              const provider = new GoogleAuthProvider();
-              provider.setCustomParameters({ prompt: 'select_account' });
-              try {
-                await signInWithPopup(auth, provider);
-              } catch {
-                await signInWithRedirect(auth, provider);
-              }
+              loginBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>Membuka Google...';
+              await startFirebaseGoogleLogin({ status: (msg) => { loginBtn.innerHTML = `<span class="spinner-border spinner-border-sm me-2"></span>${msg}`; } });
             } catch {
               if (typeof window.setToast === 'function') window.setToast('Login gagal.', 'danger');
             } finally {
@@ -13544,19 +13560,52 @@
           return next;
         };
 
+        const converterErrorMessages = {
+          RATE_LIMITED: 'YouTube sedang membatasi koneksi dari server ini. Coba lagi nanti, jangan spam retry, atau gunakan server/IP lain.',
+          BOT_CHECK: 'YouTube meminta verifikasi bot dari koneksi server. Cookies login tidak diterima atau sudah kedaluwarsa.',
+          LOGIN_REQUIRED: 'YouTube meminta login. Cookies YouTube perlu diperbarui oleh admin.',
+          AGE_RESTRICTED: 'Video membutuhkan verifikasi umur. Admin perlu memperbarui cookies YouTube yang valid.',
+          JS_RUNTIME_MISSING: 'JavaScript runtime yt-dlp belum tersedia. Deploy image terbaru yang memasang Deno/EJS.',
+          FORMAT_UNAVAILABLE: 'Format YouTube tidak bisa dibaca dari server ini. Sistem sudah mencoba fallback; cek Panduan Error kalau tetap gagal.',
+          INVALID_URL: 'Link belum valid atau domain belum didukung.',
+          QUEUE_FULL: 'Antrian server sedang penuh. Tunggu sebentar lalu coba lagi.',
+        };
+
+        const isGenericConverterError = (message = '') => /^(yt-dlp gagal|gagal memproses|terjadi kesalahan|gagal membuat job)$/i.test(String(message || '').trim());
+
+        const buildApiErrorMessage = (payload = {}, rawText = '', fallbackMessage = 'Terjadi kesalahan') => {
+          const errorObj = payload && typeof payload.error === 'object' ? payload.error : {};
+          const category = payload.errorCategory || errorObj.code || errorObj.errorCategory || '';
+          const rawMessage = typeof payload.error === 'string'
+            ? payload.error
+            : (payload.message || errorObj.message || (rawText ? String(rawText).trim().slice(0, 280) : '') || fallbackMessage);
+          const message = (category && (isGenericConverterError(rawMessage) || !rawMessage))
+            ? (converterErrorMessages[category] || rawMessage || fallbackMessage)
+            : rawMessage;
+          return {
+            message: message || fallbackMessage,
+            category,
+            hint: payload.hint || errorObj.hint || '',
+            adminActionRequired: Boolean(payload.adminActionRequired || errorObj.adminActionRequired),
+          };
+        };
+
         const resolveJsonResponse = async (resp, { fallbackMessage = 'Terjadi kesalahan', logLabel = '' } = {}) => {
           const safe = await readJsonSafe(resp);
           const payload = safe.data && typeof safe.data === 'object' ? safe.data : {};
-          if (!resp?.ok) {
+          if (!resp?.ok || payload.ok === false || payload.success === false) {
             const raw = (safe.rawText || '').trim();
             if (safe.parseError) {
               console?.warn?.('[json] gagal parsing', { label: logLabel || resp?.url, error: safe.parseError, raw });
             }
-            const message = payload.error || payload.message || (raw ? raw.slice(0, 280) : '') || fallbackMessage;
-            const err = new Error(message || fallbackMessage);
+            const friendly = buildApiErrorMessage(payload, raw, fallbackMessage);
+            const err = new Error(friendly.message);
             err.status = resp?.status;
             err.payload = payload;
             err.rawText = safe.rawText;
+            err.errorCategory = friendly.category;
+            err.hint = friendly.hint;
+            err.adminActionRequired = friendly.adminActionRequired;
             throw err;
           }
           if (safe.parseError) {
@@ -16451,6 +16500,85 @@
           }
         }
 
+        function prefersGoogleRedirectLogin() {
+          const ua = navigator.userAgent || '';
+          const isMobile = /Android|iPhone|iPad|iPod|IEMobile|Opera Mini/i.test(ua);
+          const isInApp = /FBAN|FBAV|Instagram|Line|TikTok|Twitter|WebView|wv\)/i.test(ua);
+          const isStandalone = window.matchMedia?.('(display-mode: standalone)')?.matches || navigator.standalone;
+          return Boolean(isMobile || isInApp || isStandalone);
+        }
+
+        async function startFirebaseGoogleLogin({ preferRedirect = prefersGoogleRedirectLogin(), status, pendingKey = '' } = {}) {
+          const setStatus = typeof status === 'function' ? status : () => { };
+          const modules = window.firebaseModules || await new Promise((resolve, reject) => {
+            let attempts = 0;
+            const timer = window.setInterval(() => {
+              attempts += 1;
+              if (window.firebaseModules?.auth) {
+                window.clearInterval(timer);
+                resolve(window.firebaseModules);
+              } else if (attempts > 40) {
+                window.clearInterval(timer);
+                reject(new Error('Firebase auth belum siap.'));
+              }
+            }, 250);
+          });
+
+          const { auth, signInWithPopup, signInWithRedirect, GoogleAuthProvider } = modules;
+          if (!auth || !GoogleAuthProvider || (!signInWithPopup && !signInWithRedirect)) {
+            throw new Error('Login Google belum siap di browser ini.');
+          }
+
+          const provider = new GoogleAuthProvider();
+          provider.setCustomParameters({ prompt: 'select_account' });
+
+          if (preferRedirect) {
+            if (!signInWithRedirect) throw new Error('Mode redirect Google tidak tersedia.');
+            if (pendingKey) sessionStorage.setItem(pendingKey, 'true');
+            setStatus('Mengalihkan ke Google Sign-In...');
+            await signInWithRedirect(auth, provider);
+            return null;
+          }
+
+          if (signInWithPopup) {
+            try {
+              setStatus('Membuka popup Google...');
+              return await signInWithPopup(auth, provider);
+            } catch (popupErr) {
+              console.warn('Popup Google gagal, pakai redirect', popupErr);
+            }
+          }
+
+          if (!signInWithRedirect) throw new Error('Popup diblokir dan mode redirect tidak tersedia.');
+          if (pendingKey) sessionStorage.setItem(pendingKey, 'true');
+          setStatus('Popup diblokir. Mengalihkan ke Google Sign-In...');
+          await signInWithRedirect(auth, provider);
+          return null;
+        }
+
+        function appendFirebaseGoogleFallback(container, id, label = 'Masuk mode mobile') {
+          if (!container || container.querySelector(`#${id}`)) return;
+          container.insertAdjacentHTML('beforeend', `
+            <button type="button" class="btn btn-link btn-sm text-decoration-none mt-2 px-0" id="${id}">
+              ${label}
+            </button>
+          `);
+          const btn = container.querySelector(`#${id}`);
+          if (!btn) return;
+          btn.addEventListener('click', async () => {
+            btn.disabled = true;
+            btn.textContent = 'Mengalihkan ke Google...';
+            try {
+              await startFirebaseGoogleLogin({ preferRedirect: true, status: (msg) => { btn.textContent = msg; } });
+            } catch (err) {
+              console.error('Fallback login gagal', err);
+              btn.disabled = false;
+              btn.textContent = label;
+              setToast(err?.message || translateMessage('Login gagal'));
+            }
+          });
+        }
+
         function renderGoogleFallback(messageKey) {
           if (!googleSignInButton) return;
           const message = translateMessage(
@@ -16468,8 +16596,17 @@
           const fallbackBtn = googleSignInButton.querySelector('#googleFallbackAction');
           if (fallbackBtn && !fallbackBtn.dataset.bound) {
             fallbackBtn.dataset.bound = 'true';
-            fallbackBtn.addEventListener('click', () => {
-              setToast(message);
+            fallbackBtn.addEventListener('click', async () => {
+              fallbackBtn.disabled = true;
+              fallbackBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>Mengalihkan ke Google...';
+              try {
+                await startFirebaseGoogleLogin({ preferRedirect: true });
+              } catch (err) {
+                console.error('Google fallback login gagal', err);
+                fallbackBtn.disabled = false;
+                fallbackBtn.innerHTML = `<i class="bi bi-google"></i><span>${translateMessage('Masuk dengan Google')}</span>`;
+                setToast(err?.message || message);
+              }
             });
           }
         }
@@ -16580,6 +16717,7 @@
               text: 'signin_with',
               shape: 'pill',
             });
+            appendFirebaseGoogleFallback(googleSignInButton, 'googleMobileFallbackAction');
           }
 
           const googleSignInForum = document.getElementById('googleSignInForum');
@@ -16604,6 +16742,7 @@
               shape: 'pill',
               width: '300'
             });
+            appendFirebaseGoogleFallback(profileGoogleLoginBtn, 'profileMobileFallbackAction');
           }
         }
 
@@ -19457,7 +19596,8 @@
           const spotifyPreviewUrl = previewProvider === 'spotify'
             ? previewInfo.url || original?.previewUrl || ''
             : '';
-          const canEmbedYoutube = embedAllowed && (provider === 'youtube' || isYoutubeUrl(info.webpageUrl || '')) && info.id;
+          const wantsSquareArtwork = info.artworkShape === 'square' || isYoutubeMusicUrl(info.webpageUrl || '') || isYoutubeMusicUrl(original?.url || '');
+          const canEmbedYoutube = embedAllowed && !wantsSquareArtwork && (provider === 'youtube' || isYoutubeUrl(info.webpageUrl || '')) && info.id;
           const canEmbedSpotify = embedAllowed && !!spotifyEmbedUrl;
           if (videoPreviewFrame) {
             if (canEmbedYoutube) {
@@ -19476,8 +19616,11 @@
             }
           }
           if (videoPreviewWrap) {
-            const disabled = !embedAllowed || (!canEmbedYoutube && !canEmbedSpotify);
+            const disabled = !wantsSquareArtwork && (!embedAllowed || (!canEmbedYoutube && !canEmbedSpotify));
             videoPreviewWrap.classList.toggle('is-disabled', disabled);
+            videoPreviewWrap.classList.toggle('ratio-16x9', !wantsSquareArtwork);
+            videoPreviewWrap.classList.toggle('ratio-1x1', wantsSquareArtwork);
+            videoPreviewWrap.classList.toggle('ytmusic-square-cover', wantsSquareArtwork);
           }
           if (thumbEl) {
             if (info.cover || info.thumbnail) {
@@ -21660,6 +21803,16 @@
           return detectMediaSource(text) === 'youtube';
         }
 
+        function isYoutubeMusicUrl(text = '') {
+          const raw = String(text || '').trim();
+          if (!raw) return false;
+          try {
+            return new URL(raw).hostname.toLowerCase().endsWith('music.youtube.com');
+          } catch {
+            return /(^|\.)music\.youtube\.com/i.test(raw);
+          }
+        }
+
         const RATING_STORE_KEY = 'ytmp3.ratings.v1';
 
         function loadRatingStore() {
@@ -23441,13 +23594,22 @@
           return xp;
         };
 
-        function toFriendlyConvertError(message = '') {
+        function toFriendlyConvertError(error = '') {
+          const message = typeof error === 'string' ? error : (error?.message || '');
+          const category = typeof error === 'string' ? '' : (error?.errorCategory || error?.payload?.errorCategory || error?.payload?.error?.code || '');
+          const hint = typeof error === 'string' ? '' : (error?.hint || error?.payload?.hint || '');
+          const categorized = category && converterErrorMessages[category] ? converterErrorMessages[category] : '';
           const raw = String(message || '').toLowerCase();
-          if (raw.includes('age') || raw.includes('restricted') || raw.includes('cookies')) return 'Video ini diblokir atau butuh cookies. Coba video lain atau update cookies ya.';
-          if (raw.includes('429') || raw.includes('too many') || raw.includes('rate')) return 'Server lagi padat. Santai, coba lagi sebentar ya.';
-          if (raw.includes('invalid') && raw.includes('url')) return 'Link belum valid. Cek lagi lalu kirim ulang ya.';
-          if (raw.includes('captcha')) return 'Verifikasi keamanan belum lolos. Coba klik convert sekali lagi ya.';
-          return `Hmm gagal nih, coba lagi yaa… (${message || 'unknown'})`;
+          let friendly = categorized || message;
+          if (!friendly || isGenericConverterError(friendly)) friendly = 'Hmm gagal nih, coba lagi yaa…';
+          if (!categorized) {
+            if (raw.includes('age') || raw.includes('restricted') || raw.includes('cookies')) friendly = 'Video membutuhkan cookies YouTube terbaru. Admin perlu memperbarui cookies di Admin Cookies Manager.';
+            else if (raw.includes('429') || raw.includes('too many') || raw.includes('rate') || raw.includes('bot')) friendly = 'YouTube sedang membatasi koneksi server. Tunggu dulu, jangan retry berkali-kali, atau gunakan server/IP lain.';
+            else if (raw.includes('invalid') && raw.includes('url')) friendly = 'Link belum valid. Cek lagi lalu kirim ulang ya.';
+            else if (raw.includes('captcha')) friendly = 'Verifikasi keamanan belum lolos. Coba klik convert sekali lagi ya.';
+          }
+          if (hint && !friendly.includes(hint)) friendly = `${friendly} ${hint}`;
+          return friendly;
         }
 
         function getSpeedServerLabel(mode = 'auto') {
@@ -23876,7 +24038,7 @@
             $('#logs').textContent = (err && err.stack) ? err.stack : String(err);
             resetAudioPreview();
             convertProgressAnimator.fail(translateMessage('Gagal'));
-            const friendlyErr = toFriendlyConvertError(err?.message || '');
+            const friendlyErr = toFriendlyConvertError(err);
             setToast(friendlyErr);
             announceNarrator(`Konversi gagal: ${friendlyErr}`);
             updateAiStatus(friendlyErr, 'danger');
@@ -28030,10 +28192,13 @@
               <h3 class="fw-bold mb-2 text-white" style="letter-spacing: -0.5px;">Gabung Forum</h3>
               <p class="text-secondary mb-4" style="max-width: 300px;">Diskusi seru, berbagi gambar, dan stiker dengan warga lainnya.</p>
               
-              <button id="forumGoogleLoginBtn" class="btn btn-light rounded-pill py-3 px-5 fw-bold d-flex align-items-center gap-3 shadow-lg hover-scale">
+              <button id="forumGoogleLoginBtn" type="button" class="btn btn-light rounded-pill py-3 px-5 fw-bold d-flex align-items-center gap-3 shadow-lg hover-scale">
                   <img src="https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg" width="24" height="24" alt="G">
                   <span>Masuk dengan Google</span>
-              </button>`;
+              </button>
+              <div id="forumLoginFallback" class="small text-secondary mt-3" role="status" aria-live="polite">
+                Kalau tombol tidak merespons, tekan lagi untuk mode redirect.
+              </div>`;
             const newBtn = document.getElementById('forumGoogleLoginBtn');
             if (newBtn) newBtn.addEventListener('click', handleLoginClick);
           }
@@ -28859,33 +29024,50 @@
             });
           }
 
-          async function handleLoginClick() {
-            // ... (Keep existing login logic mostly same but ensure new UI is handled)
+          function setForumLoginFallback(message, variant = 'secondary') {
+            const fallback = document.getElementById('forumLoginFallback');
+            if (!fallback) return;
+            fallback.className = `small text-${variant} mt-3`;
+            fallback.textContent = message;
+          }
+
+          function resetForumLoginButton() {
             const btn = document.getElementById('forumGoogleLoginBtn');
             if (!btn) return;
-            if (!window.firebaseModules || !window.firebaseModules.auth) return;
-            const { auth, signInWithPopup, GoogleAuthProvider, signInWithRedirect } = window.firebaseModules;
-            btn.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>...';
+            btn.disabled = false;
+            btn.innerHTML = '<img src="https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg" width="24" height="24" alt="G"><span>Masuk dengan Google</span>';
+          }
+
+          async function handleLoginClick() {
+            const btn = document.getElementById('forumGoogleLoginBtn');
+            if (!btn) return;
+            if (!window.firebaseModules || !window.firebaseModules.auth) {
+              setForumLoginFallback('Login sedang dimuat. Tunggu sebentar lalu tekan lagi.', 'warning');
+              return;
+            }
+
+            btn.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>Membuka Google...';
             btn.disabled = true;
+            setForumLoginFallback(prefersGoogleRedirectLogin()
+              ? 'Mode mobile aktif. Mengalihkan ke Google Sign-In...'
+              : 'Jika popup tidak muncul, sistem otomatis memakai mode redirect.', 'info');
+
             try {
-              const provider = new GoogleAuthProvider();
-              provider.setCustomParameters({ prompt: 'select_account' });
-              try {
-                const result = await signInWithPopup(auth, provider);
-                if (result && result.user) {
-                  setToast('Login berhasil!', 'success');
-                  sessionStorage.removeItem('forum_login_pending');
-                  forumLoginOverlay.classList.remove('d-flex');
-                  forumLoginOverlay.classList.add('d-none');
-                }
-              } catch (popupErr) {
-                sessionStorage.setItem('forum_login_pending', 'true');
-                await signInWithRedirect(auth, provider);
+              const result = await startFirebaseGoogleLogin({
+                pendingKey: 'forum_login_pending',
+                status: (msg) => setForumLoginFallback(msg, 'info'),
+              });
+              if (result && result.user) {
+                setToast('Login berhasil!', 'success');
+                sessionStorage.removeItem('forum_login_pending');
+                forumLoginOverlay.classList.remove('d-flex');
+                forumLoginOverlay.classList.add('d-none');
               }
             } catch (error) {
-              console.error(error);
-              btn.innerHTML = 'Login Google';
-              btn.disabled = false;
+              console.error('Forum login failed', error);
+              sessionStorage.removeItem('forum_login_pending');
+              setForumLoginFallback(error?.message || 'Login belum bisa dibuka. Muat ulang halaman atau izinkan popup/redirect Google.', 'danger');
+              resetForumLoginButton();
             }
           }
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 import express from "express";
 import compression from "compression";
 import cors from "cors";
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readdirSync } from "node:fs";
 import { promises as fsp } from "node:fs";
 import { createServer, request as httpRequest } from "node:http";
@@ -2916,19 +2916,63 @@ const cleanVideoTitle = (rawTitle = "") => {
   return result.replace(/\s{2,}/g, " ").trim();
 };
 
-const extractBestThumbnail = (info) => {
+const isYoutubeMusicUrl = (value = "") => {
+  const raw = typeof value === "string" ? value.trim() : "";
+  if (!raw) return false;
+  try {
+    return new URL(raw).hostname.toLowerCase().endsWith("music.youtube.com");
+  } catch {
+    return /(^|\.)music\.youtube\.com/i.test(raw);
+  }
+};
+
+const normalizeThumbnailItems = (info = {}) => {
+  const items = [];
+  if (typeof info?.thumbnail === "string" && info.thumbnail.trim()) {
+    items.push({ url: info.thumbnail.trim(), width: Number(info.width) || 0, height: Number(info.height) || 0 });
+  }
+  if (Array.isArray(info?.thumbnails)) {
+    info.thumbnails.forEach((item) => {
+      if (!item || typeof item !== "object" || !item.url) return;
+      items.push({
+        url: String(item.url),
+        width: Number(item.width) || 0,
+        height: Number(item.height) || 0,
+      });
+    });
+  }
+  const seen = new Set();
+  return items.filter((item) => {
+    if (!item.url || seen.has(item.url)) return false;
+    seen.add(item.url);
+    return true;
+  });
+};
+
+const extractBestThumbnail = (info, { preferSquare = false } = {}) => {
   if (!info || typeof info !== "object") return null;
-  if (typeof info.thumbnail === "string" && info.thumbnail.trim()) {
-    return info.thumbnail.trim();
+  const items = normalizeThumbnailItems(info);
+  if (!items.length) return null;
+  const sortedByWidth = [...items].sort((a, b) => (Number(b.width) || 0) - (Number(a.width) || 0));
+  if (preferSquare) {
+    const scored = [...items]
+      .map((item) => {
+        const width = Number(item.width) || 0;
+        const height = Number(item.height) || 0;
+        const ratio = width > 0 && height > 0 ? width / height : 1;
+        return {
+          item,
+          ratioDelta: Math.abs(1 - ratio),
+          area: width * height,
+        };
+      })
+      .filter(({ item }) => item.url);
+    scored.sort((a, b) => (a.ratioDelta - b.ratioDelta) || (b.area - a.area));
+    const squareCandidate = scored.find(({ ratioDelta }) => ratioDelta <= 0.2) || scored[0];
+    if (squareCandidate?.item?.url) return squareCandidate.item.url;
   }
-  if (Array.isArray(info.thumbnails)) {
-    const sorted = [...info.thumbnails]
-      .filter((item) => item && typeof item === "object")
-      .sort((a, b) => (Number(b?.width) || 0) - (Number(a?.width) || 0));
-    const candidate = sorted.find((item) => item?.url) || sorted[0];
-    if (candidate?.url) return String(candidate.url);
-  }
-  return null;
+  const candidate = sortedByWidth.find((item) => item?.url) || sortedByWidth[0];
+  return candidate?.url ? String(candidate.url) : null;
 };
 
 const buildVideoMetadata = (entry = {}, { requestedUrl = "", keywordUsed = false } = {}) => {
@@ -2954,7 +2998,8 @@ const buildVideoMetadata = (entry = {}, { requestedUrl = "", keywordUsed = false
     ? entry.tags.map((tag) => (tag == null ? null : String(tag))).filter(Boolean)
     : [];
 
-  const cover = extractBestThumbnail(entry);
+  const preferSquareArtwork = isYoutubeMusicUrl(requestedUrl) || isYoutubeMusicUrl(entry.original_url) || isYoutubeMusicUrl(entry.webpage_url);
+  const cover = extractBestThumbnail(entry, { preferSquare: preferSquareArtwork });
 
   return {
     id: entry.id || null,
@@ -2965,6 +3010,7 @@ const buildVideoMetadata = (entry = {}, { requestedUrl = "", keywordUsed = false
     album: album || cleaned || baseTitle,
     cover,
     thumbnail: cover,
+    artworkShape: preferSquareArtwork ? "square" : "wide",
     duration,
     webpageUrl,
     keywords,
@@ -3089,13 +3135,14 @@ const runYtDlpAttempt = (command, args, { label }) =>
 
 const categorizeYtDlpError = (value = "") => {
   const raw = String(value || "");
+  if (/429|too many requests|rate.?limit/i.test(raw)) return "RATE_LIMITED";
   if (/sign in to confirm|not a bot|bot check|use --cookies|cookies-from-browser|confirm you(?:\'|’)re not a bot/i.test(raw)) return "BOT_CHECK";
   if (/login required|sign in|private video|members-only|account/i.test(raw)) return "LOGIN_REQUIRED";
   if (/age[- ]?restricted|confirm your age|age restriction/i.test(raw)) return "AGE_RESTRICTED";
   if (/not available in your country|geo|region/i.test(raw)) return "GEO_BLOCKED";
   if (/private video/i.test(raw)) return "PRIVATE_VIDEO";
-  if (/requested format is not available|no video formats|only images are available|format/i.test(raw)) return "FORMAT_UNAVAILABLE";
-  if (/429|too many requests|rate.?limit/i.test(raw)) return "RATE_LIMITED";
+  if (/JS runtimes:\s*none|No supported JavaScript runtime|JavaScript runtime could be found|js runtime/i.test(raw)) return "JS_RUNTIME_MISSING";
+  if (/requested format is not available|no video formats|only images are available|Use --list-formats/i.test(raw)) return "FORMAT_UNAVAILABLE";
   if (/ffmpeg/i.test(raw)) return "FFMPEG_MISSING";
   if (/yt-dlp tidak bisa dijalankan|yt-dlp.*not found|no such file/i.test(raw)) return "YTDLP_MISSING";
   if (/network|timed?out|econn|enotfound|http error 5\d\d/i.test(raw)) return "NETWORK_ERROR";
@@ -3124,13 +3171,26 @@ const publicDownloadError = (err) => {
   const logs = err?.logs || err?.message || "";
   const category = err?.errorCategory || categorizeYtDlpError(logs);
   const needsAdminCookies = ["BOT_CHECK", "LOGIN_REQUIRED", "AGE_RESTRICTED"].includes(category);
-  const message = needsAdminCookies
-    ? "Video membutuhkan cookies YouTube terbaru. Admin perlu memperbarui cookies di Admin Cookies Manager."
-    : (err?.message || "Gagal memproses video");
+  const messages = {
+    RATE_LIMITED: "YouTube sedang membatasi koneksi dari server ini. Coba lagi nanti, kurangi percobaan berulang, atau gunakan server/IP lain.",
+    BOT_CHECK: "YouTube meminta verifikasi bot dari koneksi server. Cookies login tidak diterima atau sudah kedaluwarsa.",
+    LOGIN_REQUIRED: "YouTube meminta login. Cookies login tidak diterima atau sudah tidak berlaku.",
+    AGE_RESTRICTED: "Video membutuhkan verifikasi umur. Admin perlu memperbarui cookies YouTube yang valid.",
+    JS_RUNTIME_MISSING: "JavaScript runtime yt-dlp belum tersedia. Pasang Deno/EJS atau set YTDLP_JS_RUNTIME yang valid.",
+    FORMAT_UNAVAILABLE: "Format YouTube yang tersedia berubah atau tidak bisa dibaca. Sistem sudah mencoba format fallback; coba lagi nanti atau pakai Panduan Error.",
+  };
+  const message = messages[category] || err?.message || "Gagal memproses video";
+  const hints = {
+    RATE_LIMITED: "Server/IP kemungkinan terkena rate limit YouTube. Hindari retry bertubi-tubi; pindah IP/server jika 429 tetap muncul.",
+    BOT_CHECK: "Admin: upload cookies Netscape baru dari sesi incognito YouTube, tutup sesi setelah ekspor, lalu jalankan Test Cookies.",
+    LOGIN_REQUIRED: "Admin: perbarui cookies YouTube dari sesi login yang masih valid dan pastikan format Netscape LF.",
+    AGE_RESTRICTED: "Admin: gunakan cookies akun cadangan yang sudah lolos verifikasi umur.",
+    JS_RUNTIME_MISSING: "Deploy image terbaru yang memasang Deno dan yt-dlp[default], atau set YTDLP_JS_RUNTIME=deno.",
+  };
   const wrapped = new Error(message);
   wrapped.errorCategory = category;
-  wrapped.adminActionRequired = needsAdminCookies;
-  wrapped.hint = needsAdminCookies ? "Admin: buka Admin Cookies Manager, upload cookies Netscape terbaru, lalu jalankan Test Cookies." : undefined;
+  wrapped.adminActionRequired = Boolean(needsAdminCookies || category === "RATE_LIMITED" || category === "JS_RUNTIME_MISSING");
+  wrapped.hint = hints[category];
   wrapped.logs = logs;
   return wrapped;
 };
@@ -7192,18 +7252,38 @@ const parseMajorVersion = (value = "") => {
   return match ? Number(match[1]) : 0;
 };
 
+const commandExistsSync = (cmd = "") => {
+  if (!cmd) return false;
+  const result = spawnSync(cmd, ["--version"], { stdio: "ignore" });
+  return !result.error;
+};
+
 const getYtDlpJsRuntimeArgs = () => {
-  const runtime = String(process.env.YTDLP_JS_RUNTIME || "node").trim().toLowerCase();
+  const runtime = String(process.env.YTDLP_JS_RUNTIME || "deno").trim().toLowerCase();
   if (runtime === "off" || runtime === "none" || runtime === "0") return [];
 
   const nodeMajor = parseMajorVersion(process.version);
-  const selected = runtime || "node";
+  let selected = runtime || "deno";
+  if (selected === "auto") {
+    if (commandExistsSync("deno")) selected = "deno";
+    else if (nodeMajor >= 22) selected = "node";
+    else selected = "";
+  }
+
+  if (selected === "deno" && !commandExistsSync("deno")) {
+    if (nodeMajor >= 22) selected = "node";
+    else {
+      console.warn("[yt-dlp] Deno is not installed and Node is below yt-dlp JS runtime minimum; skipping --js-runtimes");
+      return [];
+    }
+  }
   if (selected === "node" && nodeMajor < 22) {
     console.warn(`[yt-dlp] Node ${process.version} is below yt-dlp 2026.06.09 minimum for JS runtime; skipping --js-runtimes node`);
     return [];
   }
+  if (!selected) return [];
 
-  return ["--js-runtimes", selected, "--remote-components", "ejs:github", "--extractor-retries", "3"];
+  return ["--js-runtimes", selected, "--remote-components", "ejs:npm", "--extractor-retries", "3"];
 };
 
 
@@ -7230,6 +7310,49 @@ const pushYoutubeExtractorArgs = (args = []) => {
     args.push("--extractor-args", value);
   }
   return args;
+};
+
+const replaceYtDlpFormatSelector = (args = [], selector = "") => {
+  const next = Array.isArray(args) ? [...args] : [];
+  const url = next[next.length - 1];
+  const isUrlLike = typeof url === "string" && /^(https?:|ytsearch|ytmsearch)/i.test(url);
+  const urlArg = isUrlLike ? next.pop() : null;
+  let replaced = false;
+  for (let i = 0; i < next.length - 1; i++) {
+    if (next[i] === "-f" && typeof next[i + 1] === "string") {
+      if (selector) next[i + 1] = selector;
+      else next.splice(i, 2);
+      replaced = true;
+      break;
+    }
+  }
+  if (!replaced && selector) next.push("-f", selector);
+  if (urlArg) next.push(urlArg);
+  return next;
+};
+
+const removeYtDlpJsRuntimeArgs = (args = []) => {
+  const next = [];
+  const source = Array.isArray(args) ? args : [];
+  for (let i = 0; i < source.length; i++) {
+    const item = source[i];
+    if (["--js-runtimes", "--remote-components", "--extractor-retries"].includes(item)) {
+      i += 1;
+      continue;
+    }
+    next.push(item);
+  }
+  return next;
+};
+
+const dedupeYtDlpArgPlans = (plans = []) => {
+  const seen = new Set();
+  return plans.filter((plan) => {
+    const key = JSON.stringify(plan.args || []);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
 };
 
 const buildYtDlpFallbackArgs = (args = []) => {
@@ -7302,8 +7425,11 @@ const runYtDlpDownload = ({ args, id, onProgress }) =>
     });
     proc.on("close", (code) => {
       if (code !== 0) {
-        const error = new Error("yt-dlp gagal");
+        const category = categorizeYtDlpError(logs || `yt-dlp exited with code ${code}`);
+        const error = new Error(category === "UNKNOWN" ? "yt-dlp gagal" : `yt-dlp gagal (${category})`);
         error.logs = logs;
+        error.errorCategory = category;
+        error.exitCode = code;
         return reject(error);
       }
       const files = readdirSync(JOBS_DIR).filter((f) =>
@@ -7742,6 +7868,7 @@ const convertSingle = async (payload = {}) => {
 
     let logs = "";
     let downloadResult = null;
+    let lastDownloadErrorCategory = "";
 
     // Untuk Spotify: metadata dari spotDL, download dari YouTube Music/YouTube via yt-dlp
     // Preview URL hanya untuk metadata, tidak digunakan untuk download
@@ -7753,6 +7880,7 @@ const convertSingle = async (payload = {}) => {
       } catch (err) {
         const baseLogs = err.logs || "";
         const errorCategory = categorizeYtDlpError(baseLogs || err?.message || "");
+        lastDownloadErrorCategory = errorCategory;
         const shouldRetryWithFallbackArgs = /Requested format is not available|HTTP Error 400|HTTP Error 403|Forbidden|Sign in|cookies|confirm your age|precondition|This video is unavailable/i.test(baseLogs || "") || isCookieRetryCategory(errorCategory);
         if (isCookieRetryCategory(errorCategory)) {
           const cookieRetry = await appendServerCookiesArgs(args);
@@ -7769,32 +7897,33 @@ const convertSingle = async (payload = {}) => {
           }
         }
         if (!downloadResult && shouldRetryWithFallbackArgs) {
-          try {
-            emitProgress({ stage: "downloading", message: "Mencoba mode kompatibilitas", percent: mapDownloadPercent(18) });
-            const fallbackArgs = buildYtDlpFallbackArgs(args);
-            downloadResult = await runYtDlpDownload({ args: fallbackArgs, id, onProgress: handleDownloadProgress });
-            logs = downloadResult.logs || baseLogs;
-          } catch (retryErr) {
-            logs = retryErr?.logs || logs || baseLogs;
-          }
-        }
-        if (!downloadResult && shouldRetryWithFallbackArgs) {
-          try {
-            emitProgress({ stage: "downloading", message: "Mencoba format universal", percent: mapDownloadPercent(19) });
-            const universalArgs = buildYtDlpFallbackArgs(args);
-            for (let i = 0; i < universalArgs.length - 1; i++) {
-              if (universalArgs[i] === "-f") {
-                universalArgs.splice(i, 2);
-                break;
-              }
+          const retryPlans = dedupeYtDlpArgPlans([
+            { label: "mode kompatibilitas", percent: 18, args: buildYtDlpFallbackArgs(args) },
+            { label: "audio universal", percent: 19, args: replaceYtDlpFormatSelector(buildYtDlpFallbackArgs(args), "ba/bestaudio/best/worst") },
+            { label: "format otomatis", percent: 20, args: replaceYtDlpFormatSelector(buildYtDlpFallbackArgs(args), "") },
+            { label: "format otomatis tanpa JS runtime", percent: 21, args: removeYtDlpJsRuntimeArgs(replaceYtDlpFormatSelector(buildYtDlpFallbackArgs(args), "")) },
+          ]);
+
+          for (const plan of retryPlans) {
+            if (downloadResult) break;
+            try {
+              emitProgress({ stage: "downloading", message: `Mencoba ${plan.label}`, percent: mapDownloadPercent(plan.percent) });
+              downloadResult = await runYtDlpDownload({ args: plan.args, id, onProgress: handleDownloadProgress });
+              logs = downloadResult.logs || logs || baseLogs;
+            } catch (retryErr) {
+              logs = retryErr?.logs || logs || baseLogs;
+              lastDownloadErrorCategory = categorizeYtDlpError(logs);
             }
-            downloadResult = await runYtDlpDownload({ args: universalArgs, id, onProgress: handleDownloadProgress });
-            logs = downloadResult.logs || logs || baseLogs;
-          } catch (retryErr) {
-            logs = retryErr?.logs || logs || baseLogs;
           }
         }
         if (!downloadResult) {
+          if (["RATE_LIMITED", "BOT_CHECK"].includes(lastDownloadErrorCategory)) {
+            if (coverPath) try { await fsp.unlink(coverPath); } catch { }
+            const restrictedError = new Error(err.message || "YouTube membatasi koneksi server");
+            restrictedError.logs = [logs, baseLogs].filter(Boolean).join("\n").slice(-8000);
+            restrictedError.errorCategory = lastDownloadErrorCategory;
+            throw restrictedError;
+          }
           if (isVideoFormat) {
             if (coverPath) try { await fsp.unlink(coverPath); } catch { }
             const videoError = new Error(err.message || "Gagal mengunduh video");
@@ -8012,6 +8141,8 @@ const convertSingle = async (payload = {}) => {
         artist: metadata.artist || null,
         album: metadata.album || null,
         cover: metadata.cover || null,
+        thumbnail: metadata.thumbnail || metadata.cover || null,
+        artworkShape: metadata.artworkShape || null,
         duration: metadata.duration || null,
         webpageUrl: metadata.webpageUrl || null,
         keywords: metadata.keywords || [],

--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -5714,10 +5714,10 @@
         <span class="ms-2">Menu fitur</span>
       </button>
       <a class="btn btn-danger d-none d-lg-inline-flex align-items-center ms-2" id="converterGuideBtn"
-        href="https://ytconvguide.vercel.app/" target="_blank" rel="noopener noreferrer"
-        aria-label="Buka Panduan Error converter">
+        href="https://ytconvhub.vercel.app/" target="_blank" rel="noopener noreferrer"
+        aria-label="Buka YTConv Hub">
         <i class="bi bi-life-preserver"></i>
-        <span class="ms-2">Panduan Error</span>
+        <span class="ms-2">YTConv Hub</span>
       </a>
       <button class="app-nav-btn d-inline-flex ms-2" type="button" id="ytMusicBtn" aria-label="Buka YT Music">
         <i class="bi bi-youtube"></i>
@@ -8568,10 +8568,10 @@
             </button>
 
             <!-- Panduan Error (mobile feature menu) -->
-            <a class="modern-nav-item d-lg-none" href="https://ytconvguide.vercel.app/" target="_blank"
-              rel="noopener noreferrer" aria-label="Buka Panduan Error converter">
+            <a class="modern-nav-item d-lg-none" href="https://ytconvhub.vercel.app/" target="_blank"
+              rel="noopener noreferrer" aria-label="Buka YTConv Hub">
               <div class="modern-nav-icon"><i class="bi bi-life-preserver"></i></div>
-              <span class="modern-nav-label">Panduan Error</span>
+              <span class="modern-nav-label">YTConv Hub</span>
               <i class="bi bi-box-arrow-up-right modern-nav-arrow"></i>
             </a>
 

--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -2670,6 +2670,12 @@
       display: block;
     }
 
+    #previewWrap .preview-visual.ytmusic-square-cover {
+      max-width: 360px;
+      margin-left: auto;
+      margin-right: auto;
+    }
+
     #previewWrap .preview-visual::after {
       content: "";
       position: absolute;
@@ -5707,6 +5713,12 @@
         <i class="bi bi-grid-3x3-gap"></i>
         <span class="ms-2">Menu fitur</span>
       </button>
+      <a class="btn btn-danger d-none d-lg-inline-flex align-items-center ms-2" id="converterGuideBtn"
+        href="https://ytconvguide.vercel.app/" target="_blank" rel="noopener noreferrer"
+        aria-label="Buka Panduan Error converter">
+        <i class="bi bi-life-preserver"></i>
+        <span class="ms-2">Panduan Error</span>
+      </a>
       <button class="app-nav-btn d-inline-flex ms-2" type="button" id="ytMusicBtn" aria-label="Buka YT Music">
         <i class="bi bi-youtube"></i>
         <span class="ms-2">YT Music</span>
@@ -8554,6 +8566,14 @@
               <span class="modern-nav-label">Bantuan</span>
               <i class="bi bi-chevron-right modern-nav-arrow"></i>
             </button>
+
+            <!-- Panduan Error (mobile feature menu) -->
+            <a class="modern-nav-item d-lg-none" href="https://ytconvguide.vercel.app/" target="_blank"
+              rel="noopener noreferrer" aria-label="Buka Panduan Error converter">
+              <div class="modern-nav-icon"><i class="bi bi-life-preserver"></i></div>
+              <span class="modern-nav-label">Panduan Error</span>
+              <i class="bi bi-box-arrow-up-right modern-nav-arrow"></i>
+            </a>
 
             <!-- Divider -->
             <hr class="my-2 border-secondary-subtle opacity-25">
@@ -14714,19 +14734,52 @@
           return next;
         };
 
+        const converterErrorMessages = {
+          RATE_LIMITED: 'YouTube sedang membatasi koneksi dari server ini. Coba lagi nanti, jangan spam retry, atau gunakan server/IP lain.',
+          BOT_CHECK: 'YouTube meminta verifikasi bot dari koneksi server. Cookies login tidak diterima atau sudah kedaluwarsa.',
+          LOGIN_REQUIRED: 'YouTube meminta login. Cookies YouTube perlu diperbarui oleh admin.',
+          AGE_RESTRICTED: 'Video membutuhkan verifikasi umur. Admin perlu memperbarui cookies YouTube yang valid.',
+          JS_RUNTIME_MISSING: 'JavaScript runtime yt-dlp belum tersedia. Deploy image terbaru yang memasang Deno/EJS.',
+          FORMAT_UNAVAILABLE: 'Format YouTube tidak bisa dibaca dari server ini. Sistem sudah mencoba fallback; cek Panduan Error kalau tetap gagal.',
+          INVALID_URL: 'Link belum valid atau domain belum didukung.',
+          QUEUE_FULL: 'Antrian server sedang penuh. Tunggu sebentar lalu coba lagi.',
+        };
+
+        const isGenericConverterError = (message = '') => /^(yt-dlp gagal|gagal memproses|terjadi kesalahan|gagal membuat job)$/i.test(String(message || '').trim());
+
+        const buildApiErrorMessage = (payload = {}, rawText = '', fallbackMessage = 'Terjadi kesalahan') => {
+          const errorObj = payload && typeof payload.error === 'object' ? payload.error : {};
+          const category = payload.errorCategory || errorObj.code || errorObj.errorCategory || '';
+          const rawMessage = typeof payload.error === 'string'
+            ? payload.error
+            : (payload.message || errorObj.message || (rawText ? String(rawText).trim().slice(0, 280) : '') || fallbackMessage);
+          const message = (category && (isGenericConverterError(rawMessage) || !rawMessage))
+            ? (converterErrorMessages[category] || rawMessage || fallbackMessage)
+            : rawMessage;
+          return {
+            message: message || fallbackMessage,
+            category,
+            hint: payload.hint || errorObj.hint || '',
+            adminActionRequired: Boolean(payload.adminActionRequired || errorObj.adminActionRequired),
+          };
+        };
+
         const resolveJsonResponse = async (resp, { fallbackMessage = 'Terjadi kesalahan', logLabel = '' } = {}) => {
           const safe = await readJsonSafe(resp);
           const payload = safe.data && typeof safe.data === 'object' ? safe.data : {};
-          if (!resp?.ok) {
+          if (!resp?.ok || payload.ok === false || payload.success === false) {
             const raw = (safe.rawText || '').trim();
             if (safe.parseError) {
               console?.warn?.('[json] gagal parsing', { label: logLabel || resp?.url, error: safe.parseError, raw });
             }
-            const message = payload.error || payload.message || (raw ? raw.slice(0, 280) : '') || fallbackMessage;
-            const err = new Error(message || fallbackMessage);
+            const friendly = buildApiErrorMessage(payload, raw, fallbackMessage);
+            const err = new Error(friendly.message);
             err.status = resp?.status;
             err.payload = payload;
             err.rawText = safe.rawText;
+            err.errorCategory = friendly.category;
+            err.hint = friendly.hint;
+            err.adminActionRequired = friendly.adminActionRequired;
             throw err;
           }
           if (safe.parseError) {
@@ -21148,7 +21201,8 @@
           const spotifyPreviewUrl = previewProvider === 'spotify'
             ? previewInfo.url || original?.previewUrl || ''
             : '';
-          const canEmbedYoutube = embedAllowed && (provider === 'youtube' || isYoutubeUrl(info.webpageUrl || '')) && info.id;
+          const wantsSquareArtwork = info.artworkShape === 'square' || isYoutubeMusicUrl(info.webpageUrl || '') || isYoutubeMusicUrl(original?.url || '');
+          const canEmbedYoutube = embedAllowed && !wantsSquareArtwork && (provider === 'youtube' || isYoutubeUrl(info.webpageUrl || '')) && info.id;
           const canEmbedSpotify = embedAllowed && !!spotifyEmbedUrl;
           if (videoPreviewFrame) {
             if (canEmbedYoutube) {
@@ -21167,8 +21221,11 @@
             }
           }
           if (videoPreviewWrap) {
-            const disabled = !embedAllowed || (!canEmbedYoutube && !canEmbedSpotify);
+            const disabled = !wantsSquareArtwork && (!embedAllowed || (!canEmbedYoutube && !canEmbedSpotify));
             videoPreviewWrap.classList.toggle('is-disabled', disabled);
+            videoPreviewWrap.classList.toggle('ratio-16x9', !wantsSquareArtwork);
+            videoPreviewWrap.classList.toggle('ratio-1x1', wantsSquareArtwork);
+            videoPreviewWrap.classList.toggle('ytmusic-square-cover', wantsSquareArtwork);
           }
           if (thumbEl) {
             if (info.cover || info.thumbnail) {
@@ -23479,6 +23536,16 @@
           return detectMediaSource(text) === 'youtube';
         }
 
+        function isYoutubeMusicUrl(text = '') {
+          const raw = String(text || '').trim();
+          if (!raw) return false;
+          try {
+            return new URL(raw).hostname.toLowerCase().endsWith('music.youtube.com');
+          } catch {
+            return /(^|\.)music\.youtube\.com/i.test(raw);
+          }
+        }
+
         const RATING_STORE_KEY = 'ytmp3.ratings.v1';
 
         function loadRatingStore() {
@@ -25382,13 +25449,22 @@
           return xp;
         };
 
-        function toFriendlyConvertError(message = '') {
+        function toFriendlyConvertError(error = '') {
+          const message = typeof error === 'string' ? error : (error?.message || '');
+          const category = typeof error === 'string' ? '' : (error?.errorCategory || error?.payload?.errorCategory || error?.payload?.error?.code || '');
+          const hint = typeof error === 'string' ? '' : (error?.hint || error?.payload?.hint || '');
+          const categorized = category && converterErrorMessages[category] ? converterErrorMessages[category] : '';
           const raw = String(message || '').toLowerCase();
-          if (raw.includes('age') || raw.includes('restricted') || raw.includes('cookies')) return 'Video membutuhkan cookies YouTube terbaru. Admin perlu memperbarui cookies di Admin Cookies Manager.';
-          if (raw.includes('429') || raw.includes('too many') || raw.includes('rate')) return 'Server lagi padat. Santai, coba lagi sebentar ya.';
-          if (raw.includes('invalid') && raw.includes('url')) return 'Link belum valid. Cek lagi lalu kirim ulang ya.';
-          if (raw.includes('captcha')) return 'Verifikasi keamanan belum lolos. Coba klik convert sekali lagi ya.';
-          return `Hmm gagal nih, coba lagi yaa… (${message || 'unknown'})`;
+          let friendly = categorized || message;
+          if (!friendly || isGenericConverterError(friendly)) friendly = 'Hmm gagal nih, coba lagi yaa…';
+          if (!categorized) {
+            if (raw.includes('age') || raw.includes('restricted') || raw.includes('cookies')) friendly = 'Video membutuhkan cookies YouTube terbaru. Admin perlu memperbarui cookies di Admin Cookies Manager.';
+            else if (raw.includes('429') || raw.includes('too many') || raw.includes('rate') || raw.includes('bot')) friendly = 'YouTube sedang membatasi koneksi server. Tunggu dulu, jangan retry berkali-kali, atau gunakan server/IP lain.';
+            else if (raw.includes('invalid') && raw.includes('url')) friendly = 'Link belum valid. Cek lagi lalu kirim ulang ya.';
+            else if (raw.includes('captcha')) friendly = 'Verifikasi keamanan belum lolos. Coba klik convert sekali lagi ya.';
+          }
+          if (hint && !friendly.includes(hint)) friendly = `${friendly} ${hint}`;
+          return friendly;
         }
 
         function getSpeedServerLabel(mode = 'auto') {
@@ -25822,7 +25898,7 @@
             $('#logs').textContent = (err && err.stack) ? err.stack : String(err);
             resetAudioPreview();
             convertProgressAnimator.fail(translateMessage('Gagal'));
-            const friendlyErr = toFriendlyConvertError(err?.message || '');
+            const friendlyErr = toFriendlyConvertError(err);
             try {
               ensureForumSocket()?.emit('conversion_error', { reason: friendlyErr || 'convert_error' });
               window.reportUserAction?.('conversion_error', friendlyErr || 'convert_error');

--- a/src/lib/converterState.js
+++ b/src/lib/converterState.js
@@ -82,6 +82,7 @@ export const publicJobSnapshot = (job = {}) => {
     downloadUrl: job.downloadUrl || null,
     error,
     errorCategory: job.errorCategory || error?.code || null,
+    hint: job.hint || null,
     createdAt: job.createdAt || null,
     startedAt: job.startedAt || null,
     completedAt: job.completedAt || null,

--- a/src/lib/env.js
+++ b/src/lib/env.js
@@ -138,7 +138,7 @@ export const loadEnv = (rawEnv = process.env) => {
     INTERNAL_API_KEY: str(rawEnv.INTERNAL_API_KEY),
     INTERNAL_REQUEST_TIMEOUT_MS: int(rawEnv.INTERNAL_REQUEST_TIMEOUT_MS, 15_000, { min: 500, max: 120_000 }),
 
-    YTDLP_JS_RUNTIME: str(rawEnv.YTDLP_JS_RUNTIME, "node"),
+    YTDLP_JS_RUNTIME: str(rawEnv.YTDLP_JS_RUNTIME, "deno"),
     YTDLP_PATH: str(rawEnv.YTDLP_PATH),
     FFMPEG_PATH: str(rawEnv.FFMPEG_PATH),
     FFPROBE_PATH: str(rawEnv.FFPROBE_PATH),


### PR DESCRIPTION
### Motivation
- Improve yt-dlp JavaScript runtime support by using Deno in Docker images and defaulting to a Deno-first runtime to better solve JS extractor challenges. 
- Make downloads more resilient by adding richer fallback plans and better detection of runtime/format issues. 
- Surface clearer, localized error messages and admin hints to end users and provide more robust Google Sign-In fallbacks in the UI. 

### Description
- Dockerfile: install Deno, add `unzip`, install `yt-dlp[default]` via pip, and set `YTDLP_JS_RUNTIME=deno` in the image.
- Environment: change default `YTDLP_JS_RUNTIME` to `deno` in `src/lib/env.js` and update `docs/ENVIRONMENT.md` to document the Deno default and `auto` behavior.
- Python helper (`download_audio.py`): default JS runtime set to `deno`, implement `auto`/fallback selection for runtimes, change remote component source to `ejs:npm`, expand format fallbacks and add attempts (`audio_opts`, `no_runtime_opts`), and generally harden extractor options.
- Server (`index.js`): add robust detection for Deno/Node, prefer Deno by default, provide `--js-runtimes` handling with `ejs:npm`, implement utilities to normalize thumbnails, prefer square artwork for YouTube Music, add multiple deduped retry plans (format selectors, removing JS runtime), enhance yt-dlp error categorization (new categories including `JS_RUNTIME_MISSING` and `RATE_LIMITED`), produce friendlier public error messages and hints, propagate `hint` and `errorCategory` into public job snapshots and job serialization, and add various fixes around progress/error handling.
- Frontend (`index.html` and `public-ui/index.html`): add a visible "Panduan Error" guide link, improve Google auth UX with `startFirebaseGoogleLogin` (popup/redirect detection), add fallback buttons/messages for mobile/blocked popups, include richer client-side parsing of API error payloads (`buildApiErrorMessage`, `converterErrorMessages`), and refine preview layout for YouTube Music square covers.

### Testing
- Built the Docker image (`docker build .`) to verify Deno and Python/yt-dlp installation in the container; the image build completed successfully.
- Performed a local server smoke start (`node index.js`) to validate startup path and runtime detection; the server launched and logged runtime info.
- Exercised end-to-end download/convert fallbacks with manual conversion attempts to validate retry plans and that improved error categories/hints are surfaced to the client; conversions fell back appropriately and friendly messages were shown.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52230495988331bb9d58999efc9054)