### PR TITLE
Trigger YTConv 1.6.6 npm publication

### DIFF
--- a/.github/release-markers/ytconv-1.6.6
+++ b/.github/release-markers/ytconv-1.6.6
@@ -1,2 +1,3 @@
 Publish ytconv 1.6.6 from source commit 3bce580ce9aa0d58e6d470f665bb17ac440fd396
-Trigger sequence: 4
+Trigger sequence: 5
+Trigger route: merged pull request


### PR DESCRIPTION
Triggers the trusted npm publication workflow for the already validated YTConv 1.6.6 source commit `3bce580ce9aa0d58e6d470f665bb17ac440fd396`. No package source files are changed.