### PR TITLE
release(cli): publish YTConv 1.6.3 retry hotfix

### DIFF
--- a/cli/.release-1.6.3
+++ b/cli/.release-1.6.3
@@ -1,0 +1,1 @@
+YTConv 1.6.3 retry-sleep hotfix release trigger.


### PR DESCRIPTION
## Summary

Trigger the verified YTConv CLI 1.6.3 stable release.

- Fixes nested yt-dlp retry sleep values such as `fragment:http:linear=1::2`.
- Normalizes default, command-line, saved-profile, environment, and legacy retry settings.
- Keeps YouTube Music AUTO as MP3 and regular YouTube AUTO as MP4.
- Publishes the immutable patch as npm `latest` through the protected `npm` environment.

Closes #166.