### PR TITLE
Fix mobile header stacking and touch handling

### DIFF
--- a/public-ui/index.html
+++ b/public-ui/index.html
@@ -1912,30 +1912,58 @@
     .ytclean-sidebar-footer { margin-top: auto; display: grid; gap: 8px; padding-bottom: max(12px, env(safe-area-inset-bottom)); }
     @media (max-height: 760px) { .ytclean-sidebar-footer { margin-top: 10px; } }
 
+    :root {
+      --ytclean-mobilebar-z: 2147482000;
+      --ytclean-mobilebar-top-gap: 10px;
+      --ytclean-mobilebar-x-gap: 12px;
+      --ytclean-mobilebar-min-height: 56px;
+      --ytclean-mobilebar-padding-y: 10px;
+      --ytclean-mobilebar-safe-offset: calc(env(safe-area-inset-top, 0px) + var(--ytclean-mobilebar-top-gap));
+      --ytclean-mobilebar-total-height: calc(var(--ytclean-mobilebar-safe-offset) + var(--ytclean-mobilebar-min-height) + (var(--ytclean-mobilebar-padding-y) * 2));
+    }
+
     .ytclean-mobilebar {
       display: none;
-      position: sticky;
-      top: 0;
-      z-index: 120130;
-      min-height: 56px;
+      position: fixed;
+      top: var(--ytclean-mobilebar-safe-offset);
+      left: var(--ytclean-mobilebar-x-gap);
+      right: var(--ytclean-mobilebar-x-gap);
+      width: auto;
+      z-index: var(--ytclean-mobilebar-z);
+      min-height: var(--ytclean-mobilebar-min-height);
       background: #18181b !important;
       background-color: #18181b !important;
       border: 1px solid rgba(148, 163, 184, .42);
       border-radius: 18px;
       pointer-events: auto;
-      padding: 10px 14px;
+      padding: var(--ytclean-mobilebar-padding-y) 14px;
       align-items: center;
       justify-content: space-between;
       box-shadow: 0 12px 34px rgba(0, 0, 0, .55) !important;
       isolation: isolate;
-      transform: translateZ(0);
-      -webkit-transform: translateZ(0);
-      overflow: hidden;
+      overflow: visible;
+      touch-action: manipulation;
+    }
+
+    .ytclean-mobilebar::before,
+    .ytclean-mobilebar::after {
+      pointer-events: none;
+    }
+
+    .ytclean-mobilebar .ytclean-icon-btn,
+    .ytclean-mobilebar a,
+    .ytclean-mobilebar button {
+      position: relative;
+      z-index: calc(var(--ytclean-mobilebar-z) + 1);
+      pointer-events: auto;
+      touch-action: manipulation;
     }
 
     .ytclean-drawer-backdrop { display: none; }
 
     body.ytclean-ui #mainContent {
+      position: relative;
+      z-index: 1;
       max-width: 880px !important;
       margin: 0 auto !important;
       padding: 32px 24px !important;
@@ -2046,13 +2074,13 @@
     :focus-visible { outline: 2px solid var(--text) !important; outline-offset: 2px; }
 
     @media (max-width: 991.98px) {
-      .ytclean-mobilebar { display: flex !important; position: fixed !important; top: calc(env(safe-area-inset-top) + 10px) !important; left: 12px; right: 12px; }
-      .ytclean-sidebar { transform: translateX(-100%); width: min(86vw, 310px); }
-      body.ytclean-drawer-open .ytclean-sidebar { transform: translateX(0); padding-top: calc(86px + env(safe-area-inset-top)); }
-      body.ytclean-drawer-open .ytclean-drawer-backdrop { display: block; position: fixed; inset: 0; z-index: 120090; background: rgba(0,0,0,.55); border: 0; pointer-events: auto; }
+      .ytclean-mobilebar { display: flex !important; }
+      .ytclean-sidebar { transform: translateX(-100%); width: min(86vw, 310px); z-index: calc(var(--ytclean-mobilebar-z) - 10); }
+      body.ytclean-drawer-open .ytclean-sidebar { transform: translateX(0); padding-top: calc(var(--ytclean-mobilebar-total-height) + 10px); }
+      body.ytclean-drawer-open .ytclean-drawer-backdrop { display: block; position: fixed; inset: 0; z-index: calc(var(--ytclean-mobilebar-z) - 20); background: rgba(0,0,0,.55); border: 0; pointer-events: auto; }
       body.ytclean-drawer-open { overflow: hidden; }
       body.ytclean-ui.ytclean-main-offset { margin-left: 0 !important; }
-      body.ytclean-ui #mainContent { padding: calc(96px + env(safe-area-inset-top)) 16px 20px !important; }
+      body.ytclean-ui #mainContent { padding: calc(var(--ytclean-mobilebar-total-height) + 20px) 16px 20px !important; }
     }
 
     body.has-open-modal .ytclean-mobilebar,

--- a/tests/frontend-ia.test.js
+++ b/tests/frontend-ia.test.js
@@ -39,15 +39,20 @@ test('clean UI boots with skeleton and scrollable sidebar', () => {
 });
 
 test('mobile clean header stays above drawer layers and can toggle drawer', () => {
-  assert.match(html, /\.ytclean-mobilebar \{[\s\S]*?z-index: 120130;/);
-  assert.match(html, /min-height: 56px;/);
+  assert.match(html, /--ytclean-mobilebar-z: 2147482000;/);
+  assert.match(html, /--ytclean-mobilebar-safe-offset: calc\(env\(safe-area-inset-top, 0px\) \+ var\(--ytclean-mobilebar-top-gap\)\);/);
+  assert.match(html, /--ytclean-mobilebar-total-height: calc\(var\(--ytclean-mobilebar-safe-offset\) \+ var\(--ytclean-mobilebar-min-height\) \+ \(var\(--ytclean-mobilebar-padding-y\) \* 2\)\);/);
+  assert.match(html, /\.ytclean-mobilebar \{[\s\S]*?position: fixed;[\s\S]*?z-index: var\(--ytclean-mobilebar-z\);/);
+  assert.match(html, /min-height: var\(--ytclean-mobilebar-min-height\);/);
   assert.match(html, /background: #18181b !important;/);
   assert.match(html, /background-color: #18181b !important;/);
   assert.match(html, /box-shadow: 0 12px 34px rgba\(0, 0, 0, \.55\) !important;/);
   assert.match(html, /isolation: isolate;/);
-  assert.match(html, /\.ytclean-mobilebar \{ display: flex !important; position: fixed !important; top: calc\(env\(safe-area-inset-top\) \+ 10px\) !important; left: 12px; right: 12px; \}/);
-  assert.match(html, /body\.ytclean-drawer-open \.ytclean-sidebar \{ transform: translateX\(0\); padding-top: calc\(86px \+ env\(safe-area-inset-top\)\); \}/);
-  assert.match(html, /body\.ytclean-ui #mainContent \{ padding: calc\(96px \+ env\(safe-area-inset-top\)\) 16px 20px !important; \}/);
+  assert.match(html, /\.ytclean-mobilebar::before,[\s\S]*?\.ytclean-mobilebar::after \{[\s\S]*?pointer-events: none;/);
+  assert.match(html, /\.ytclean-mobilebar \.ytclean-icon-btn,[\s\S]*?pointer-events: auto;[\s\S]*?touch-action: manipulation;/);
+  assert.match(html, /\.ytclean-mobilebar \{ display: flex !important; \}/);
+  assert.match(html, /body\.ytclean-drawer-open \.ytclean-sidebar \{ transform: translateX\(0\); padding-top: calc\(var\(--ytclean-mobilebar-total-height\) \+ 10px\); \}/);
+  assert.match(html, /body\.ytclean-ui #mainContent \{ padding: calc\(var\(--ytclean-mobilebar-total-height\) \+ 20px\) 16px 20px !important; \}/);
   assert.match(html, /body\.modal-open \.ytclean-mobilebar/);
   assert.match(html, /const toggleDrawer = \(\) => document\.body\.classList\.toggle\('ytclean-drawer-open'\);/);
   assert.match(html, /ytcleanOpenDrawer'\)\?\.addEventListener\('click', toggleDrawer\)/);


### PR DESCRIPTION
### Motivation

- Mobile header buttons were not clickable and page content scrolled over the header due to competing stacking contexts, missing safe-area offsets, and pseudo-elements/backdrops intercepting pointer events.
- The fix aims to make the mobile header permanently topmost and interactive on all mobile widths without breaking desktop layout.

### Description

- Convert `.ytclean-mobilebar` to a fixed, safe-area-aware top layer with CSS variables for z-index, top offset and total height, and set `position: fixed`, `isolation: isolate`, `pointer-events: auto`, and `touch-action: manipulation` so it reliably receives touch/clicks (file: `public-ui/index.html`).
- Ensure header pseudo-elements and decorative overlays do not capture pointer events by applying `pointer-events: none` to `::before/::after` and explicitly enabling `pointer-events: auto` for header buttons/links with increased z-index (file: `public-ui/index.html`).
- Move header stacking control out of conflicting parents by adjusting sidebar/drawer/backdrop stacking so the drawer/backdrop sit below the header on mobile and the drawer top padding is computed from the header height variables (file: `public-ui/index.html`).
- Prevent page content from scrolling under the fixed header by setting `#mainContent` to `position: relative; z-index: 1` and adding top padding computed from the header total height, and update the frontend IA test to assert these behaviors (files: `public-ui/index.html`, `tests/frontend-ia.test.js`).

### Testing

- Ran the full test suite with `npm test` which completed successfully and all tests passed (111 passed, 0 failed). 
- Updated `tests/frontend-ia.test.js` to verify the new CSS variables, `position: fixed` header rules, pointer-events on pseudo-elements, header button touch handling, drawer/backdrop stacking, and the `#mainContent` padding offset, and those assertions passed under the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a535a652a8c833191aabccabd9682bc)