### PR TITLE
Trigger final YTConv 1.6.6 zero-dependency publication workflow

### DIFF
--- a/.github/release-markers/publish-ytconv-1.6.6-zero-deps-final
+++ b/.github/release-markers/publish-ytconv-1.6.6-zero-deps-final
@@ -1,0 +1,3 @@
+Publish immutable YTConv 1.6.6 source 9e34bf39cded0415e7fe181f149873693bdce561
+Validated core run 30987893516
+Validated native run 30987893498


### PR DESCRIPTION
This PR adds only the registered release marker for the dedicated YTConv 1.6.6 publication orchestrator.

The workflow checks out immutable source commit `9e34bf39cded0415e7fe181f149873693bdce561`, proves zero production/optional/peer dependencies, runs the complete release suite, downloads artifacts from native matrix `30987893498`, publishes the exact npm tarball with provenance, verifies npm registry bytes, and creates GitHub Release `ytconv-v1.6.6` with SBOM and SHA-256 checksums.

It does not modify the ongoing YTConv 1.6.7 preparation workflow.