### PR TITLE
Sync final YTConv 1.5.0 validation and docs into 1.6 beta

### DIFF
--- a/.github/workflows/ytconv-auth.yml
+++ b/.github/workflows/ytconv-auth.yml
@@ -1,0 +1,53 @@
+name: YTConv Account Server
+
+on:
+  push:
+    branches:
+      - release/ytconv-1.5.0
+      - release/ytconv-1.6.0-beta
+    paths:
+      - "next-app/**"
+      - "sql/**"
+      - ".github/workflows/ytconv-auth.yml"
+  pull_request:
+    paths:
+      - "next-app/**"
+      - "sql/**"
+      - ".github/workflows/ytconv-auth.yml"
+  workflow_dispatch:
+
+jobs:
+  build-and-typecheck:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: next-app
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/ytconv
+      GOOGLE_CLIENT_ID: test-client.apps.googleusercontent.com
+      GOOGLE_CLIENT_SECRET: test-google-secret
+      NEXTAUTH_SECRET: test-nextauth-secret-with-at-least-32-characters
+      NEXTAUTH_URL: http://localhost:3000
+      CLI_AUTH_ENCRYPTION_KEY: test-cli-auth-encryption-key-with-at-least-32-characters
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: next-app/package.json
+      - run: npm install --ignore-scripts
+      - run: npx tsc --noEmit
+      - run: npm run build
+      - name: Verify account routes and schema are present
+        working-directory: .
+        run: |
+          test -f next-app/pages/cli-login.tsx
+          test -f next-app/pages/api/auth/'[...nextauth].ts'
+          test -f next-app/pages/api/cli-auth/device.ts
+          test -f next-app/pages/api/cli-auth/approve.ts
+          test -f next-app/pages/api/cli-auth/token.ts
+          test -f next-app/pages/api/cli-auth/me.ts
+          test -f next-app/pages/api/cli-auth/logout.ts
+          grep -q 'CREATE TABLE IF NOT EXISTS cli_access_tokens' sql/schema.sql
+          grep -q 'CREATE TABLE IF NOT EXISTS cli_device_codes' sql/schema.sql

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,170 +1,55 @@
-# YTConv CLI 1.5.0 Beta 2
+# YTConv CLI 1.5.0
 
-YTConv is a beginner-friendly media downloader and converter for Windows CMD, PowerShell, Linux distributions, macOS, SSH/headless servers, Android Termux, and iPhone/iPad through the native iSH frontend. It uses **yt-dlp**, **gallery-dl**, and **FFmpeg** for video, audio, images, carousels, Stories, Reels, mixed posts, and playlists.
+YTConv is a cross-platform media downloader and converter for Windows CMD/PowerShell, Linux, macOS, SSH/headless servers, Android Termux, and iPhone/iPad through iSH. It uses **yt-dlp**, **gallery-dl**, and **FFmpeg** for supported video, audio, images, carousels, Stories, Reels, mixed posts, and playlists.
 
 > Download only media that you own, that is openly licensed, or that you are allowed to save. YTConv does not bypass DRM, paywalls, private-account access, regional restrictions, or copyright controls.
 
-## Release channels
+## What is new in 1.5.0
 
-```text
-Stable: 1.4.0          npm install -g ytconv@latest
-Beta:   1.5.0-beta.2   npm install -g ytconv@beta
-```
+- An active YTConv account is required before every download or conversion.
+- Secure browser device login works from Windows, Linux, macOS, Termux, SSH, and iSH.
+- `ytconv login`, `ytconv auth status`, `ytconv whoami`, and `ytconv logout`.
+- Device codes expire after ten minutes and CLI access tokens expire after ninety days.
+- Long-lived tokens are stored as hashes by the server; the temporary device exchange is encrypted and one-time.
+- Public X/Twitter posts try yt-dlp before gallery-dl, and an empty gallery result is no longer reported as a successful conversion.
+- All 1.5.0-beta.2 features remain: persistent config, named profiles, privacy-limited history, shell completion, playlist/batch, retry/resume, subtitles, SponsorBlock mark mode, and separate archives.
 
-Installing the beta must not replace the npm `latest` tag.
+## Install stable 1.5.0
 
-## Beta defaults
-
-```text
-Subtitles        ON for video
-SponsorBlock     ON in safe mark mode
-Download archive ON with separate output profiles
-Resume           ON
-```
-
-Disable any beta default for one run:
-
-```bash
-ytconv download "URL" --no-subtitles
-ytconv download "URL" --no-sponsorblock
-ytconv download "URL" --no-archive
-```
-
-`SponsorBlock mark` adds chapter markers and does not cut media. Cutting still requires `--sponsorblock remove`.
-
-## New in beta.2
-
-### Persistent configuration
-
-```bash
-ytconv config list
-ytconv config path
-ytconv config set output "$HOME/Downloads/YTConv"
-ytconv config set audioQuality 192
-ytconv config get output
-ytconv config unset audioQuality
-ytconv config reset
-```
-
-Configuration is stored with user-only file permissions in:
-
-```text
-~/.ytconv/config.json
-```
-
-Supported saved settings are validated before writing. Cookie contents, tokens, and browser sessions are never stored by the config command.
-
-Ignore saved settings for one run:
-
-```bash
-ytconv --no-config download "URL"
-```
-
-### Named profiles
-
-```bash
-ytconv profile set music preset=music audioQuality=320
-ytconv profile set phone preset=mobile resolution=720
-ytconv profile list
-ytconv profile show music
-ytconv profile use phone
-ytconv download "URL"
-ytconv --profile music download "URL"
-ytconv profile clear
-ytconv profile delete phone
-```
-
-Explicit command-line options override saved defaults.
-
-### Download history
-
-Headless and batch runs write a small privacy-limited history entry:
-
-```bash
-ytconv history
-ytconv history --json
-ytconv history --limit 50
-ytconv history clear
-```
-
-History includes time, version, command, URLs, mode, preset, profile, output directory, and exit code. It excludes cookies, tokens, proxy credentials, and browser session data. The file is capped at 500 entries.
-
-### Shell completion
-
-```bash
-ytconv completion bash
-ytconv completion zsh
-ytconv completion fish
-ytconv completion powershell
-```
-
-Copy the generated line into the matching shell profile.
-
-### Beginner quick start
-
-```bash
-ytconv quickstart
-```
-
-## Install beta.2
-
-### Windows CMD
-
-```cmd
-npm.cmd uninstall -g ytconv
-npm.cmd cache verify
-npm.cmd install -g ytconv@beta --force
-ytconv.cmd --version
-ytconv.cmd --self-test
-ytconv.cmd doctor
-ytconv.cmd quickstart
-```
-
-### Windows PowerShell
+### Windows
 
 ```powershell
 npm.cmd uninstall -g ytconv
 npm.cmd cache verify
-npm.cmd install -g ytconv@beta --force
+npm.cmd install -g ytconv@latest --force
 ytconv.cmd --version
-ytconv.cmd --self-test
-ytconv.cmd doctor
-ytconv.cmd quickstart
+ytconv.cmd login
 ```
 
-Use `ytconv.cmd` when PowerShell execution policy blocks `ytconv.ps1`.
+Use `ytconv.cmd` when PowerShell execution policy blocks the generated `ytconv.ps1` shim.
 
-### Linux, macOS, and SSH
+### Linux, macOS, or SSH
 
-Install the operating-system requirements using [docs/LINUX.md](docs/LINUX.md). Replace `ytconv@latest` with `ytconv@beta` for the prerelease:
-
-```bash
+```sh
 npm uninstall -g ytconv
 npm cache verify
-npm install -g ytconv@beta --force
+npm install -g ytconv@latest --force
 ytconv --version
-ytconv --self-test
-ytconv doctor
-ytconv quickstart
+ytconv login
 ```
 
-Expected version:
-
-```text
-1.5.0-beta.2
-```
+The included `scripts/install-unix.sh` can install the operating-system dependencies on supported package managers without using `sudo npm install -g`.
 
 ### Android Termux
 
-```bash
+```sh
 pkg update
 pkg install -y nodejs python ffmpeg curl ca-certificates
 termux-setup-storage
 python -m pip install -U --no-cache-dir yt-dlp gallery-dl
-npm install -g ytconv@beta --omit=optional --force
+npm install -g ytconv@latest --omit=optional --force
 ytconv repair
-ytconv --self-test
-ytconv doctor
+ytconv login
 ```
 
 Default output: `~/storage/downloads/YTConv`.
@@ -172,17 +57,30 @@ Default output: `~/storage/downloads/YTConv`.
 ### iPhone/iPad through iSH
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/andhikamarcella/youtubetomp3/release/ytconv-1.5.0-beta.2/cli/scripts/install-ish.sh -o /tmp/ytconv-ish.sh
+curl -fsSL https://raw.githubusercontent.com/andhikamarcella/youtubetomp3/release/ytconv-1.5.0/cli/scripts/install-ish.sh -o /tmp/ytconv-ish.sh
 sh /tmp/ytconv-ish.sh
 ytconv --version
-ytconv doctor
+ytconv login
 ```
 
-The native iSH frontend provides the media workflow and beta defaults. The Node-specific config/profile/completion layer is documented separately when unavailable in the older iSH runtime.
+The browser can be opened on the same device or another device. Enter the eight-character code shown in the terminal and approve the CLI session.
+
+## Account commands
+
+```sh
+ytconv login
+ytconv auth status
+ytconv whoami
+ytconv logout
+```
+
+The local device token is stored in `~/.ytconv/auth.json`. On Unix-like systems it is written with user-only permissions. Never share that file, browser cookies, access tokens, or device codes.
+
+Help, version, diagnostics, repair, update, configuration, profile, and history commands remain available before login. Media downloads and conversions do not.
 
 ## Media commands
 
-```bash
+```sh
 ytconv download "URL"
 ytconv playlist "PLAYLIST_URL"
 ytconv batch links.txt --jobs 2 --continue-on-error --result-json report.json
@@ -191,82 +89,101 @@ ytconv formats "URL"
 ytconv subtitles "URL"
 ```
 
-## Formats and quality
+## Persistent configuration and profiles
 
-```bash
-ytconv download "URL" --audio-format mp3 --audio-quality 192
+```sh
+ytconv config list
+ytconv config set output "$HOME/Downloads/YTConv"
+ytconv config set audioQuality 192
+ytconv profile set music preset=music audioQuality=320
+ytconv profile set phone preset=mobile resolution=720
+ytconv profile use phone
+ytconv --profile music download "URL"
+```
+
+Explicit command-line options override saved defaults. Use `--no-config` for a clean one-run session.
+
+## Default media behavior
+
+```text
+Subtitles         enabled for video
+SponsorBlock      enabled in non-destructive mark mode
+Download archives enabled per output profile
+Resume            enabled
+```
+
+One-run opt-outs:
+
+```sh
+ytconv download "URL" --no-subtitles
+ytconv download "URL" --no-sponsorblock
+ytconv download "URL" --no-archive
+```
+
+SponsorBlock `mark` adds chapter markers; it does not cut the media. Cutting requires the explicit `--sponsorblock remove` option.
+
+## Formats, metadata, cookies, and diagnostics
+
+```sh
+ytconv download "URL" --audio-format mp3 --audio-quality 320
 ytconv download "URL" --audio-format flac
 ytconv download "URL" --video-format mp4 --resolution 1080
-ytconv formats "URL" --json
-```
-
-MP3 at 320 kbps is an encoder target and cannot create detail that was absent from the source.
-
-## Metadata and cover art
-
-```bash
 ytconv download "URL" --preset music
 ytconv download "URL" --metadata --thumbnail --metadata-files
-ytconv download "URL" --artist "Artist" --title "Title" --album "Album" --track 3 --year 2026 --genre "Pop"
-```
-
-## Playlist, retry, resume, and archive
-
-```bash
-ytconv playlist "URL" --playlist-items "1-10"
-ytconv playlist "URL" --max-downloads 25 --skip-playlist-after-errors 5
-ytconv download "URL" --retries 20 --fragment-retries 30
-ytconv download "URL" --resume
-```
-
-The beta creates separate yt-dlp text archives and gallery-dl SQLite archives under `~/.ytconv/archives` unless `--no-archive` is used.
-
-## Cookies
-
-```bash
 ytconv download "URL" --cookies cookies.txt
 ytconv download "URL" --cookies-from-browser chrome
-ytconv download "URL" --cookies-from-browser "firefox:default-release"
-```
-
-Cookies are sensitive credentials. Never include them in screenshots, logs, issues, or chat messages.
-
-## Diagnostics
-
-```bash
 ytconv doctor
 ytconv repair
 ytconv --self-test
 ytconv --shell-info
-ytconv clean
 ```
 
-`clean` preserves configuration, profiles, download history, and download archives.
+Cookies are account credentials. Use them only for media you are authorized to access and never include them in screenshots, logs, issues, or chat messages.
 
-## Return to stable
+## History and shell completion
 
-```bash
-npm uninstall -g ytconv
-npm cache verify
-npm install -g ytconv@latest --force
-ytconv --version
+```sh
+ytconv history
+ytconv history --json
+ytconv history --limit 50
+ytconv history clear
+ytconv completion bash
+ytconv completion zsh
+ytconv completion fish
+ytconv completion powershell
 ```
+
+History is capped and excludes cookies, tokens, proxy credentials, and browser session data.
+
+## Account-server deployment
+
+The Next.js account server needs:
+
+```text
+DATABASE_URL
+GOOGLE_CLIENT_ID
+GOOGLE_CLIENT_SECRET
+NEXTAUTH_SECRET
+NEXTAUTH_URL
+CLI_AUTH_ENCRYPTION_KEY (recommended)
+```
+
+The CLI auth tables are included in `sql/schema.sql` and are also created by the API when the database is ready. See [docs/AUTH.md](docs/AUTH.md).
+
+## Release channels
+
+```text
+Stable: 1.5.0          npm install -g ytconv@latest
+Beta:   1.6.0-beta.1   npm install -g ytconv@beta
+```
+
+The guarded beta workflow preserves the stable npm `latest` tag.
 
 ## Documentation
 
-- [Complete stable installation guide](docs/INSTALL.md)
+- [Account login and deployment](docs/AUTH.md)
+- [Complete installation guide](docs/INSTALL.md)
 - [Linux distribution guide](docs/LINUX.md)
-- [Beta channel and test guide](docs/BETA.md)
-- [Shell guide](docs/SHELLS.md)
 - [Command reference](docs/COMMANDS.md)
+- [Shell guide](docs/SHELLS.md)
 - [Troubleshooting](docs/TROUBLESHOOTING.md)
-- [Release checklist](docs/RELEASE.md)
-- [Changelog](CHANGELOG.md)
-
-## Limitations
-
-No downloader can guarantee every URL, site, device, architecture, and distribution forever. Sites can change APIs, require login, remove posts, return HTTP 429, restrict regions, or use DRM. YTConv provides fallback engines, retries, repair tools, diagnostics, and actionable errors, but it cannot create access that is technically or legally unavailable.
-
-## License
-
-MIT. yt-dlp, gallery-dl, FFmpeg, and other dependencies keep their own licenses.


### PR DESCRIPTION
Temporary synchronization PR to carry the final stable account-server workflow and README commit into the 1.6 beta history before restoring the beta README.