### PR TITLE
Add Deno support, improve yt-dlp runtime selection/retries, and introduce YTClean UI polish

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
 FROM node:20-slim
 
-# Install ffmpeg, Python, yt-dlp, and PyTube
+# Install ffmpeg, Python, yt-dlp, PyTube, and Deno for yt-dlp JavaScript challenges.
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ffmpeg curl ca-certificates python3 python3-pip \
-  && python3 -m pip install --no-cache-dir --break-system-packages yt-dlp pytube \
+  && apt-get install -y --no-install-recommends ffmpeg curl unzip ca-certificates python3 python3-pip \
+  && curl -fsSL https://deno.land/install.sh | sh \
+  && install -m 0755 /root/.deno/bin/deno /usr/local/bin/deno \
+  && python3 -m pip install --no-cache-dir --break-system-packages "yt-dlp[default]" pytube \
   && rm -rf /var/lib/apt/lists/*
+
+ENV YTDLP_JS_RUNTIME=deno
 
 WORKDIR /app
 COPY package*.json ./

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -35,7 +35,7 @@ Use `/data` for persistent Railway volume data:
 - `CACHE_DIR=/data/ytconv/cache`
 - `TEMP_DIR=/tmp/ytconv-jobs`
 
-`YTDLP_PATH`, `FFMPEG_PATH`, and `FFPROBE_PATH` may be empty if binaries are on `PATH`. Configure `YTDLP_JS_RUNTIME=node` for the supported yt-dlp JavaScript runtime.
+`YTDLP_PATH`, `FFMPEG_PATH`, and `FFPROBE_PATH` may be empty if binaries are on `PATH`. Configure `YTDLP_JS_RUNTIME=deno` (default in Docker) for yt-dlp JavaScript challenge solving; use `auto` to fall back to Node >= 22 when Deno is unavailable.
 
 ## Security and abuse controls
 

--- a/download_audio.py
+++ b/download_audio.py
@@ -46,11 +46,21 @@ def get_youtube_extractor_args() -> Dict[str, Dict[str, list[str]]]:
 
 
 def get_js_runtime_options() -> Dict[str, object]:
-    runtime = os.environ.get("YTDLP_JS_RUNTIME", "node").strip().lower()
+    runtime = os.environ.get("YTDLP_JS_RUNTIME", "deno").strip().lower()
     if runtime in {"", "off", "none", "0"}:
         return {}
 
-    if runtime == "node":
+    selected = runtime
+    if runtime == "auto":
+        if shutil.which("deno"):
+            selected = "deno"
+        else:
+            selected = "node"
+
+    if selected == "deno" and not shutil.which("deno"):
+        selected = "node"
+
+    if selected == "node":
         node_bin = shutil.which("node")
         if not node_bin:
             print("node runtime not found; yt_dlp JS runtime disabled", file=sys.stderr)
@@ -65,8 +75,8 @@ def get_js_runtime_options() -> Dict[str, object]:
             return {}
 
     return {
-        "js_runtimes": {runtime: {}},
-        "remote_components": ["ejs:github"],
+        "js_runtimes": {selected: {}},
+        "remote_components": ["ejs:npm"],
         "extractor_retries": 3,
     }
 
@@ -164,7 +174,7 @@ def download_with_ytdlp(
 
     template = os.path.join(out_dir, f"{out_basename}.%(ext)s")
     base_opts = {
-        "format": "bestaudio/best",
+        "format": "ba/bestaudio/best/worst",
         "outtmpl": template,
         "restrictfilenames": False,
         "noplaylist": True,
@@ -191,8 +201,11 @@ def download_with_ytdlp(
     tv_opts = dict(base_opts)
     tv_opts["extractor_args"] = {"youtube": {"player_client": ["mweb", "web_safari", "tv_embedded", "android"]}}
 
+    audio_opts = dict(compat_opts)
+    audio_opts["format"] = "ba/bestaudio/best/worst"
+
     relaxed_opts = dict(compat_opts)
-    relaxed_opts["format"] = "best"
+    relaxed_opts["format"] = "best/worst"
 
     http_opts = dict(relaxed_opts)
     http_opts["format"] = "bestaudio[protocol^=http]/best[protocol^=http]/bestaudio/best/worst"
@@ -200,9 +213,13 @@ def download_with_ytdlp(
     universal_opts = dict(tv_opts)
     universal_opts.pop("format", None)
 
+    no_runtime_opts = dict(universal_opts)
+    no_runtime_opts.pop("js_runtimes", None)
+    no_runtime_opts.pop("remote_components", None)
+
     last_exc: Optional[Exception] = None
     upgrade_tried = False
-    attempts = [base_opts, compat_opts, tv_opts, relaxed_opts, http_opts, universal_opts]
+    attempts = [base_opts, compat_opts, tv_opts, audio_opts, relaxed_opts, http_opts, universal_opts, no_runtime_opts]
     for opts in attempts:
         try:
             with YoutubeDL(opts) as ydl:  # type: ignore[misc]

--- a/index.html
+++ b/index.html
@@ -1654,6 +1654,375 @@
       transform: scale(0.95) translateY(0);
       box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
     }
+
+
+    /* YTConv clean professional shell (neutral, no gradients/glow). */
+    :root {
+      --background: #ffffff;
+      --sidebar: #f7f7f8;
+      --surface: #ffffff;
+      --surface-secondary: #f4f4f4;
+      --border: #e5e5e5;
+      --text: #202123;
+      --text-secondary: #6b6b6b;
+      --button-primary: #212121;
+      --button-primary-text: #ffffff;
+      --success: #17803d;
+      --warning: #a15c00;
+      --danger: #c83232;
+      --yt-shell-width: 264px;
+    }
+
+    html[data-bs-theme='dark'] {
+      --background: #212121;
+      --sidebar: #171717;
+      --surface: #2f2f2f;
+      --surface-secondary: #262626;
+      --border: #424242;
+      --text: #ececec;
+      --text-secondary: #b4b4b4;
+      --button-primary: #f4f4f4;
+      --button-primary-text: #171717;
+    }
+
+    html, body {
+      overflow-x: hidden;
+    }
+
+    body.ytclean-ui {
+      margin: 0;
+      background: var(--background) !important;
+      color: var(--text) !important;
+      font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif !important;
+      font-size: 16px;
+      line-height: 1.5;
+    }
+
+    body.ytclean-ui :where(.card, .modal-content, .offcanvas, .dropdown-menu, .accordion-item, .list-group-item, .btn, .ytclean-link, .ytclean-sidebar, .ytclean-mobilebar) {
+      text-shadow: none !important;
+      box-shadow: none !important;
+      background-image: none !important;
+      filter: none !important;
+      backdrop-filter: none !important;
+      -webkit-backdrop-filter: none !important;
+    }
+
+    body.ytclean-ui .app-header-lite,
+    body.ytclean-ui #converterGuideBtn,
+    body.ytclean-ui #converterGuideMobileBtn {
+      display: none !important;
+    }
+
+    .ytclean-shell {
+      min-height: 0;
+      height: 0;
+      background: var(--background);
+    }
+
+    .ytclean-sidebar {
+      position: fixed;
+      inset: 0 auto 0 0;
+      z-index: 1040;
+      width: var(--yt-shell-width);
+      background: var(--sidebar);
+      border-right: 1px solid var(--border);
+      display: flex;
+      flex-direction: column;
+      padding: 14px;
+      transition: width .18s ease, transform .18s ease;
+    }
+
+    body.ytclean-collapsed .ytclean-sidebar { width: 78px; }
+    body.ytclean-collapsed .ytclean-label,
+    body.ytclean-collapsed .ytclean-sidebar-section-title,
+    body.ytclean-collapsed .ytclean-brand-text { display: none; }
+
+    .ytclean-brand {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      min-height: 44px;
+      padding: 6px 8px 14px;
+      color: var(--text);
+      text-decoration: none;
+      font-weight: 600;
+    }
+
+    .ytclean-brand-mark, .ytclean-icon-btn {
+      width: 34px;
+      height: 34px;
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      display: inline-grid;
+      place-items: center;
+      background: var(--surface);
+      color: var(--text);
+      flex: 0 0 auto;
+    }
+
+    .ytclean-icon-btn { cursor: pointer; }
+    .ytclean-icon-btn:hover, .ytclean-link:hover { background: var(--surface-secondary); }
+
+    .ytclean-nav { display: flex; flex-direction: column; gap: 4px; }
+    .ytclean-sidebar-section { padding: 10px 0; border-top: 1px solid var(--border); margin-top: 8px; }
+    .ytclean-sidebar-section-title { color: var(--text-secondary); font-size: 12px; font-weight: 600; padding: 0 10px 6px; }
+
+    .ytclean-link {
+      min-height: 42px;
+      border-radius: 10px;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 9px 10px;
+      color: var(--text);
+      text-decoration: none;
+      border: 1px solid transparent;
+      font-weight: 500;
+    }
+
+    .ytclean-link i { width: 20px; text-align: center; color: var(--text-secondary); }
+    .ytclean-link.is-active { background: var(--surface); border-color: var(--border); }
+    .ytclean-sidebar-footer { margin-top: auto; display: grid; gap: 8px; }
+
+    .ytclean-mobilebar {
+      display: none;
+      position: sticky;
+      top: 0;
+      z-index: 1030;
+      background: var(--surface);
+      border-bottom: 1px solid var(--border);
+      padding: 10px 14px;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .ytclean-drawer-backdrop { display: none; }
+
+    body.ytclean-ui #mainContent {
+      max-width: 880px !important;
+      margin: 0 auto !important;
+      padding: 32px 24px !important;
+    }
+
+    body.ytclean-ui.ytclean-main-offset {
+      margin-left: var(--yt-shell-width);
+      transition: margin-left .18s ease;
+    }
+    body.ytclean-collapsed.ytclean-ui.ytclean-main-offset { margin-left: 78px; }
+
+    body.ytclean-ui .section-header {
+      display: block !important;
+      margin: 0 0 22px !important;
+      padding: 0 !important;
+      border: 0 !important;
+      background: transparent !important;
+    }
+    body.ytclean-ui #activeSectionTitle {
+      font-size: clamp(28px, 4vw, 40px) !important;
+      line-height: 1.15;
+      font-weight: 600 !important;
+      color: var(--text) !important;
+      margin: 0 0 8px !important;
+    }
+    body.ytclean-ui #activeSectionSubtitle {
+      color: var(--text-secondary) !important;
+      font-size: 16px !important;
+      margin: 0 !important;
+    }
+    body.ytclean-ui .section-header > :not(:first-child) { display: none !important; }
+
+    body.ytclean-ui #advanced-mode > .row,
+    body.ytclean-ui #advanced-mode > .row > .col-lg-7,
+    body.ytclean-ui #advanced-mode > .row > .col-lg-7 > .card {
+      width: 100% !important;
+      max-width: 100% !important;
+    }
+
+    body.ytclean-ui #advanced-mode .brand-badge,
+    body.ytclean-ui #advanced-mode .card-body > .d-flex.flex-wrap.align-items-center.justify-content-between {
+      display: none !important;
+    }
+
+    body.ytclean-ui .card,
+    body.ytclean-ui .modal-content,
+    body.ytclean-ui .offcanvas,
+    body.ytclean-ui .accordion-item,
+    body.ytclean-ui .list-group-item {
+      background: var(--surface) !important;
+      border: 1px solid var(--border) !important;
+      border-radius: 14px !important;
+      color: var(--text) !important;
+    }
+
+    body.ytclean-ui #advanced-mode .card-body { padding: 22px !important; }
+    body.ytclean-ui label { color: var(--text) !important; font-weight: 500 !important; }
+    body.ytclean-ui .form-text, body.ytclean-ui .text-secondary { color: var(--text-secondary) !important; }
+    body.ytclean-ui .form-control, body.ytclean-ui .form-select, body.ytclean-ui textarea {
+      min-height: 46px;
+      background: var(--surface) !important;
+      border: 1px solid var(--border) !important;
+      color: var(--text) !important;
+      border-radius: 12px !important;
+    }
+    body.ytclean-ui #url { min-height: 56px; font-size: 16px; }
+    body.ytclean-ui .input-group-text { background: var(--surface-secondary) !important; border-color: var(--border) !important; color: var(--text-secondary) !important; }
+
+    body.ytclean-ui .btn { border-radius: 12px !important; font-weight: 500; }
+    body.ytclean-ui .btn-primary, body.ytclean-ui .primary-cta-btn, body.ytclean-ui #convertBtn {
+      background: var(--button-primary) !important;
+      border-color: var(--button-primary) !important;
+      color: var(--button-primary-text) !important;
+    }
+    body.ytclean-ui .btn-outline-primary, body.ytclean-ui .btn-outline-secondary {
+      color: var(--text) !important;
+      border-color: var(--border) !important;
+      background: var(--surface) !important;
+    }
+    body.ytclean-ui .progress { background: var(--surface-secondary) !important; border-radius: 999px; height: 10px !important; }
+    body.ytclean-ui .progress-bar { background: var(--button-primary) !important; }
+
+    .ytclean-ecosystem {
+      margin: 28px auto 0;
+      max-width: 880px;
+      padding-top: 18px;
+      border-top: 1px solid var(--border);
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+    .ytclean-ecosystem a { color: var(--text-secondary); text-decoration: none; font-size: 14px; }
+    .ytclean-ecosystem a:hover { color: var(--text); }
+
+    .ytclean-error-actions {
+      margin-top: 12px;
+      padding: 14px;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      background: var(--surface-secondary);
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 10px;
+    }
+    .ytclean-error-actions p { margin: 0; flex: 1 1 100%; color: var(--text); }
+
+    :focus-visible { outline: 2px solid var(--text) !important; outline-offset: 2px; }
+
+    @media (max-width: 991.98px) {
+      .ytclean-mobilebar { display: flex; position: fixed; left: 0; right: 0; }
+      .ytclean-sidebar { transform: translateX(-100%); width: 270px; }
+      body.ytclean-drawer-open .ytclean-sidebar { transform: translateX(0); }
+      body.ytclean-drawer-open .ytclean-drawer-backdrop { display: block; position: fixed; inset: 0; z-index: 1035; background: rgba(0,0,0,.35); border: 0; }
+      body.ytclean-ui.ytclean-main-offset { margin-left: 0 !important; }
+      body.ytclean-ui #mainContent { padding: 72px 16px 20px !important; }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      body.ytclean-ui *, body.ytclean-ui *::before, body.ytclean-ui *::after {
+        animation: none !important;
+        transition: none !important;
+      }
+    }
+
+
+
+    /* Responsive polish + lazy/skeleton helpers for the clean shell. */
+    body.ytclean-ui.ytclean-route-converter #mainContent { max-width: 880px !important; }
+    body.ytclean-ui.ytclean-route-studio #mainContent,
+    body.ytclean-ui.ytclean-route-history #mainContent,
+    body.ytclean-ui.ytclean-route-rewards #mainContent,
+    body.ytclean-ui.ytclean-route-support #mainContent {
+      max-width: 1120px !important;
+    }
+
+    body.ytclean-ui .app-section {
+      width: 100%;
+    }
+
+    body.ytclean-ui #section-experience .card,
+    body.ytclean-ui #section-saweria .card,
+    body.ytclean-ui #section-history .card,
+    body.ytclean-ui #historyPanel,
+    body.ytclean-ui .app-footer,
+    body.ytclean-ui .aero-footer {
+      max-width: 100% !important;
+    }
+
+    body.ytclean-ui #section-experience .row,
+    body.ytclean-ui #section-saweria .row,
+    body.ytclean-ui #section-history .row {
+      --bs-gutter-x: 1rem;
+      --bs-gutter-y: 1rem;
+    }
+
+    body.ytclean-ui .ytclean-responsive-card {
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      background: var(--surface);
+    }
+
+    .ytclean-skeleton {
+      position: relative;
+      overflow: hidden;
+      border-radius: 12px;
+      background: var(--surface-secondary);
+      min-height: 16px;
+    }
+
+    .ytclean-skeleton::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      transform: translateX(-100%);
+      background: rgba(255, 255, 255, .28);
+      animation: ytclean-skeleton 1.1s ease-in-out infinite;
+    }
+
+    html[data-bs-theme='dark'] .ytclean-skeleton::after { background: rgba(255, 255, 255, .08); }
+
+    @keyframes ytclean-skeleton {
+      100% { transform: translateX(100%); }
+    }
+
+    .ytclean-skeleton-stack {
+      display: grid;
+      gap: 12px;
+      padding: 16px;
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      background: var(--surface);
+    }
+
+    .ytclean-skeleton-stack[hidden] { display: none !important; }
+
+    body.ytclean-ui img[loading='lazy'],
+    body.ytclean-ui iframe[loading='lazy'] {
+      content-visibility: auto;
+    }
+
+    @media (min-width: 1200px) {
+      body.ytclean-ui.ytclean-route-studio #mainContent,
+      body.ytclean-ui.ytclean-route-history #mainContent,
+      body.ytclean-ui.ytclean-route-rewards #mainContent,
+      body.ytclean-ui.ytclean-route-support #mainContent {
+        max-width: 1180px !important;
+      }
+    }
+
+    @media (max-width: 575.98px) {
+      body.ytclean-ui .card-body { padding: 16px !important; }
+      body.ytclean-ui .ytclean-ecosystem { padding-inline: 16px; }
+      body.ytclean-ui .btn,
+      body.ytclean-ui .ytclean-link { min-height: 44px; }
+      body.ytclean-ui #section-experience .row > *,
+      body.ytclean-ui #section-saweria .row > *,
+      body.ytclean-ui #section-history .row > * { width: 100% !important; }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .ytclean-skeleton::after { animation: none !important; }
+    }
+
   </style>
   <style>
     :root {
@@ -2432,6 +2801,12 @@
       height: 100%;
       object-fit: cover;
       display: block;
+    }
+
+    #previewWrap .preview-visual.ytmusic-square-cover {
+      max-width: 360px;
+      margin-left: auto;
+      margin-right: auto;
     }
 
     #previewWrap .preview-visual::after {
@@ -5038,6 +5413,41 @@
 </head>
 
 <body>
+
+  <div class="ytclean-shell" aria-hidden="false">
+    <div class="ytclean-mobilebar">
+      <button class="ytclean-icon-btn" id="ytcleanOpenDrawer" type="button" aria-label="Buka menu"><i class="bi bi-list"></i></button>
+      <strong>YTConv</strong>
+      <button class="ytclean-icon-btn" id="ytcleanMobileTheme" type="button" aria-label="Ganti tema"><i class="bi bi-circle-half"></i></button>
+    </div>
+    <button class="ytclean-drawer-backdrop" id="ytcleanDrawerBackdrop" type="button" aria-label="Tutup menu"></button>
+    <aside class="ytclean-sidebar" id="ytcleanSidebar" aria-label="Navigasi utama">
+      <div class="d-flex align-items-center justify-content-between gap-2">
+        <a class="ytclean-brand" href="/" aria-label="YTConv beranda"><span class="ytclean-brand-mark"><i class="bi bi-music-note-beamed"></i></span><span class="ytclean-brand-text">YTConv</span></a>
+        <button class="ytclean-icon-btn d-none d-lg-inline-grid" id="ytcleanCollapse" type="button" aria-label="Ciutkan sidebar"><i class="bi bi-layout-sidebar-inset"></i></button>
+        <button class="ytclean-icon-btn d-lg-none" id="ytcleanCloseDrawer" type="button" aria-label="Tutup menu"><i class="bi bi-x-lg"></i></button>
+      </div>
+      <nav class="ytclean-nav" aria-label="Layanan utama">
+        <a class="ytclean-link is-active" href="/"><i class="bi bi-download"></i><span class="ytclean-label">Converter</span></a>
+        <a class="ytclean-link" href="/studio"><i class="bi bi-sliders"></i><span class="ytclean-label">Studio</span></a>
+        <a class="ytclean-link" href="/history"><i class="bi bi-clock-history"></i><span class="ytclean-label">Riwayat</span></a>
+        <a class="ytclean-link" href="https://ytconvhub.vercel.app/"><i class="bi bi-grid-3x3-gap"></i><span class="ytclean-label">YTConv Hub</span></a>
+      </nav>
+      <div class="ytclean-sidebar-section">
+        <div class="ytclean-sidebar-section-title">Ekosistem</div>
+        <nav class="ytclean-nav" aria-label="Ekosistem YTConv">
+          <a class="ytclean-link" href="https://ytconvtools.vercel.app/"><i class="bi bi-tools"></i><span class="ytclean-label">Tools</span></a>
+          <a class="ytclean-link" href="https://ytconvdocs.vercel.app/"><i class="bi bi-file-text"></i><span class="ytclean-label">Docs</span></a>
+          <a class="ytclean-link" href="https://ytconvstatus.vercel.app/"><i class="bi bi-activity"></i><span class="ytclean-label">Status</span></a>
+          <a class="ytclean-link" href="https://ytconvhelp.vercel.app/"><i class="bi bi-question-circle"></i><span class="ytclean-label">Help Center</span></a>
+        </nav>
+      </div>
+      <div class="ytclean-sidebar-footer">
+        <button class="ytclean-link" id="ytcleanSettings" type="button"><i class="bi bi-gear"></i><span class="ytclean-label">Pengaturan</span></button>
+        <button class="ytclean-link" id="ytcleanTheme" type="button"><i class="bi bi-circle-half"></i><span class="ytclean-label">Tema</span></button>
+      </div>
+    </aside>
+  </div>
   <a href="#mainContent" class="visually-hidden-focusable">Lewati ke konten utama</a>
   <nav class="navbar navbar-expand-lg sticky-top bg-body-tertiary shadow-sm">
     <div class="container d-flex align-items-center gap-3">
@@ -7823,6 +8233,14 @@
               <i class="bi bi-chevron-right modern-nav-arrow"></i>
             </button>
 
+            <!-- Help Center (mobile feature menu) -->
+            <a class="modern-nav-item d-lg-none" href="https://ytconvguide.vercel.app/" target="_blank"
+              rel="noopener noreferrer" aria-label="Buka Help Center converter">
+              <div class="modern-nav-icon"><i class="bi bi-life-preserver"></i></div>
+              <span class="modern-nav-label">Help Center</span>
+              <i class="bi bi-box-arrow-up-right modern-nav-arrow"></i>
+            </a>
+
             <!-- Divider -->
             <hr class="my-2 border-secondary-subtle opacity-25">
 
@@ -8178,12 +8596,15 @@
               <p class="text-secondary mb-4" style="max-width: 300px;">Diskusi seru, berbagi gambar, dan stiker dengan
                 warga lainnya.</p>
 
-              <button id="forumGoogleLoginBtn"
+              <button id="forumGoogleLoginBtn" type="button"
                 class="btn btn-light rounded-pill py-3 px-5 fw-bold d-flex align-items-center gap-3 shadow-lg hover-scale">
                 <img src="https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg" width="24" height="24"
                   alt="G">
                 <span>Masuk dengan Google</span>
               </button>
+              <div id="forumLoginFallback" class="small text-secondary mt-3" role="status" aria-live="polite">
+                Kalau tombol tidak merespons, tekan lagi untuk mode redirect.
+              </div>
             </div>
           </div>
 
@@ -10811,17 +11232,10 @@
 
           loginBtn.addEventListener('click', async () => {
             try {
-              const m = await waitForFirebase();
-              const { auth, signInWithPopup, signInWithRedirect, GoogleAuthProvider } = m;
+              await waitForFirebase();
               loginBtn.disabled = true;
-              loginBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>...';
-              const provider = new GoogleAuthProvider();
-              provider.setCustomParameters({ prompt: 'select_account' });
-              try {
-                await signInWithPopup(auth, provider);
-              } catch {
-                await signInWithRedirect(auth, provider);
-              }
+              loginBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>Membuka Google...';
+              await startFirebaseGoogleLogin({ status: (msg) => { loginBtn.innerHTML = `<span class="spinner-border spinner-border-sm me-2"></span>${msg}`; } });
             } catch {
               if (typeof window.setToast === 'function') window.setToast('Login gagal.', 'danger');
             } finally {
@@ -13544,19 +13958,52 @@
           return next;
         };
 
+        const converterErrorMessages = {
+          RATE_LIMITED: 'YouTube sedang membatasi koneksi dari server ini. Coba lagi nanti, jangan spam retry, atau gunakan server/IP lain.',
+          BOT_CHECK: 'YouTube meminta verifikasi bot dari koneksi server. Cookies login tidak diterima atau sudah kedaluwarsa.',
+          LOGIN_REQUIRED: 'YouTube meminta login. Cookies YouTube perlu diperbarui oleh admin.',
+          AGE_RESTRICTED: 'Video membutuhkan verifikasi umur. Admin perlu memperbarui cookies YouTube yang valid.',
+          JS_RUNTIME_MISSING: 'JavaScript runtime yt-dlp belum tersedia. Deploy image terbaru yang memasang Deno/EJS.',
+          FORMAT_UNAVAILABLE: 'Format YouTube tidak bisa dibaca dari server ini. Sistem sudah mencoba fallback; buka Help Center kalau tetap gagal.',
+          INVALID_URL: 'Link belum valid atau domain belum didukung.',
+          QUEUE_FULL: 'Antrian server sedang penuh. Tunggu sebentar lalu coba lagi.',
+        };
+
+        const isGenericConverterError = (message = '') => /^(yt-dlp gagal|gagal memproses|terjadi kesalahan|gagal membuat job)$/i.test(String(message || '').trim());
+
+        const buildApiErrorMessage = (payload = {}, rawText = '', fallbackMessage = 'Terjadi kesalahan') => {
+          const errorObj = payload && typeof payload.error === 'object' ? payload.error : {};
+          const category = payload.errorCategory || errorObj.code || errorObj.errorCategory || '';
+          const rawMessage = typeof payload.error === 'string'
+            ? payload.error
+            : (payload.message || errorObj.message || (rawText ? String(rawText).trim().slice(0, 280) : '') || fallbackMessage);
+          const message = (category && (isGenericConverterError(rawMessage) || !rawMessage))
+            ? (converterErrorMessages[category] || rawMessage || fallbackMessage)
+            : rawMessage;
+          return {
+            message: message || fallbackMessage,
+            category,
+            hint: payload.hint || errorObj.hint || '',
+            adminActionRequired: Boolean(payload.adminActionRequired || errorObj.adminActionRequired),
+          };
+        };
+
         const resolveJsonResponse = async (resp, { fallbackMessage = 'Terjadi kesalahan', logLabel = '' } = {}) => {
           const safe = await readJsonSafe(resp);
           const payload = safe.data && typeof safe.data === 'object' ? safe.data : {};
-          if (!resp?.ok) {
+          if (!resp?.ok || payload.ok === false || payload.success === false) {
             const raw = (safe.rawText || '').trim();
             if (safe.parseError) {
               console?.warn?.('[json] gagal parsing', { label: logLabel || resp?.url, error: safe.parseError, raw });
             }
-            const message = payload.error || payload.message || (raw ? raw.slice(0, 280) : '') || fallbackMessage;
-            const err = new Error(message || fallbackMessage);
+            const friendly = buildApiErrorMessage(payload, raw, fallbackMessage);
+            const err = new Error(friendly.message);
             err.status = resp?.status;
             err.payload = payload;
             err.rawText = safe.rawText;
+            err.errorCategory = friendly.category;
+            err.hint = friendly.hint;
+            err.adminActionRequired = friendly.adminActionRequired;
             throw err;
           }
           if (safe.parseError) {
@@ -13573,6 +14020,80 @@
           });
           return resolveJsonResponse(resp, options);
         };
+
+
+
+        const initYtcleanUi = () => {
+          document.body.classList.add('ytclean-ui');
+          const main = document.getElementById('mainContent');
+          if (main?.parentElement) main.parentElement.classList.add('ytclean-main-offset');
+          const title = document.getElementById('activeSectionTitle');
+          const subtitle = document.getElementById('activeSectionSubtitle');
+          const currentPath = window.location.pathname || '/';
+
+          const routeName = currentPath.startsWith('/studio') ? 'studio'
+            : currentPath.startsWith('/history') ? 'history'
+              : currentPath.startsWith('/rewards') ? 'rewards'
+                : currentPath.startsWith('/support') ? 'support'
+                  : 'converter';
+          document.body.classList.add(`ytclean-route-${routeName}`);
+          ['converter', 'studio', 'history', 'rewards', 'support'].forEach((name) => {
+            if (name !== routeName) document.body.classList.remove(`ytclean-route-${name}`);
+          });
+          const isConverterRoute = currentPath === '/' || currentPath === '';
+          if (isConverterRoute) {
+            if (title) title.textContent = 'Unduh audio atau video';
+            if (subtitle) subtitle.textContent = 'Tempel link, pilih format, lalu mulai prosesnya.';
+          }
+          document.querySelectorAll('.ytclean-link').forEach((link) => {
+            const href = link.getAttribute('href') || '';
+            const isActive = (currentPath === '/' && href === '/') || (href.startsWith('/') && href !== '/' && currentPath.startsWith(href));
+            link.classList.toggle('is-active', isActive);
+          });
+          document.querySelectorAll('a[href="https://ytconv.onrender.com/status"]').forEach((link) => { link.href = 'https://ytconvstatus.vercel.app/'; });
+          const openDrawer = () => document.body.classList.add('ytclean-drawer-open');
+          const closeDrawer = () => document.body.classList.remove('ytclean-drawer-open');
+          document.getElementById('ytcleanOpenDrawer')?.addEventListener('click', openDrawer);
+          document.getElementById('ytcleanCloseDrawer')?.addEventListener('click', closeDrawer);
+          document.getElementById('ytcleanDrawerBackdrop')?.addEventListener('click', closeDrawer);
+          document.addEventListener('keydown', (event) => { if (event.key === 'Escape') closeDrawer(); });
+          document.getElementById('ytcleanCollapse')?.addEventListener('click', () => document.body.classList.toggle('ytclean-collapsed'));
+          const cycleTheme = () => {
+            const current = localStorage.getItem('ytconv.theme.mode') || localStorage.getItem('themeMode') || 'system';
+            const next = current === 'system' ? 'light' : current === 'light' ? 'dark' : 'system';
+            localStorage.setItem('ytconv.theme.mode', next);
+            localStorage.setItem('themeMode', next === 'system' ? 'auto' : next);
+            const resolved = next === 'system'
+              ? (window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+              : next;
+            document.documentElement.setAttribute('data-bs-theme', resolved);
+            setToast?.(`Tema: ${next === 'system' ? 'Sistem' : next === 'light' ? 'Terang' : 'Gelap'}`);
+          };
+          document.getElementById('ytcleanTheme')?.addEventListener('click', cycleTheme);
+          document.getElementById('ytcleanMobileTheme')?.addEventListener('click', cycleTheme);
+          document.getElementById('ytcleanSettings')?.addEventListener('click', () => document.querySelector('[data-bs-target="#offcanvasSettings"]')?.click());
+
+          const applyLazyLoading = () => {
+            document.querySelectorAll('img').forEach((img) => {
+              if (!img.hasAttribute('loading')) img.setAttribute('loading', 'lazy');
+              if (!img.hasAttribute('decoding')) img.setAttribute('decoding', 'async');
+            });
+            document.querySelectorAll('iframe').forEach((frame) => {
+              if (!frame.hasAttribute('loading')) frame.setAttribute('loading', 'lazy');
+            });
+            document.querySelectorAll('video').forEach((video) => {
+              if (!video.hasAttribute('preload')) video.setAttribute('preload', 'metadata');
+            });
+          };
+          applyLazyLoading();
+          window.addEventListener('load', applyLazyLoading, { once: true });
+          const ecosystem = document.createElement('div');
+          ecosystem.className = 'ytclean-ecosystem';
+          ecosystem.innerHTML = '<a href="https://ytconvhub.vercel.app/"><i class="bi bi-grid-3x3-gap me-1"></i>YTConv Hub</a><a href="https://ytconvtools.vercel.app/">Tools</a><a href="https://ytconvdocs.vercel.app/">Docs</a><a href="https://ytconvstatus.vercel.app/">Status</a><a href="https://ytconvhelp.vercel.app/">Help Center</a>';
+          if (main && !document.querySelector('.ytclean-ecosystem')) main.insertAdjacentElement('afterend', ecosystem);
+        };
+        if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', initYtcleanUi, { once: true });
+        else initYtcleanUi();
 
         const xpSyncTracker = new Set();
 
@@ -16451,6 +16972,85 @@
           }
         }
 
+        function prefersGoogleRedirectLogin() {
+          const ua = navigator.userAgent || '';
+          const isMobile = /Android|iPhone|iPad|iPod|IEMobile|Opera Mini/i.test(ua);
+          const isInApp = /FBAN|FBAV|Instagram|Line|TikTok|Twitter|WebView|wv\)/i.test(ua);
+          const isStandalone = window.matchMedia?.('(display-mode: standalone)')?.matches || navigator.standalone;
+          return Boolean(isMobile || isInApp || isStandalone);
+        }
+
+        async function startFirebaseGoogleLogin({ preferRedirect = prefersGoogleRedirectLogin(), status, pendingKey = '' } = {}) {
+          const setStatus = typeof status === 'function' ? status : () => { };
+          const modules = window.firebaseModules || await new Promise((resolve, reject) => {
+            let attempts = 0;
+            const timer = window.setInterval(() => {
+              attempts += 1;
+              if (window.firebaseModules?.auth) {
+                window.clearInterval(timer);
+                resolve(window.firebaseModules);
+              } else if (attempts > 40) {
+                window.clearInterval(timer);
+                reject(new Error('Firebase auth belum siap.'));
+              }
+            }, 250);
+          });
+
+          const { auth, signInWithPopup, signInWithRedirect, GoogleAuthProvider } = modules;
+          if (!auth || !GoogleAuthProvider || (!signInWithPopup && !signInWithRedirect)) {
+            throw new Error('Login Google belum siap di browser ini.');
+          }
+
+          const provider = new GoogleAuthProvider();
+          provider.setCustomParameters({ prompt: 'select_account' });
+
+          if (preferRedirect) {
+            if (!signInWithRedirect) throw new Error('Mode redirect Google tidak tersedia.');
+            if (pendingKey) sessionStorage.setItem(pendingKey, 'true');
+            setStatus('Mengalihkan ke Google Sign-In...');
+            await signInWithRedirect(auth, provider);
+            return null;
+          }
+
+          if (signInWithPopup) {
+            try {
+              setStatus('Membuka popup Google...');
+              return await signInWithPopup(auth, provider);
+            } catch (popupErr) {
+              console.warn('Popup Google gagal, pakai redirect', popupErr);
+            }
+          }
+
+          if (!signInWithRedirect) throw new Error('Popup diblokir dan mode redirect tidak tersedia.');
+          if (pendingKey) sessionStorage.setItem(pendingKey, 'true');
+          setStatus('Popup diblokir. Mengalihkan ke Google Sign-In...');
+          await signInWithRedirect(auth, provider);
+          return null;
+        }
+
+        function appendFirebaseGoogleFallback(container, id, label = 'Masuk mode mobile') {
+          if (!container || container.querySelector(`#${id}`)) return;
+          container.insertAdjacentHTML('beforeend', `
+            <button type="button" class="btn btn-link btn-sm text-decoration-none mt-2 px-0" id="${id}">
+              ${label}
+            </button>
+          `);
+          const btn = container.querySelector(`#${id}`);
+          if (!btn) return;
+          btn.addEventListener('click', async () => {
+            btn.disabled = true;
+            btn.textContent = 'Mengalihkan ke Google...';
+            try {
+              await startFirebaseGoogleLogin({ preferRedirect: true, status: (msg) => { btn.textContent = msg; } });
+            } catch (err) {
+              console.error('Fallback login gagal', err);
+              btn.disabled = false;
+              btn.textContent = label;
+              setToast(err?.message || translateMessage('Login gagal'));
+            }
+          });
+        }
+
         function renderGoogleFallback(messageKey) {
           if (!googleSignInButton) return;
           const message = translateMessage(
@@ -16468,8 +17068,17 @@
           const fallbackBtn = googleSignInButton.querySelector('#googleFallbackAction');
           if (fallbackBtn && !fallbackBtn.dataset.bound) {
             fallbackBtn.dataset.bound = 'true';
-            fallbackBtn.addEventListener('click', () => {
-              setToast(message);
+            fallbackBtn.addEventListener('click', async () => {
+              fallbackBtn.disabled = true;
+              fallbackBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>Mengalihkan ke Google...';
+              try {
+                await startFirebaseGoogleLogin({ preferRedirect: true });
+              } catch (err) {
+                console.error('Google fallback login gagal', err);
+                fallbackBtn.disabled = false;
+                fallbackBtn.innerHTML = `<i class="bi bi-google"></i><span>${translateMessage('Masuk dengan Google')}</span>`;
+                setToast(err?.message || message);
+              }
             });
           }
         }
@@ -16580,6 +17189,7 @@
               text: 'signin_with',
               shape: 'pill',
             });
+            appendFirebaseGoogleFallback(googleSignInButton, 'googleMobileFallbackAction');
           }
 
           const googleSignInForum = document.getElementById('googleSignInForum');
@@ -16604,6 +17214,7 @@
               shape: 'pill',
               width: '300'
             });
+            appendFirebaseGoogleFallback(profileGoogleLoginBtn, 'profileMobileFallbackAction');
           }
         }
 
@@ -19457,7 +20068,8 @@
           const spotifyPreviewUrl = previewProvider === 'spotify'
             ? previewInfo.url || original?.previewUrl || ''
             : '';
-          const canEmbedYoutube = embedAllowed && (provider === 'youtube' || isYoutubeUrl(info.webpageUrl || '')) && info.id;
+          const wantsSquareArtwork = info.artworkShape === 'square' || isYoutubeMusicUrl(info.webpageUrl || '') || isYoutubeMusicUrl(original?.url || '');
+          const canEmbedYoutube = embedAllowed && !wantsSquareArtwork && (provider === 'youtube' || isYoutubeUrl(info.webpageUrl || '')) && info.id;
           const canEmbedSpotify = embedAllowed && !!spotifyEmbedUrl;
           if (videoPreviewFrame) {
             if (canEmbedYoutube) {
@@ -19476,8 +20088,11 @@
             }
           }
           if (videoPreviewWrap) {
-            const disabled = !embedAllowed || (!canEmbedYoutube && !canEmbedSpotify);
+            const disabled = !wantsSquareArtwork && (!embedAllowed || (!canEmbedYoutube && !canEmbedSpotify));
             videoPreviewWrap.classList.toggle('is-disabled', disabled);
+            videoPreviewWrap.classList.toggle('ratio-16x9', !wantsSquareArtwork);
+            videoPreviewWrap.classList.toggle('ratio-1x1', wantsSquareArtwork);
+            videoPreviewWrap.classList.toggle('ytmusic-square-cover', wantsSquareArtwork);
           }
           if (thumbEl) {
             if (info.cover || info.thumbnail) {
@@ -21660,6 +22275,16 @@
           return detectMediaSource(text) === 'youtube';
         }
 
+        function isYoutubeMusicUrl(text = '') {
+          const raw = String(text || '').trim();
+          if (!raw) return false;
+          try {
+            return new URL(raw).hostname.toLowerCase().endsWith('music.youtube.com');
+          } catch {
+            return /(^|\.)music\.youtube\.com/i.test(raw);
+          }
+        }
+
         const RATING_STORE_KEY = 'ytmp3.ratings.v1';
 
         function loadRatingStore() {
@@ -23441,13 +24066,22 @@
           return xp;
         };
 
-        function toFriendlyConvertError(message = '') {
+        function toFriendlyConvertError(error = '') {
+          const message = typeof error === 'string' ? error : (error?.message || '');
+          const category = typeof error === 'string' ? '' : (error?.errorCategory || error?.payload?.errorCategory || error?.payload?.error?.code || '');
+          const hint = typeof error === 'string' ? '' : (error?.hint || error?.payload?.hint || '');
+          const categorized = category && converterErrorMessages[category] ? converterErrorMessages[category] : '';
           const raw = String(message || '').toLowerCase();
-          if (raw.includes('age') || raw.includes('restricted') || raw.includes('cookies')) return 'Video ini diblokir atau butuh cookies. Coba video lain atau update cookies ya.';
-          if (raw.includes('429') || raw.includes('too many') || raw.includes('rate')) return 'Server lagi padat. Santai, coba lagi sebentar ya.';
-          if (raw.includes('invalid') && raw.includes('url')) return 'Link belum valid. Cek lagi lalu kirim ulang ya.';
-          if (raw.includes('captcha')) return 'Verifikasi keamanan belum lolos. Coba klik convert sekali lagi ya.';
-          return `Hmm gagal nih, coba lagi yaa… (${message || 'unknown'})`;
+          let friendly = categorized || message;
+          if (!friendly || isGenericConverterError(friendly)) friendly = 'Hmm gagal nih, coba lagi yaa…';
+          if (!categorized) {
+            if (raw.includes('age') || raw.includes('restricted') || raw.includes('cookies')) friendly = 'Video membutuhkan cookies YouTube terbaru. Admin perlu memperbarui cookies di Admin Cookies Manager.';
+            else if (raw.includes('429') || raw.includes('too many') || raw.includes('rate') || raw.includes('bot')) friendly = 'YouTube sedang membatasi koneksi server. Tunggu dulu, jangan retry berkali-kali, atau gunakan server/IP lain.';
+            else if (raw.includes('invalid') && raw.includes('url')) friendly = 'Link belum valid. Cek lagi lalu kirim ulang ya.';
+            else if (raw.includes('captcha')) friendly = 'Verifikasi keamanan belum lolos. Coba klik convert sekali lagi ya.';
+          }
+          if (hint && !friendly.includes(hint)) friendly = `${friendly} ${hint}`;
+          return friendly;
         }
 
         function getSpeedServerLabel(mode = 'auto') {
@@ -23866,7 +24500,17 @@
             }
             if ($('#autoClear').checked && !overrideUrl) { $('#clearBtn').click(); }
           } catch (err) {
-            $('#status').textContent = translateMessage(`Error: ${err.message}`);
+            $('#status').textContent = 'Proses belum berhasil. Coba lagi atau buka Help Center.';
+            let cleanActions = document.getElementById('ytcleanConvertErrorActions');
+            if (!cleanActions) {
+              cleanActions = document.createElement('div');
+              cleanActions.id = 'ytcleanConvertErrorActions';
+              cleanActions.className = 'ytclean-error-actions';
+              cleanActions.setAttribute('aria-live', 'polite');
+              document.getElementById('statusWrap')?.appendChild(cleanActions);
+            }
+            cleanActions.innerHTML = '<p>Proses belum berhasil. Coba lagi atau buka Help Center.</p><button type="button" class="btn btn-primary btn-sm" id="ytcleanRetryConvert">Coba Lagi</button><a class="btn btn-outline-secondary btn-sm" href="https://ytconvhelp.vercel.app/">Buka Help Center</a>';
+            document.getElementById('ytcleanRetryConvert')?.addEventListener('click', () => doConvert(null, false), { once: true });
             $('#loadingSpinner').style.display = 'none';
             if (window.manageCTAState) window.manageCTAState('completed');
             $('#resultWrap').hidden = true;
@@ -23876,7 +24520,7 @@
             $('#logs').textContent = (err && err.stack) ? err.stack : String(err);
             resetAudioPreview();
             convertProgressAnimator.fail(translateMessage('Gagal'));
-            const friendlyErr = toFriendlyConvertError(err?.message || '');
+            const friendlyErr = toFriendlyConvertError(err);
             setToast(friendlyErr);
             announceNarrator(`Konversi gagal: ${friendlyErr}`);
             updateAiStatus(friendlyErr, 'danger');
@@ -28030,10 +28674,13 @@
               <h3 class="fw-bold mb-2 text-white" style="letter-spacing: -0.5px;">Gabung Forum</h3>
               <p class="text-secondary mb-4" style="max-width: 300px;">Diskusi seru, berbagi gambar, dan stiker dengan warga lainnya.</p>
               
-              <button id="forumGoogleLoginBtn" class="btn btn-light rounded-pill py-3 px-5 fw-bold d-flex align-items-center gap-3 shadow-lg hover-scale">
+              <button id="forumGoogleLoginBtn" type="button" class="btn btn-light rounded-pill py-3 px-5 fw-bold d-flex align-items-center gap-3 shadow-lg hover-scale">
                   <img src="https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg" width="24" height="24" alt="G">
                   <span>Masuk dengan Google</span>
-              </button>`;
+              </button>
+              <div id="forumLoginFallback" class="small text-secondary mt-3" role="status" aria-live="polite">
+                Kalau tombol tidak merespons, tekan lagi untuk mode redirect.
+              </div>`;
             const newBtn = document.getElementById('forumGoogleLoginBtn');
             if (newBtn) newBtn.addEventListener('click', handleLoginClick);
           }
@@ -28859,33 +29506,50 @@
             });
           }
 
-          async function handleLoginClick() {
-            // ... (Keep existing login logic mostly same but ensure new UI is handled)
+          function setForumLoginFallback(message, variant = 'secondary') {
+            const fallback = document.getElementById('forumLoginFallback');
+            if (!fallback) return;
+            fallback.className = `small text-${variant} mt-3`;
+            fallback.textContent = message;
+          }
+
+          function resetForumLoginButton() {
             const btn = document.getElementById('forumGoogleLoginBtn');
             if (!btn) return;
-            if (!window.firebaseModules || !window.firebaseModules.auth) return;
-            const { auth, signInWithPopup, GoogleAuthProvider, signInWithRedirect } = window.firebaseModules;
-            btn.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>...';
+            btn.disabled = false;
+            btn.innerHTML = '<img src="https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg" width="24" height="24" alt="G"><span>Masuk dengan Google</span>';
+          }
+
+          async function handleLoginClick() {
+            const btn = document.getElementById('forumGoogleLoginBtn');
+            if (!btn) return;
+            if (!window.firebaseModules || !window.firebaseModules.auth) {
+              setForumLoginFallback('Login sedang dimuat. Tunggu sebentar lalu tekan lagi.', 'warning');
+              return;
+            }
+
+            btn.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>Membuka Google...';
             btn.disabled = true;
+            setForumLoginFallback(prefersGoogleRedirectLogin()
+              ? 'Mode mobile aktif. Mengalihkan ke Google Sign-In...'
+              : 'Jika popup tidak muncul, sistem otomatis memakai mode redirect.', 'info');
+
             try {
-              const provider = new GoogleAuthProvider();
-              provider.setCustomParameters({ prompt: 'select_account' });
-              try {
-                const result = await signInWithPopup(auth, provider);
-                if (result && result.user) {
-                  setToast('Login berhasil!', 'success');
-                  sessionStorage.removeItem('forum_login_pending');
-                  forumLoginOverlay.classList.remove('d-flex');
-                  forumLoginOverlay.classList.add('d-none');
-                }
-              } catch (popupErr) {
-                sessionStorage.setItem('forum_login_pending', 'true');
-                await signInWithRedirect(auth, provider);
+              const result = await startFirebaseGoogleLogin({
+                pendingKey: 'forum_login_pending',
+                status: (msg) => setForumLoginFallback(msg, 'info'),
+              });
+              if (result && result.user) {
+                setToast('Login berhasil!', 'success');
+                sessionStorage.removeItem('forum_login_pending');
+                forumLoginOverlay.classList.remove('d-flex');
+                forumLoginOverlay.classList.add('d-none');
               }
             } catch (error) {
-              console.error(error);
-              btn.innerHTML = 'Login Google';
-              btn.disabled = false;
+              console.error('Forum login failed', error);
+              sessionStorage.removeItem('forum_login_pending');
+              setForumLoginFallback(error?.message || 'Login belum bisa dibuka. Muat ulang halaman atau izinkan popup/redirect Google.', 'danger');
+              resetForumLoginButton();
             }
           }
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 import express from "express";
 import compression from "compression";
 import cors from "cors";
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readdirSync } from "node:fs";
 import { promises as fsp } from "node:fs";
 import { createServer, request as httpRequest } from "node:http";
@@ -2916,19 +2916,63 @@ const cleanVideoTitle = (rawTitle = "") => {
   return result.replace(/\s{2,}/g, " ").trim();
 };
 
-const extractBestThumbnail = (info) => {
+const isYoutubeMusicUrl = (value = "") => {
+  const raw = typeof value === "string" ? value.trim() : "";
+  if (!raw) return false;
+  try {
+    return new URL(raw).hostname.toLowerCase().endsWith("music.youtube.com");
+  } catch {
+    return /(^|\.)music\.youtube\.com/i.test(raw);
+  }
+};
+
+const normalizeThumbnailItems = (info = {}) => {
+  const items = [];
+  if (typeof info?.thumbnail === "string" && info.thumbnail.trim()) {
+    items.push({ url: info.thumbnail.trim(), width: Number(info.width) || 0, height: Number(info.height) || 0 });
+  }
+  if (Array.isArray(info?.thumbnails)) {
+    info.thumbnails.forEach((item) => {
+      if (!item || typeof item !== "object" || !item.url) return;
+      items.push({
+        url: String(item.url),
+        width: Number(item.width) || 0,
+        height: Number(item.height) || 0,
+      });
+    });
+  }
+  const seen = new Set();
+  return items.filter((item) => {
+    if (!item.url || seen.has(item.url)) return false;
+    seen.add(item.url);
+    return true;
+  });
+};
+
+const extractBestThumbnail = (info, { preferSquare = false } = {}) => {
   if (!info || typeof info !== "object") return null;
-  if (typeof info.thumbnail === "string" && info.thumbnail.trim()) {
-    return info.thumbnail.trim();
+  const items = normalizeThumbnailItems(info);
+  if (!items.length) return null;
+  const sortedByWidth = [...items].sort((a, b) => (Number(b.width) || 0) - (Number(a.width) || 0));
+  if (preferSquare) {
+    const scored = [...items]
+      .map((item) => {
+        const width = Number(item.width) || 0;
+        const height = Number(item.height) || 0;
+        const ratio = width > 0 && height > 0 ? width / height : 1;
+        return {
+          item,
+          ratioDelta: Math.abs(1 - ratio),
+          area: width * height,
+        };
+      })
+      .filter(({ item }) => item.url);
+    scored.sort((a, b) => (a.ratioDelta - b.ratioDelta) || (b.area - a.area));
+    const squareCandidate = scored.find(({ ratioDelta }) => ratioDelta <= 0.2) || scored[0];
+    if (squareCandidate?.item?.url) return squareCandidate.item.url;
   }
-  if (Array.isArray(info.thumbnails)) {
-    const sorted = [...info.thumbnails]
-      .filter((item) => item && typeof item === "object")
-      .sort((a, b) => (Number(b?.width) || 0) - (Number(a?.width) || 0));
-    const candidate = sorted.find((item) => item?.url) || sorted[0];
-    if (candidate?.url) return String(candidate.url);
-  }
-  return null;
+  const candidate = sortedByWidth.find((item) => item?.url) || sortedByWidth[0];
+  return candidate?.url ? String(candidate.url) : null;
 };
 
 const buildVideoMetadata = (entry = {}, { requestedUrl = "", keywordUsed = false } = {}) => {
@@ -2954,7 +2998,8 @@ const buildVideoMetadata = (entry = {}, { requestedUrl = "", keywordUsed = false
     ? entry.tags.map((tag) => (tag == null ? null : String(tag))).filter(Boolean)
     : [];
 
-  const cover = extractBestThumbnail(entry);
+  const preferSquareArtwork = isYoutubeMusicUrl(requestedUrl) || isYoutubeMusicUrl(entry.original_url) || isYoutubeMusicUrl(entry.webpage_url);
+  const cover = extractBestThumbnail(entry, { preferSquare: preferSquareArtwork });
 
   return {
     id: entry.id || null,
@@ -2965,6 +3010,7 @@ const buildVideoMetadata = (entry = {}, { requestedUrl = "", keywordUsed = false
     album: album || cleaned || baseTitle,
     cover,
     thumbnail: cover,
+    artworkShape: preferSquareArtwork ? "square" : "wide",
     duration,
     webpageUrl,
     keywords,
@@ -3089,13 +3135,14 @@ const runYtDlpAttempt = (command, args, { label }) =>
 
 const categorizeYtDlpError = (value = "") => {
   const raw = String(value || "");
+  if (/429|too many requests|rate.?limit/i.test(raw)) return "RATE_LIMITED";
   if (/sign in to confirm|not a bot|bot check|use --cookies|cookies-from-browser|confirm you(?:\'|’)re not a bot/i.test(raw)) return "BOT_CHECK";
   if (/login required|sign in|private video|members-only|account/i.test(raw)) return "LOGIN_REQUIRED";
   if (/age[- ]?restricted|confirm your age|age restriction/i.test(raw)) return "AGE_RESTRICTED";
   if (/not available in your country|geo|region/i.test(raw)) return "GEO_BLOCKED";
   if (/private video/i.test(raw)) return "PRIVATE_VIDEO";
-  if (/requested format is not available|no video formats|only images are available|format/i.test(raw)) return "FORMAT_UNAVAILABLE";
-  if (/429|too many requests|rate.?limit/i.test(raw)) return "RATE_LIMITED";
+  if (/JS runtimes:\s*none|No supported JavaScript runtime|JavaScript runtime could be found|js runtime/i.test(raw)) return "JS_RUNTIME_MISSING";
+  if (/requested format is not available|no video formats|only images are available|Use --list-formats/i.test(raw)) return "FORMAT_UNAVAILABLE";
   if (/ffmpeg/i.test(raw)) return "FFMPEG_MISSING";
   if (/yt-dlp tidak bisa dijalankan|yt-dlp.*not found|no such file/i.test(raw)) return "YTDLP_MISSING";
   if (/network|timed?out|econn|enotfound|http error 5\d\d/i.test(raw)) return "NETWORK_ERROR";
@@ -3124,13 +3171,26 @@ const publicDownloadError = (err) => {
   const logs = err?.logs || err?.message || "";
   const category = err?.errorCategory || categorizeYtDlpError(logs);
   const needsAdminCookies = ["BOT_CHECK", "LOGIN_REQUIRED", "AGE_RESTRICTED"].includes(category);
-  const message = needsAdminCookies
-    ? "Video membutuhkan cookies YouTube terbaru. Admin perlu memperbarui cookies di Admin Cookies Manager."
-    : (err?.message || "Gagal memproses video");
+  const messages = {
+    RATE_LIMITED: "YouTube sedang membatasi koneksi dari server ini. Coba lagi nanti, kurangi percobaan berulang, atau gunakan server/IP lain.",
+    BOT_CHECK: "YouTube meminta verifikasi bot dari koneksi server. Cookies login tidak diterima atau sudah kedaluwarsa.",
+    LOGIN_REQUIRED: "YouTube meminta login. Cookies login tidak diterima atau sudah tidak berlaku.",
+    AGE_RESTRICTED: "Video membutuhkan verifikasi umur. Admin perlu memperbarui cookies YouTube yang valid.",
+    JS_RUNTIME_MISSING: "JavaScript runtime yt-dlp belum tersedia. Pasang Deno/EJS atau set YTDLP_JS_RUNTIME yang valid.",
+    FORMAT_UNAVAILABLE: "Format YouTube yang tersedia berubah atau tidak bisa dibaca. Sistem sudah mencoba format fallback; coba lagi nanti atau pakai Panduan Error.",
+  };
+  const message = messages[category] || err?.message || "Gagal memproses video";
+  const hints = {
+    RATE_LIMITED: "Server/IP kemungkinan terkena rate limit YouTube. Hindari retry bertubi-tubi; pindah IP/server jika 429 tetap muncul.",
+    BOT_CHECK: "Admin: upload cookies Netscape baru dari sesi incognito YouTube, tutup sesi setelah ekspor, lalu jalankan Test Cookies.",
+    LOGIN_REQUIRED: "Admin: perbarui cookies YouTube dari sesi login yang masih valid dan pastikan format Netscape LF.",
+    AGE_RESTRICTED: "Admin: gunakan cookies akun cadangan yang sudah lolos verifikasi umur.",
+    JS_RUNTIME_MISSING: "Deploy image terbaru yang memasang Deno dan yt-dlp[default], atau set YTDLP_JS_RUNTIME=deno.",
+  };
   const wrapped = new Error(message);
   wrapped.errorCategory = category;
-  wrapped.adminActionRequired = needsAdminCookies;
-  wrapped.hint = needsAdminCookies ? "Admin: buka Admin Cookies Manager, upload cookies Netscape terbaru, lalu jalankan Test Cookies." : undefined;
+  wrapped.adminActionRequired = Boolean(needsAdminCookies || category === "RATE_LIMITED" || category === "JS_RUNTIME_MISSING");
+  wrapped.hint = hints[category];
   wrapped.logs = logs;
   return wrapped;
 };
@@ -7192,18 +7252,38 @@ const parseMajorVersion = (value = "") => {
   return match ? Number(match[1]) : 0;
 };
 
+const commandExistsSync = (cmd = "") => {
+  if (!cmd) return false;
+  const result = spawnSync(cmd, ["--version"], { stdio: "ignore" });
+  return !result.error;
+};
+
 const getYtDlpJsRuntimeArgs = () => {
-  const runtime = String(process.env.YTDLP_JS_RUNTIME || "node").trim().toLowerCase();
+  const runtime = String(process.env.YTDLP_JS_RUNTIME || "deno").trim().toLowerCase();
   if (runtime === "off" || runtime === "none" || runtime === "0") return [];
 
   const nodeMajor = parseMajorVersion(process.version);
-  const selected = runtime || "node";
+  let selected = runtime || "deno";
+  if (selected === "auto") {
+    if (commandExistsSync("deno")) selected = "deno";
+    else if (nodeMajor >= 22) selected = "node";
+    else selected = "";
+  }
+
+  if (selected === "deno" && !commandExistsSync("deno")) {
+    if (nodeMajor >= 22) selected = "node";
+    else {
+      console.warn("[yt-dlp] Deno is not installed and Node is below yt-dlp JS runtime minimum; skipping --js-runtimes");
+      return [];
+    }
+  }
   if (selected === "node" && nodeMajor < 22) {
     console.warn(`[yt-dlp] Node ${process.version} is below yt-dlp 2026.06.09 minimum for JS runtime; skipping --js-runtimes node`);
     return [];
   }
+  if (!selected) return [];
 
-  return ["--js-runtimes", selected, "--remote-components", "ejs:github", "--extractor-retries", "3"];
+  return ["--js-runtimes", selected, "--remote-components", "ejs:npm", "--extractor-retries", "3"];
 };
 
 
@@ -7230,6 +7310,49 @@ const pushYoutubeExtractorArgs = (args = []) => {
     args.push("--extractor-args", value);
   }
   return args;
+};
+
+const replaceYtDlpFormatSelector = (args = [], selector = "") => {
+  const next = Array.isArray(args) ? [...args] : [];
+  const url = next[next.length - 1];
+  const isUrlLike = typeof url === "string" && /^(https?:|ytsearch|ytmsearch)/i.test(url);
+  const urlArg = isUrlLike ? next.pop() : null;
+  let replaced = false;
+  for (let i = 0; i < next.length - 1; i++) {
+    if (next[i] === "-f" && typeof next[i + 1] === "string") {
+      if (selector) next[i + 1] = selector;
+      else next.splice(i, 2);
+      replaced = true;
+      break;
+    }
+  }
+  if (!replaced && selector) next.push("-f", selector);
+  if (urlArg) next.push(urlArg);
+  return next;
+};
+
+const removeYtDlpJsRuntimeArgs = (args = []) => {
+  const next = [];
+  const source = Array.isArray(args) ? args : [];
+  for (let i = 0; i < source.length; i++) {
+    const item = source[i];
+    if (["--js-runtimes", "--remote-components", "--extractor-retries"].includes(item)) {
+      i += 1;
+      continue;
+    }
+    next.push(item);
+  }
+  return next;
+};
+
+const dedupeYtDlpArgPlans = (plans = []) => {
+  const seen = new Set();
+  return plans.filter((plan) => {
+    const key = JSON.stringify(plan.args || []);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
 };
 
 const buildYtDlpFallbackArgs = (args = []) => {
@@ -7302,8 +7425,11 @@ const runYtDlpDownload = ({ args, id, onProgress }) =>
     });
     proc.on("close", (code) => {
       if (code !== 0) {
-        const error = new Error("yt-dlp gagal");
+        const category = categorizeYtDlpError(logs || `yt-dlp exited with code ${code}`);
+        const error = new Error(category === "UNKNOWN" ? "yt-dlp gagal" : `yt-dlp gagal (${category})`);
         error.logs = logs;
+        error.errorCategory = category;
+        error.exitCode = code;
         return reject(error);
       }
       const files = readdirSync(JOBS_DIR).filter((f) =>
@@ -7742,6 +7868,7 @@ const convertSingle = async (payload = {}) => {
 
     let logs = "";
     let downloadResult = null;
+    let lastDownloadErrorCategory = "";
 
     // Untuk Spotify: metadata dari spotDL, download dari YouTube Music/YouTube via yt-dlp
     // Preview URL hanya untuk metadata, tidak digunakan untuk download
@@ -7753,6 +7880,7 @@ const convertSingle = async (payload = {}) => {
       } catch (err) {
         const baseLogs = err.logs || "";
         const errorCategory = categorizeYtDlpError(baseLogs || err?.message || "");
+        lastDownloadErrorCategory = errorCategory;
         const shouldRetryWithFallbackArgs = /Requested format is not available|HTTP Error 400|HTTP Error 403|Forbidden|Sign in|cookies|confirm your age|precondition|This video is unavailable/i.test(baseLogs || "") || isCookieRetryCategory(errorCategory);
         if (isCookieRetryCategory(errorCategory)) {
           const cookieRetry = await appendServerCookiesArgs(args);
@@ -7769,32 +7897,33 @@ const convertSingle = async (payload = {}) => {
           }
         }
         if (!downloadResult && shouldRetryWithFallbackArgs) {
-          try {
-            emitProgress({ stage: "downloading", message: "Mencoba mode kompatibilitas", percent: mapDownloadPercent(18) });
-            const fallbackArgs = buildYtDlpFallbackArgs(args);
-            downloadResult = await runYtDlpDownload({ args: fallbackArgs, id, onProgress: handleDownloadProgress });
-            logs = downloadResult.logs || baseLogs;
-          } catch (retryErr) {
-            logs = retryErr?.logs || logs || baseLogs;
-          }
-        }
-        if (!downloadResult && shouldRetryWithFallbackArgs) {
-          try {
-            emitProgress({ stage: "downloading", message: "Mencoba format universal", percent: mapDownloadPercent(19) });
-            const universalArgs = buildYtDlpFallbackArgs(args);
-            for (let i = 0; i < universalArgs.length - 1; i++) {
-              if (universalArgs[i] === "-f") {
-                universalArgs.splice(i, 2);
-                break;
-              }
+          const retryPlans = dedupeYtDlpArgPlans([
+            { label: "mode kompatibilitas", percent: 18, args: buildYtDlpFallbackArgs(args) },
+            { label: "audio universal", percent: 19, args: replaceYtDlpFormatSelector(buildYtDlpFallbackArgs(args), "ba/bestaudio/best/worst") },
+            { label: "format otomatis", percent: 20, args: replaceYtDlpFormatSelector(buildYtDlpFallbackArgs(args), "") },
+            { label: "format otomatis tanpa JS runtime", percent: 21, args: removeYtDlpJsRuntimeArgs(replaceYtDlpFormatSelector(buildYtDlpFallbackArgs(args), "")) },
+          ]);
+
+          for (const plan of retryPlans) {
+            if (downloadResult) break;
+            try {
+              emitProgress({ stage: "downloading", message: `Mencoba ${plan.label}`, percent: mapDownloadPercent(plan.percent) });
+              downloadResult = await runYtDlpDownload({ args: plan.args, id, onProgress: handleDownloadProgress });
+              logs = downloadResult.logs || logs || baseLogs;
+            } catch (retryErr) {
+              logs = retryErr?.logs || logs || baseLogs;
+              lastDownloadErrorCategory = categorizeYtDlpError(logs);
             }
-            downloadResult = await runYtDlpDownload({ args: universalArgs, id, onProgress: handleDownloadProgress });
-            logs = downloadResult.logs || logs || baseLogs;
-          } catch (retryErr) {
-            logs = retryErr?.logs || logs || baseLogs;
           }
         }
         if (!downloadResult) {
+          if (["RATE_LIMITED", "BOT_CHECK"].includes(lastDownloadErrorCategory)) {
+            if (coverPath) try { await fsp.unlink(coverPath); } catch { }
+            const restrictedError = new Error(err.message || "YouTube membatasi koneksi server");
+            restrictedError.logs = [logs, baseLogs].filter(Boolean).join("\n").slice(-8000);
+            restrictedError.errorCategory = lastDownloadErrorCategory;
+            throw restrictedError;
+          }
           if (isVideoFormat) {
             if (coverPath) try { await fsp.unlink(coverPath); } catch { }
             const videoError = new Error(err.message || "Gagal mengunduh video");
@@ -8012,6 +8141,8 @@ const convertSingle = async (payload = {}) => {
         artist: metadata.artist || null,
         album: metadata.album || null,
         cover: metadata.cover || null,
+        thumbnail: metadata.thumbnail || metadata.cover || null,
+        artworkShape: metadata.artworkShape || null,
         duration: metadata.duration || null,
         webpageUrl: metadata.webpageUrl || null,
         keywords: metadata.keywords || [],

--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -1704,6 +1704,375 @@
       box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
     }
 
+
+
+    /* YTConv clean professional shell (neutral, no gradients/glow). */
+    :root {
+      --background: #ffffff;
+      --sidebar: #f7f7f8;
+      --surface: #ffffff;
+      --surface-secondary: #f4f4f4;
+      --border: #e5e5e5;
+      --text: #202123;
+      --text-secondary: #6b6b6b;
+      --button-primary: #212121;
+      --button-primary-text: #ffffff;
+      --success: #17803d;
+      --warning: #a15c00;
+      --danger: #c83232;
+      --yt-shell-width: 264px;
+    }
+
+    html[data-bs-theme='dark'] {
+      --background: #212121;
+      --sidebar: #171717;
+      --surface: #2f2f2f;
+      --surface-secondary: #262626;
+      --border: #424242;
+      --text: #ececec;
+      --text-secondary: #b4b4b4;
+      --button-primary: #f4f4f4;
+      --button-primary-text: #171717;
+    }
+
+    html, body {
+      overflow-x: hidden;
+    }
+
+    body.ytclean-ui {
+      margin: 0;
+      background: var(--background) !important;
+      color: var(--text) !important;
+      font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif !important;
+      font-size: 16px;
+      line-height: 1.5;
+    }
+
+    body.ytclean-ui :where(.card, .modal-content, .offcanvas, .dropdown-menu, .accordion-item, .list-group-item, .btn, .ytclean-link, .ytclean-sidebar, .ytclean-mobilebar) {
+      text-shadow: none !important;
+      box-shadow: none !important;
+      background-image: none !important;
+      filter: none !important;
+      backdrop-filter: none !important;
+      -webkit-backdrop-filter: none !important;
+    }
+
+    body.ytclean-ui .app-header-lite,
+    body.ytclean-ui #converterGuideBtn,
+    body.ytclean-ui #converterGuideMobileBtn {
+      display: none !important;
+    }
+
+    .ytclean-shell {
+      min-height: 0;
+      height: 0;
+      background: var(--background);
+    }
+
+    .ytclean-sidebar {
+      position: fixed;
+      inset: 0 auto 0 0;
+      z-index: 1040;
+      width: var(--yt-shell-width);
+      background: var(--sidebar);
+      border-right: 1px solid var(--border);
+      display: flex;
+      flex-direction: column;
+      padding: 14px;
+      transition: width .18s ease, transform .18s ease;
+    }
+
+    body.ytclean-collapsed .ytclean-sidebar { width: 78px; }
+    body.ytclean-collapsed .ytclean-label,
+    body.ytclean-collapsed .ytclean-sidebar-section-title,
+    body.ytclean-collapsed .ytclean-brand-text { display: none; }
+
+    .ytclean-brand {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      min-height: 44px;
+      padding: 6px 8px 14px;
+      color: var(--text);
+      text-decoration: none;
+      font-weight: 600;
+    }
+
+    .ytclean-brand-mark, .ytclean-icon-btn {
+      width: 34px;
+      height: 34px;
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      display: inline-grid;
+      place-items: center;
+      background: var(--surface);
+      color: var(--text);
+      flex: 0 0 auto;
+    }
+
+    .ytclean-icon-btn { cursor: pointer; }
+    .ytclean-icon-btn:hover, .ytclean-link:hover { background: var(--surface-secondary); }
+
+    .ytclean-nav { display: flex; flex-direction: column; gap: 4px; }
+    .ytclean-sidebar-section { padding: 10px 0; border-top: 1px solid var(--border); margin-top: 8px; }
+    .ytclean-sidebar-section-title { color: var(--text-secondary); font-size: 12px; font-weight: 600; padding: 0 10px 6px; }
+
+    .ytclean-link {
+      min-height: 42px;
+      border-radius: 10px;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 9px 10px;
+      color: var(--text);
+      text-decoration: none;
+      border: 1px solid transparent;
+      font-weight: 500;
+    }
+
+    .ytclean-link i { width: 20px; text-align: center; color: var(--text-secondary); }
+    .ytclean-link.is-active { background: var(--surface); border-color: var(--border); }
+    .ytclean-sidebar-footer { margin-top: auto; display: grid; gap: 8px; }
+
+    .ytclean-mobilebar {
+      display: none;
+      position: sticky;
+      top: 0;
+      z-index: 1030;
+      background: var(--surface);
+      border-bottom: 1px solid var(--border);
+      padding: 10px 14px;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .ytclean-drawer-backdrop { display: none; }
+
+    body.ytclean-ui #mainContent {
+      max-width: 880px !important;
+      margin: 0 auto !important;
+      padding: 32px 24px !important;
+    }
+
+    body.ytclean-ui.ytclean-main-offset {
+      margin-left: var(--yt-shell-width);
+      transition: margin-left .18s ease;
+    }
+    body.ytclean-collapsed.ytclean-ui.ytclean-main-offset { margin-left: 78px; }
+
+    body.ytclean-ui .section-header {
+      display: block !important;
+      margin: 0 0 22px !important;
+      padding: 0 !important;
+      border: 0 !important;
+      background: transparent !important;
+    }
+    body.ytclean-ui #activeSectionTitle {
+      font-size: clamp(28px, 4vw, 40px) !important;
+      line-height: 1.15;
+      font-weight: 600 !important;
+      color: var(--text) !important;
+      margin: 0 0 8px !important;
+    }
+    body.ytclean-ui #activeSectionSubtitle {
+      color: var(--text-secondary) !important;
+      font-size: 16px !important;
+      margin: 0 !important;
+    }
+    body.ytclean-ui .section-header > :not(:first-child) { display: none !important; }
+
+    body.ytclean-ui #advanced-mode > .row,
+    body.ytclean-ui #advanced-mode > .row > .col-lg-7,
+    body.ytclean-ui #advanced-mode > .row > .col-lg-7 > .card {
+      width: 100% !important;
+      max-width: 100% !important;
+    }
+
+    body.ytclean-ui #advanced-mode .brand-badge,
+    body.ytclean-ui #advanced-mode .card-body > .d-flex.flex-wrap.align-items-center.justify-content-between {
+      display: none !important;
+    }
+
+    body.ytclean-ui .card,
+    body.ytclean-ui .modal-content,
+    body.ytclean-ui .offcanvas,
+    body.ytclean-ui .accordion-item,
+    body.ytclean-ui .list-group-item {
+      background: var(--surface) !important;
+      border: 1px solid var(--border) !important;
+      border-radius: 14px !important;
+      color: var(--text) !important;
+    }
+
+    body.ytclean-ui #advanced-mode .card-body { padding: 22px !important; }
+    body.ytclean-ui label { color: var(--text) !important; font-weight: 500 !important; }
+    body.ytclean-ui .form-text, body.ytclean-ui .text-secondary { color: var(--text-secondary) !important; }
+    body.ytclean-ui .form-control, body.ytclean-ui .form-select, body.ytclean-ui textarea {
+      min-height: 46px;
+      background: var(--surface) !important;
+      border: 1px solid var(--border) !important;
+      color: var(--text) !important;
+      border-radius: 12px !important;
+    }
+    body.ytclean-ui #url { min-height: 56px; font-size: 16px; }
+    body.ytclean-ui .input-group-text { background: var(--surface-secondary) !important; border-color: var(--border) !important; color: var(--text-secondary) !important; }
+
+    body.ytclean-ui .btn { border-radius: 12px !important; font-weight: 500; }
+    body.ytclean-ui .btn-primary, body.ytclean-ui .primary-cta-btn, body.ytclean-ui #convertBtn {
+      background: var(--button-primary) !important;
+      border-color: var(--button-primary) !important;
+      color: var(--button-primary-text) !important;
+    }
+    body.ytclean-ui .btn-outline-primary, body.ytclean-ui .btn-outline-secondary {
+      color: var(--text) !important;
+      border-color: var(--border) !important;
+      background: var(--surface) !important;
+    }
+    body.ytclean-ui .progress { background: var(--surface-secondary) !important; border-radius: 999px; height: 10px !important; }
+    body.ytclean-ui .progress-bar { background: var(--button-primary) !important; }
+
+    .ytclean-ecosystem {
+      margin: 28px auto 0;
+      max-width: 880px;
+      padding-top: 18px;
+      border-top: 1px solid var(--border);
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+    .ytclean-ecosystem a { color: var(--text-secondary); text-decoration: none; font-size: 14px; }
+    .ytclean-ecosystem a:hover { color: var(--text); }
+
+    .ytclean-error-actions {
+      margin-top: 12px;
+      padding: 14px;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      background: var(--surface-secondary);
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 10px;
+    }
+    .ytclean-error-actions p { margin: 0; flex: 1 1 100%; color: var(--text); }
+
+    :focus-visible { outline: 2px solid var(--text) !important; outline-offset: 2px; }
+
+    @media (max-width: 991.98px) {
+      .ytclean-mobilebar { display: flex; position: fixed; left: 0; right: 0; }
+      .ytclean-sidebar { transform: translateX(-100%); width: 270px; }
+      body.ytclean-drawer-open .ytclean-sidebar { transform: translateX(0); }
+      body.ytclean-drawer-open .ytclean-drawer-backdrop { display: block; position: fixed; inset: 0; z-index: 1035; background: rgba(0,0,0,.35); border: 0; }
+      body.ytclean-ui.ytclean-main-offset { margin-left: 0 !important; }
+      body.ytclean-ui #mainContent { padding: 72px 16px 20px !important; }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      body.ytclean-ui *, body.ytclean-ui *::before, body.ytclean-ui *::after {
+        animation: none !important;
+        transition: none !important;
+      }
+    }
+
+
+
+    /* Responsive polish + lazy/skeleton helpers for the clean shell. */
+    body.ytclean-ui.ytclean-route-converter #mainContent { max-width: 880px !important; }
+    body.ytclean-ui.ytclean-route-studio #mainContent,
+    body.ytclean-ui.ytclean-route-history #mainContent,
+    body.ytclean-ui.ytclean-route-rewards #mainContent,
+    body.ytclean-ui.ytclean-route-support #mainContent {
+      max-width: 1120px !important;
+    }
+
+    body.ytclean-ui .app-section {
+      width: 100%;
+    }
+
+    body.ytclean-ui #section-experience .card,
+    body.ytclean-ui #section-saweria .card,
+    body.ytclean-ui #section-history .card,
+    body.ytclean-ui #historyPanel,
+    body.ytclean-ui .app-footer,
+    body.ytclean-ui .aero-footer {
+      max-width: 100% !important;
+    }
+
+    body.ytclean-ui #section-experience .row,
+    body.ytclean-ui #section-saweria .row,
+    body.ytclean-ui #section-history .row {
+      --bs-gutter-x: 1rem;
+      --bs-gutter-y: 1rem;
+    }
+
+    body.ytclean-ui .ytclean-responsive-card {
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      background: var(--surface);
+    }
+
+    .ytclean-skeleton {
+      position: relative;
+      overflow: hidden;
+      border-radius: 12px;
+      background: var(--surface-secondary);
+      min-height: 16px;
+    }
+
+    .ytclean-skeleton::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      transform: translateX(-100%);
+      background: rgba(255, 255, 255, .28);
+      animation: ytclean-skeleton 1.1s ease-in-out infinite;
+    }
+
+    html[data-bs-theme='dark'] .ytclean-skeleton::after { background: rgba(255, 255, 255, .08); }
+
+    @keyframes ytclean-skeleton {
+      100% { transform: translateX(100%); }
+    }
+
+    .ytclean-skeleton-stack {
+      display: grid;
+      gap: 12px;
+      padding: 16px;
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      background: var(--surface);
+    }
+
+    .ytclean-skeleton-stack[hidden] { display: none !important; }
+
+    body.ytclean-ui img[loading='lazy'],
+    body.ytclean-ui iframe[loading='lazy'] {
+      content-visibility: auto;
+    }
+
+    @media (min-width: 1200px) {
+      body.ytclean-ui.ytclean-route-studio #mainContent,
+      body.ytclean-ui.ytclean-route-history #mainContent,
+      body.ytclean-ui.ytclean-route-rewards #mainContent,
+      body.ytclean-ui.ytclean-route-support #mainContent {
+        max-width: 1180px !important;
+      }
+    }
+
+    @media (max-width: 575.98px) {
+      body.ytclean-ui .card-body { padding: 16px !important; }
+      body.ytclean-ui .ytclean-ecosystem { padding-inline: 16px; }
+      body.ytclean-ui .btn,
+      body.ytclean-ui .ytclean-link { min-height: 44px; }
+      body.ytclean-ui #section-experience .row > *,
+      body.ytclean-ui #section-saweria .row > *,
+      body.ytclean-ui #section-history .row > * { width: 100% !important; }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .ytclean-skeleton::after { animation: none !important; }
+    }
+
   </style>
   <style>
     :root {
@@ -2668,6 +3037,12 @@
       height: 100%;
       object-fit: cover;
       display: block;
+    }
+
+    #previewWrap .preview-visual.ytmusic-square-cover {
+      max-width: 360px;
+      margin-left: auto;
+      margin-right: auto;
     }
 
     #previewWrap .preview-visual::after {
@@ -5327,11 +5702,13 @@
 
 
     /* No-glass UI pass: mobile + desktop use solid surfaces and no expensive shadows/blurs. */
-    body:not(.keep-rich-shadows),
-    body:not(.keep-rich-shadows) :where(*) {
+    body:not(.keep-rich-shadows) {
       --bs-box-shadow: none;
       --bs-box-shadow-sm: none;
       --bs-box-shadow-lg: none;
+    }
+
+    body:not(.keep-rich-shadows) :where(.card, .btn, .modal-content, .offcanvas, .dropdown-menu, .accordion-item, .list-group-item, .history-item, .modern-card, .feature-card, .status-card, .history-card, .assistant-toggle, .footer-pill) {
       box-shadow: none !important;
       text-shadow: none !important;
       backdrop-filter: none !important;
@@ -5636,6 +6013,41 @@
 </head>
 
 <body>
+
+  <div class="ytclean-shell" aria-hidden="false">
+    <div class="ytclean-mobilebar">
+      <button class="ytclean-icon-btn" id="ytcleanOpenDrawer" type="button" aria-label="Buka menu"><i class="bi bi-list"></i></button>
+      <strong>YTConv</strong>
+      <button class="ytclean-icon-btn" id="ytcleanMobileTheme" type="button" aria-label="Ganti tema"><i class="bi bi-circle-half"></i></button>
+    </div>
+    <button class="ytclean-drawer-backdrop" id="ytcleanDrawerBackdrop" type="button" aria-label="Tutup menu"></button>
+    <aside class="ytclean-sidebar" id="ytcleanSidebar" aria-label="Navigasi utama">
+      <div class="d-flex align-items-center justify-content-between gap-2">
+        <a class="ytclean-brand" href="/" aria-label="YTConv beranda"><span class="ytclean-brand-mark"><i class="bi bi-music-note-beamed"></i></span><span class="ytclean-brand-text">YTConv</span></a>
+        <button class="ytclean-icon-btn d-none d-lg-inline-grid" id="ytcleanCollapse" type="button" aria-label="Ciutkan sidebar"><i class="bi bi-layout-sidebar-inset"></i></button>
+        <button class="ytclean-icon-btn d-lg-none" id="ytcleanCloseDrawer" type="button" aria-label="Tutup menu"><i class="bi bi-x-lg"></i></button>
+      </div>
+      <nav class="ytclean-nav" aria-label="Layanan utama">
+        <a class="ytclean-link is-active" href="/"><i class="bi bi-download"></i><span class="ytclean-label">Converter</span></a>
+        <a class="ytclean-link" href="/studio"><i class="bi bi-sliders"></i><span class="ytclean-label">Studio</span></a>
+        <a class="ytclean-link" href="/history"><i class="bi bi-clock-history"></i><span class="ytclean-label">Riwayat</span></a>
+        <a class="ytclean-link" href="https://ytconvhub.vercel.app/"><i class="bi bi-grid-3x3-gap"></i><span class="ytclean-label">YTConv Hub</span></a>
+      </nav>
+      <div class="ytclean-sidebar-section">
+        <div class="ytclean-sidebar-section-title">Ekosistem</div>
+        <nav class="ytclean-nav" aria-label="Ekosistem YTConv">
+          <a class="ytclean-link" href="https://ytconvtools.vercel.app/"><i class="bi bi-tools"></i><span class="ytclean-label">Tools</span></a>
+          <a class="ytclean-link" href="https://ytconvdocs.vercel.app/"><i class="bi bi-file-text"></i><span class="ytclean-label">Docs</span></a>
+          <a class="ytclean-link" href="https://ytconvstatus.vercel.app/"><i class="bi bi-activity"></i><span class="ytclean-label">Status</span></a>
+          <a class="ytclean-link" href="https://ytconvhelp.vercel.app/"><i class="bi bi-question-circle"></i><span class="ytclean-label">Help Center</span></a>
+        </nav>
+      </div>
+      <div class="ytclean-sidebar-footer">
+        <button class="ytclean-link" id="ytcleanSettings" type="button"><i class="bi bi-gear"></i><span class="ytclean-label">Pengaturan</span></button>
+        <button class="ytclean-link" id="ytcleanTheme" type="button"><i class="bi bi-circle-half"></i><span class="ytclean-label">Tema</span></button>
+      </div>
+    </aside>
+  </div>
   <a href="#mainContent" class="visually-hidden-focusable">Lewati ke konten utama</a>
   <nav class="navbar navbar-expand-lg sticky-top bg-body-tertiary app-header-lite">
     <div class="container d-flex align-items-center gap-3">
@@ -8554,6 +8966,14 @@
               <span class="modern-nav-label">Bantuan</span>
               <i class="bi bi-chevron-right modern-nav-arrow"></i>
             </button>
+
+            <!-- Help Center (mobile feature menu) -->
+            <a class="modern-nav-item d-lg-none" href="https://ytconvguide.vercel.app/" target="_blank"
+              rel="noopener noreferrer" aria-label="Buka Help Center converter">
+              <div class="modern-nav-icon"><i class="bi bi-life-preserver"></i></div>
+              <span class="modern-nav-label">Help Center</span>
+              <i class="bi bi-box-arrow-up-right modern-nav-arrow"></i>
+            </a>
 
             <!-- Divider -->
             <hr class="my-2 border-secondary-subtle opacity-25">
@@ -14714,19 +15134,52 @@
           return next;
         };
 
+        const converterErrorMessages = {
+          RATE_LIMITED: 'YouTube sedang membatasi koneksi dari server ini. Coba lagi nanti, jangan spam retry, atau gunakan server/IP lain.',
+          BOT_CHECK: 'YouTube meminta verifikasi bot dari koneksi server. Cookies login tidak diterima atau sudah kedaluwarsa.',
+          LOGIN_REQUIRED: 'YouTube meminta login. Cookies YouTube perlu diperbarui oleh admin.',
+          AGE_RESTRICTED: 'Video membutuhkan verifikasi umur. Admin perlu memperbarui cookies YouTube yang valid.',
+          JS_RUNTIME_MISSING: 'JavaScript runtime yt-dlp belum tersedia. Deploy image terbaru yang memasang Deno/EJS.',
+          FORMAT_UNAVAILABLE: 'Format YouTube tidak bisa dibaca dari server ini. Sistem sudah mencoba fallback; buka Help Center kalau tetap gagal.',
+          INVALID_URL: 'Link belum valid atau domain belum didukung.',
+          QUEUE_FULL: 'Antrian server sedang penuh. Tunggu sebentar lalu coba lagi.',
+        };
+
+        const isGenericConverterError = (message = '') => /^(yt-dlp gagal|gagal memproses|terjadi kesalahan|gagal membuat job)$/i.test(String(message || '').trim());
+
+        const buildApiErrorMessage = (payload = {}, rawText = '', fallbackMessage = 'Terjadi kesalahan') => {
+          const errorObj = payload && typeof payload.error === 'object' ? payload.error : {};
+          const category = payload.errorCategory || errorObj.code || errorObj.errorCategory || '';
+          const rawMessage = typeof payload.error === 'string'
+            ? payload.error
+            : (payload.message || errorObj.message || (rawText ? String(rawText).trim().slice(0, 280) : '') || fallbackMessage);
+          const message = (category && (isGenericConverterError(rawMessage) || !rawMessage))
+            ? (converterErrorMessages[category] || rawMessage || fallbackMessage)
+            : rawMessage;
+          return {
+            message: message || fallbackMessage,
+            category,
+            hint: payload.hint || errorObj.hint || '',
+            adminActionRequired: Boolean(payload.adminActionRequired || errorObj.adminActionRequired),
+          };
+        };
+
         const resolveJsonResponse = async (resp, { fallbackMessage = 'Terjadi kesalahan', logLabel = '' } = {}) => {
           const safe = await readJsonSafe(resp);
           const payload = safe.data && typeof safe.data === 'object' ? safe.data : {};
-          if (!resp?.ok) {
+          if (!resp?.ok || payload.ok === false || payload.success === false) {
             const raw = (safe.rawText || '').trim();
             if (safe.parseError) {
               console?.warn?.('[json] gagal parsing', { label: logLabel || resp?.url, error: safe.parseError, raw });
             }
-            const message = payload.error || payload.message || (raw ? raw.slice(0, 280) : '') || fallbackMessage;
-            const err = new Error(message || fallbackMessage);
+            const friendly = buildApiErrorMessage(payload, raw, fallbackMessage);
+            const err = new Error(friendly.message);
             err.status = resp?.status;
             err.payload = payload;
             err.rawText = safe.rawText;
+            err.errorCategory = friendly.category;
+            err.hint = friendly.hint;
+            err.adminActionRequired = friendly.adminActionRequired;
             throw err;
           }
           if (safe.parseError) {
@@ -14752,6 +15205,80 @@
           });
           return resolveJsonResponse(resp, options);
         };
+
+
+
+        const initYtcleanUi = () => {
+          document.body.classList.add('ytclean-ui');
+          const main = document.getElementById('mainContent');
+          if (main?.parentElement) main.parentElement.classList.add('ytclean-main-offset');
+          const title = document.getElementById('activeSectionTitle');
+          const subtitle = document.getElementById('activeSectionSubtitle');
+          const currentPath = window.location.pathname || '/';
+
+          const routeName = currentPath.startsWith('/studio') ? 'studio'
+            : currentPath.startsWith('/history') ? 'history'
+              : currentPath.startsWith('/rewards') ? 'rewards'
+                : currentPath.startsWith('/support') ? 'support'
+                  : 'converter';
+          document.body.classList.add(`ytclean-route-${routeName}`);
+          ['converter', 'studio', 'history', 'rewards', 'support'].forEach((name) => {
+            if (name !== routeName) document.body.classList.remove(`ytclean-route-${name}`);
+          });
+          const isConverterRoute = currentPath === '/' || currentPath === '';
+          if (isConverterRoute) {
+            if (title) title.textContent = 'Unduh audio atau video';
+            if (subtitle) subtitle.textContent = 'Tempel link, pilih format, lalu mulai prosesnya.';
+          }
+          document.querySelectorAll('.ytclean-link').forEach((link) => {
+            const href = link.getAttribute('href') || '';
+            const isActive = (currentPath === '/' && href === '/') || (href.startsWith('/') && href !== '/' && currentPath.startsWith(href));
+            link.classList.toggle('is-active', isActive);
+          });
+          document.querySelectorAll('a[href="https://ytconv.onrender.com/status"]').forEach((link) => { link.href = 'https://ytconvstatus.vercel.app/'; });
+          const openDrawer = () => document.body.classList.add('ytclean-drawer-open');
+          const closeDrawer = () => document.body.classList.remove('ytclean-drawer-open');
+          document.getElementById('ytcleanOpenDrawer')?.addEventListener('click', openDrawer);
+          document.getElementById('ytcleanCloseDrawer')?.addEventListener('click', closeDrawer);
+          document.getElementById('ytcleanDrawerBackdrop')?.addEventListener('click', closeDrawer);
+          document.addEventListener('keydown', (event) => { if (event.key === 'Escape') closeDrawer(); });
+          document.getElementById('ytcleanCollapse')?.addEventListener('click', () => document.body.classList.toggle('ytclean-collapsed'));
+          const cycleTheme = () => {
+            const current = localStorage.getItem('ytconv.theme.mode') || localStorage.getItem('themeMode') || 'system';
+            const next = current === 'system' ? 'light' : current === 'light' ? 'dark' : 'system';
+            localStorage.setItem('ytconv.theme.mode', next);
+            localStorage.setItem('themeMode', next === 'system' ? 'auto' : next);
+            const resolved = next === 'system'
+              ? (window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+              : next;
+            document.documentElement.setAttribute('data-bs-theme', resolved);
+            setToast?.(`Tema: ${next === 'system' ? 'Sistem' : next === 'light' ? 'Terang' : 'Gelap'}`);
+          };
+          document.getElementById('ytcleanTheme')?.addEventListener('click', cycleTheme);
+          document.getElementById('ytcleanMobileTheme')?.addEventListener('click', cycleTheme);
+          document.getElementById('ytcleanSettings')?.addEventListener('click', () => document.querySelector('[data-bs-target="#offcanvasSettings"]')?.click());
+
+          const applyLazyLoading = () => {
+            document.querySelectorAll('img').forEach((img) => {
+              if (!img.hasAttribute('loading')) img.setAttribute('loading', 'lazy');
+              if (!img.hasAttribute('decoding')) img.setAttribute('decoding', 'async');
+            });
+            document.querySelectorAll('iframe').forEach((frame) => {
+              if (!frame.hasAttribute('loading')) frame.setAttribute('loading', 'lazy');
+            });
+            document.querySelectorAll('video').forEach((video) => {
+              if (!video.hasAttribute('preload')) video.setAttribute('preload', 'metadata');
+            });
+          };
+          applyLazyLoading();
+          window.addEventListener('load', applyLazyLoading, { once: true });
+          const ecosystem = document.createElement('div');
+          ecosystem.className = 'ytclean-ecosystem';
+          ecosystem.innerHTML = '<a href="https://ytconvhub.vercel.app/"><i class="bi bi-grid-3x3-gap me-1"></i>YTConv Hub</a><a href="https://ytconvtools.vercel.app/">Tools</a><a href="https://ytconvdocs.vercel.app/">Docs</a><a href="https://ytconvstatus.vercel.app/">Status</a><a href="https://ytconvhelp.vercel.app/">Help Center</a>';
+          if (main && !document.querySelector('.ytclean-ecosystem')) main.insertAdjacentElement('afterend', ecosystem);
+        };
+        if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', initYtcleanUi, { once: true });
+        else initYtcleanUi();
 
         const xpSyncTracker = new Set();
 
@@ -21148,7 +21675,8 @@
           const spotifyPreviewUrl = previewProvider === 'spotify'
             ? previewInfo.url || original?.previewUrl || ''
             : '';
-          const canEmbedYoutube = embedAllowed && (provider === 'youtube' || isYoutubeUrl(info.webpageUrl || '')) && info.id;
+          const wantsSquareArtwork = info.artworkShape === 'square' || isYoutubeMusicUrl(info.webpageUrl || '') || isYoutubeMusicUrl(original?.url || '');
+          const canEmbedYoutube = embedAllowed && !wantsSquareArtwork && (provider === 'youtube' || isYoutubeUrl(info.webpageUrl || '')) && info.id;
           const canEmbedSpotify = embedAllowed && !!spotifyEmbedUrl;
           if (videoPreviewFrame) {
             if (canEmbedYoutube) {
@@ -21167,8 +21695,11 @@
             }
           }
           if (videoPreviewWrap) {
-            const disabled = !embedAllowed || (!canEmbedYoutube && !canEmbedSpotify);
+            const disabled = !wantsSquareArtwork && (!embedAllowed || (!canEmbedYoutube && !canEmbedSpotify));
             videoPreviewWrap.classList.toggle('is-disabled', disabled);
+            videoPreviewWrap.classList.toggle('ratio-16x9', !wantsSquareArtwork);
+            videoPreviewWrap.classList.toggle('ratio-1x1', wantsSquareArtwork);
+            videoPreviewWrap.classList.toggle('ytmusic-square-cover', wantsSquareArtwork);
           }
           if (thumbEl) {
             if (info.cover || info.thumbnail) {
@@ -23479,6 +24010,16 @@
           return detectMediaSource(text) === 'youtube';
         }
 
+        function isYoutubeMusicUrl(text = '') {
+          const raw = String(text || '').trim();
+          if (!raw) return false;
+          try {
+            return new URL(raw).hostname.toLowerCase().endsWith('music.youtube.com');
+          } catch {
+            return /(^|\.)music\.youtube\.com/i.test(raw);
+          }
+        }
+
         const RATING_STORE_KEY = 'ytmp3.ratings.v1';
 
         function loadRatingStore() {
@@ -25382,13 +25923,22 @@
           return xp;
         };
 
-        function toFriendlyConvertError(message = '') {
+        function toFriendlyConvertError(error = '') {
+          const message = typeof error === 'string' ? error : (error?.message || '');
+          const category = typeof error === 'string' ? '' : (error?.errorCategory || error?.payload?.errorCategory || error?.payload?.error?.code || '');
+          const hint = typeof error === 'string' ? '' : (error?.hint || error?.payload?.hint || '');
+          const categorized = category && converterErrorMessages[category] ? converterErrorMessages[category] : '';
           const raw = String(message || '').toLowerCase();
-          if (raw.includes('age') || raw.includes('restricted') || raw.includes('cookies')) return 'Video membutuhkan cookies YouTube terbaru. Admin perlu memperbarui cookies di Admin Cookies Manager.';
-          if (raw.includes('429') || raw.includes('too many') || raw.includes('rate')) return 'Server lagi padat. Santai, coba lagi sebentar ya.';
-          if (raw.includes('invalid') && raw.includes('url')) return 'Link belum valid. Cek lagi lalu kirim ulang ya.';
-          if (raw.includes('captcha')) return 'Verifikasi keamanan belum lolos. Coba klik convert sekali lagi ya.';
-          return `Hmm gagal nih, coba lagi yaa… (${message || 'unknown'})`;
+          let friendly = categorized || message;
+          if (!friendly || isGenericConverterError(friendly)) friendly = 'Hmm gagal nih, coba lagi yaa…';
+          if (!categorized) {
+            if (raw.includes('age') || raw.includes('restricted') || raw.includes('cookies')) friendly = 'Video membutuhkan cookies YouTube terbaru. Admin perlu memperbarui cookies di Admin Cookies Manager.';
+            else if (raw.includes('429') || raw.includes('too many') || raw.includes('rate') || raw.includes('bot')) friendly = 'YouTube sedang membatasi koneksi server. Tunggu dulu, jangan retry berkali-kali, atau gunakan server/IP lain.';
+            else if (raw.includes('invalid') && raw.includes('url')) friendly = 'Link belum valid. Cek lagi lalu kirim ulang ya.';
+            else if (raw.includes('captcha')) friendly = 'Verifikasi keamanan belum lolos. Coba klik convert sekali lagi ya.';
+          }
+          if (hint && !friendly.includes(hint)) friendly = `${friendly} ${hint}`;
+          return friendly;
         }
 
         function getSpeedServerLabel(mode = 'auto') {
@@ -25812,7 +26362,17 @@
             }
             if ($('#autoClear').checked && !overrideUrl) { $('#clearBtn').click(); }
           } catch (err) {
-            $('#status').textContent = translateMessage(`Error: ${err.message}`);
+            $('#status').textContent = 'Proses belum berhasil. Coba lagi atau buka Help Center.';
+            let cleanActions = document.getElementById('ytcleanConvertErrorActions');
+            if (!cleanActions) {
+              cleanActions = document.createElement('div');
+              cleanActions.id = 'ytcleanConvertErrorActions';
+              cleanActions.className = 'ytclean-error-actions';
+              cleanActions.setAttribute('aria-live', 'polite');
+              document.getElementById('statusWrap')?.appendChild(cleanActions);
+            }
+            cleanActions.innerHTML = '<p>Proses belum berhasil. Coba lagi atau buka Help Center.</p><button type="button" class="btn btn-primary btn-sm" id="ytcleanRetryConvert">Coba Lagi</button><a class="btn btn-outline-secondary btn-sm" href="https://ytconvhelp.vercel.app/">Buka Help Center</a>';
+            document.getElementById('ytcleanRetryConvert')?.addEventListener('click', () => doConvert(null, false), { once: true });
             $('#loadingSpinner').style.display = 'none';
             if (window.manageCTAState) window.manageCTAState('completed');
             $('#resultWrap').hidden = true;
@@ -25822,7 +26382,7 @@
             $('#logs').textContent = (err && err.stack) ? err.stack : String(err);
             resetAudioPreview();
             convertProgressAnimator.fail(translateMessage('Gagal'));
-            const friendlyErr = toFriendlyConvertError(err?.message || '');
+            const friendlyErr = toFriendlyConvertError(err);
             try {
               ensureForumSocket()?.emit('conversion_error', { reason: friendlyErr || 'convert_error' });
               window.reportUserAction?.('conversion_error', friendlyErr || 'convert_error');

--- a/src/lib/converterState.js
+++ b/src/lib/converterState.js
@@ -82,6 +82,7 @@ export const publicJobSnapshot = (job = {}) => {
     downloadUrl: job.downloadUrl || null,
     error,
     errorCategory: job.errorCategory || error?.code || null,
+    hint: job.hint || null,
     createdAt: job.createdAt || null,
     startedAt: job.startedAt || null,
     completedAt: job.completedAt || null,

--- a/src/lib/env.js
+++ b/src/lib/env.js
@@ -138,7 +138,7 @@ export const loadEnv = (rawEnv = process.env) => {
     INTERNAL_API_KEY: str(rawEnv.INTERNAL_API_KEY),
     INTERNAL_REQUEST_TIMEOUT_MS: int(rawEnv.INTERNAL_REQUEST_TIMEOUT_MS, 15_000, { min: 500, max: 120_000 }),
 
-    YTDLP_JS_RUNTIME: str(rawEnv.YTDLP_JS_RUNTIME, "node"),
+    YTDLP_JS_RUNTIME: str(rawEnv.YTDLP_JS_RUNTIME, "deno"),
     YTDLP_PATH: str(rawEnv.YTDLP_PATH),
     FFMPEG_PATH: str(rawEnv.FFMPEG_PATH),
     FFPROBE_PATH: str(rawEnv.FFPROBE_PATH),


### PR DESCRIPTION
### Motivation
- Provide a more robust yt-dlp JavaScript runtime by shipping Deno in the Docker image and defaulting to Deno where available to improve extractor handling for JS-challenged YouTube endpoints.
- Improve downloader resiliency with better runtime detection, richer retry/fallback strategies, and clearer error categorization so the server recovers from common yt-dlp failures (rate limits, bot checks, format changes, missing JS runtime).
- Improve client UX by adding a lightweight "YTClean" shell, clearer error messages and retry actions, and better Google sign-in fallback handling for mobile/in-app browsers.

### Description
- Docker: install Deno in the Dockerfile, add `unzip`, set `YTDLP_JS_RUNTIME=deno` environment variable, and install `yt-dlp[default]` via pip.
- Environment: change default `YTDLP_JS_RUNTIME` to `deno` in `src/lib/env.js` and document `YTDLP_JS_RUNTIME=deno` recommendation in `docs/ENVIRONMENT.md` (with `auto` fallback note).
- Python helper (`download_audio.py`): default JS runtime to `deno`, support `auto` selection and fallback to Node, return `remote_components` as `ejs:npm`, expand format fallback options and include a no-JS-runtime attempt in the attempt order.
- Node server (`index.js` and supporting libs): add `spawnSync` helper, `commandExistsSync`, richer `getYtDlpJsRuntimeArgs` selection (support `deno`, `auto`, fallback to node when appropriate), switch remote components to `ejs:npm`, add functions to replace/dedupe yt-dlp args, remove JS runtime args for fallback runs, enhance error categorization (`JS_RUNTIME_MISSING`, `RATE_LIMITED`, etc.), improve public download error messages and hints, expand yt-music artwork handling and thumbnail normalization, include `hint` in public job snapshot and serialized store, and implement deduplicated retry plans for yt-dlp downloads (compatibility, audio-focused, no-JS runtime fallbacks).
- UI/client (large changes in `index.html` and `public-ui/index.html`): add the YTClean UI shell (sidebar, mobile bar, theme cycling, lazy-loading helpers), improved friendly converter error messages and inline retry/help actions, Google sign-in improvements with `startFirebaseGoogleLogin` and popup/redirect fallbacks, and various accessibility and responsive tweaks (aria/live regions, keyboard handling, reduced-motion respect).

### Testing
- No automated tests were executed as part of this PR; changes were limited to runtime/install, server logic, retry behavior, and front-end templates and should be validated with the repository's existing CI/test workflows and a local smoke test of conversion flows (ensure Docker image build, yt-dlp runtime selection, and client interactions behave as expected).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52230495988331bb9d58999efc9054)