### PR TITLE
Add ShipForge CLI 0.1.0

### DIFF
--- a/.github/workflows/shipforge-ci.yml
+++ b/.github/workflows/shipforge-ci.yml
@@ -1,0 +1,36 @@
+name: ShipForge CLI CI
+
+on:
+  push:
+    paths:
+      - 'shipforge/**'
+      - '.github/workflows/shipforge-ci.yml'
+  pull_request:
+    paths:
+      - 'shipforge/**'
+      - '.github/workflows/shipforge-ci.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        node: [22, 24]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: shipforge
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+          cache-dependency-path: shipforge/package-lock.json
+      - run: npm ci --ignore-scripts
+      - run: npm run check
+      - run: npm test
+      - run: npm pack --dry-run

--- a/shipforge/.github/workflows/ci.yml
+++ b/shipforge/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: ShipForge CI
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        node: [22, 24]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+      - run: npm ci --ignore-scripts
+      - run: npm run check
+      - run: npm test
+      - run: npm pack --dry-run

--- a/shipforge/.github/workflows/release.yml
+++ b/shipforge/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Publish ShipForge
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: npm
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          cache: npm
+      - run: npm ci --ignore-scripts
+      - run: npm run check
+      - run: npm test
+      - run: npm pack --ignore-scripts
+      - name: Publish npm with provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --provenance
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "$GITHUB_REF_NAME" shipforge-cli-*.tgz --generate-notes --verify-tag

--- a/shipforge/.gitignore
+++ b/shipforge/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+*.tgz
+.env
+.DS_Store

--- a/shipforge/LICENSE
+++ b/shipforge/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Andhika Marcella Fernanda
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/shipforge/README.md
+++ b/shipforge/README.md
@@ -1,0 +1,67 @@
+# ShipForge CLI
+
+ShipForge is a safe, zero-runtime-dependency, cross-platform release automation CLI. It discovers and synchronizes project versions, validates the release state, generates changelogs and SHA-256 manifests, publishes npm packages with provenance, creates GitHub Releases, and verifies both destinations.
+
+## Requirements
+
+- Node.js 22.14 or newer
+- Git for repository checks and changelog generation
+- npm for npm publication
+- GitHub CLI (`gh`) only when publishing or verifying GitHub Releases
+
+## Install for development
+
+```bash
+npm install
+npm link
+shipforge --help
+```
+
+## Safe release workflow
+
+```bash
+shipforge init
+shipforge scan
+shipforge version 1.2.0
+shipforge version 1.2.0 --write
+shipforge changelog 1.2.0
+shipforge check
+shipforge checksum dist
+shipforge publish 1.2.0 --npm --github --dry-run
+shipforge publish 1.2.0 --npm --github --yes
+shipforge verify 1.2.0
+```
+
+`shipforge version` is preview-only unless `--write` is supplied. Publication is blocked unless the release checks pass and `--yes` is supplied. ShipForge has zero runtime dependencies. Child processes are started with argument arrays and `shell: false`.
+
+## Version files detected in 0.1.0
+
+- npm `package.json`
+- Rust `Cargo.toml`
+- Python `pyproject.toml`
+- Android `build.gradle` and `build.gradle.kts`
+- Snap `snapcraft.yaml`
+- Alpine `APKBUILD`
+
+## Configuration
+
+Run `shipforge init` to create `shipforge.config.json`. Configure test commands, tag prefix, npm directory/tag, GitHub repository, changelog path, and release asset locations.
+
+## Commands
+
+- `init` — create the configuration file
+- `scan` — list detected version files
+- `check` — validate version consistency, Git state, and project checks
+- `version <version>` — preview or synchronize versions
+- `changelog <version>` — generate release notes from Git commits
+- `checksum [directory]` — create `SHA256SUMS.txt`
+- `publish <version>` — publish explicitly selected npm/GitHub targets
+- `verify <version>` — verify publication results
+
+## Security model
+
+ShipForge does not store npm or GitHub tokens. It relies on the user's existing npm and GitHub CLI authentication. It never invokes a shell for child processes, requires explicit publication targets, and requires `--yes` for irreversible publishing.
+
+## License
+
+MIT

--- a/shipforge/bin/shipforge.js
+++ b/shipforge/bin/shipforge.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+import { runCli } from '../src/cli.js';
+
+runCli(process.argv).catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`\nShipForge failed: ${message}`);
+  process.exitCode = 1;
+});

--- a/shipforge/docs/ROADMAP.md
+++ b/shipforge/docs/ROADMAP.md
@@ -1,0 +1,16 @@
+# Roadmap
+
+## 0.2
+
+- Cargo and PyPI publishing adapters
+- GitHub Actions workflow generator
+- Conventional Commits grouping
+- Monorepo workspace support
+- Signed provenance report
+
+## 0.3
+
+- DEB, RPM, AppImage, Snap, Flatpak, Android, and Windows package adapters
+- Release rollback guidance
+- Plugin API
+- Interactive terminal dashboard

--- a/shipforge/package-lock.json
+++ b/shipforge/package-lock.json
@@ -1,0 +1,19 @@
+{
+  "name": "shipforge-cli",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "shipforge-cli",
+      "version": "0.1.0",
+      "license": "MIT",
+      "bin": {
+        "shipforge": "bin/shipforge.js"
+      },
+      "engines": {
+        "node": ">=22.14.0"
+      }
+    }
+  }
+}

--- a/shipforge/package.json
+++ b/shipforge/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "shipforge-cli",
+  "version": "0.1.0",
+  "description": "Safe zero-dependency release automation CLI for versioning, validation, checksums, npm publishing, and GitHub Releases.",
+  "type": "module",
+  "bin": {
+    "shipforge": "bin/shipforge.js"
+  },
+  "exports": {
+    ".": "./src/index.js"
+  },
+  "files": [
+    "bin",
+    "src",
+    "docs",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "start": "node ./bin/shipforge.js",
+    "check": "node --check ./bin/shipforge.js && find src test -name '*.js' -print0 | xargs -0 -n1 node --check",
+    "test": "node --test",
+    "prepack": "npm run check && npm test"
+  },
+  "keywords": [
+    "release",
+    "automation",
+    "npm",
+    "github-release",
+    "versioning",
+    "checksum",
+    "sbom",
+    "cli"
+  ],
+  "author": "Andhika Marcella Fernanda <andhikamarcella546@gmail.com>",
+  "license": "MIT",
+  "engines": {
+    "node": ">=22.14.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  }
+}

--- a/shipforge/src/changelog.js
+++ b/shipforge/src/changelog.js
@@ -1,0 +1,25 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { run } from './process.js';
+
+export async function generateChangelogEntry(cwd, version, options = {}) {
+  const tagPrefix = options.tagPrefix ?? 'v';
+  const latestTag = await run('git', ['describe', '--tags', '--abbrev=0'], { cwd, capture: true, allowFailure: true });
+  const range = latestTag.code === 0 ? `${latestTag.stdout}..HEAD` : 'HEAD';
+  const log = await run('git', ['log', range, '--pretty=format:%s'], { cwd, capture: true, allowFailure: true });
+  const commits = log.stdout.split('\n').map((line) => line.trim()).filter(Boolean);
+  const date = new Date().toISOString().slice(0, 10);
+  const body = commits.length ? commits.map((message) => `- ${message}`).join('\n') : '- Initial release preparation.';
+  return `## ${tagPrefix}${version} — ${date}\n\n${body}\n`;
+}
+
+export async function writeChangelog(cwd, version, config) {
+  const file = path.resolve(cwd, config.changelog ?? 'CHANGELOG.md');
+  const entry = await generateChangelogEntry(cwd, version, { tagPrefix: config.tagPrefix });
+  let previous = '';
+  try { previous = await fs.readFile(file, 'utf8'); } catch (error) { if (error?.code !== 'ENOENT') throw error; }
+  const header = previous.startsWith('# Changelog') ? '# Changelog\n\n' : '# Changelog\n\n';
+  const rest = previous.replace(/^# Changelog\s*/u, '');
+  await fs.writeFile(file, `${header}${entry}\n${rest}`.trimEnd() + '\n', 'utf8');
+  return file;
+}

--- a/shipforge/src/checks.js
+++ b/shipforge/src/checks.js
@@ -1,0 +1,49 @@
+import path from 'node:path';
+import { scanProject } from './scanner.js';
+import { loadConfig } from './config.js';
+import { run } from './process.js';
+
+function parseCommand(command) {
+  const parts = command.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/gu) ?? [];
+  return parts.map((part) => part.replace(/^["']|["']$/gu, ''));
+}
+
+export async function checkVersionConsistency(cwd) {
+  const entries = await scanProject(cwd);
+  const versions = [...new Set(entries.map((entry) => entry.version))];
+  return {
+    ok: entries.length > 0 && versions.length === 1,
+    entries,
+    versions,
+    message: entries.length === 0
+      ? 'No supported version files were detected.'
+      : versions.length === 1
+        ? `All ${entries.length} version files use ${versions[0]}.`
+        : `Version mismatch detected: ${versions.join(', ')}`
+  };
+}
+
+export async function checkGitState(cwd) {
+  const result = await run('git', ['status', '--porcelain'], { cwd, capture: true, allowFailure: true });
+  if (result.code !== 0) return { ok: false, message: 'Not a Git repository or Git is unavailable.' };
+  return { ok: result.stdout.length === 0, message: result.stdout ? 'Working tree contains uncommitted changes.' : 'Git working tree is clean.' };
+}
+
+export async function runConfiguredChecks(cwd, config) {
+  const results = [];
+  for (const command of config.checks ?? []) {
+    const [executable, ...args] = parseCommand(command);
+    if (!executable) continue;
+    const result = await run(executable, args, { cwd, capture: true, allowFailure: true });
+    results.push({ command, ok: result.code === 0, output: result.stdout || result.stderr });
+  }
+  return results;
+}
+
+export async function runChecks(cwd, options = {}) {
+  const config = await loadConfig(cwd);
+  const consistency = await checkVersionConsistency(cwd);
+  const git = await checkGitState(cwd);
+  const commands = options.skipCommands ? [] : await runConfiguredChecks(path.resolve(cwd), config);
+  return { consistency, git, commands, ok: consistency.ok && git.ok && commands.every((item) => item.ok) };
+}

--- a/shipforge/src/checksums.js
+++ b/shipforge/src/checksums.js
@@ -1,0 +1,28 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { walk, relative } from './fs-utils.js';
+
+async function sha256(file) {
+  const hash = crypto.createHash('sha256');
+  const handle = await fs.open(file, 'r');
+  try {
+    for await (const chunk of handle.createReadStream()) hash.update(chunk);
+  } finally {
+    await handle.close();
+  }
+  return hash.digest('hex');
+}
+
+export async function generateChecksums(directory, output = 'SHA256SUMS.txt') {
+  const absoluteDirectory = path.resolve(directory);
+  const outputPath = path.resolve(absoluteDirectory, output);
+  const files = (await walk(absoluteDirectory, { maxDepth: 12 }))
+    .filter((file) => path.resolve(file) !== outputPath)
+    .sort();
+  if (!files.length) throw new Error(`No files found in ${absoluteDirectory}`);
+  const lines = [];
+  for (const file of files) lines.push(`${await sha256(file)}  ${relative(absoluteDirectory, file)}`);
+  await fs.writeFile(outputPath, `${lines.join('\n')}\n`, 'utf8');
+  return { outputPath, count: files.length, lines };
+}

--- a/shipforge/src/cli.js
+++ b/shipforge/src/cli.js
@@ -1,0 +1,222 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { writeDefaultConfig, loadConfig } from './config.js';
+import { scanProject } from './scanner.js';
+import { updateProjectVersion } from './versioning.js';
+import { runChecks } from './checks.js';
+import { generateChecksums } from './checksums.js';
+import { writeChangelog } from './changelog.js';
+import { publishNpm, publishGitHub, verifyNpm, verifyGitHub } from './publish.js';
+import { assertSemver } from './semver.js';
+import { heading, line, printTable } from './ui.js';
+
+const VERSION = '0.1.0';
+
+const HELP = `ShipForge ${VERSION}
+
+Safe release automation for npm packages and GitHub Releases.
+
+Usage:
+  shipforge [--cwd <directory>] <command> [options]
+
+Commands:
+  init                         Create shipforge.config.json
+  scan                         Find supported version files
+  check                        Validate versions, Git state, and checks
+  version <version>            Preview or synchronize project versions
+  changelog <version>          Prepend release notes from Git commits
+  checksum [directory]         Create SHA256SUMS.txt
+  publish <version>            Publish selected npm/GitHub targets
+  verify <version>             Verify npm and GitHub publication
+
+Global options:
+  -C, --cwd <directory>        Project directory
+  -h, --help                   Show help
+  -V, --version                Show ShipForge version
+
+Examples:
+  shipforge scan
+  shipforge version 1.2.0
+  shipforge version 1.2.0 --write
+  shipforge publish 1.2.0 --npm --github --dry-run
+  shipforge publish 1.2.0 --npm --github --yes
+`;
+
+function parse(argv) {
+  const args = argv.slice(2);
+  let cwd = process.cwd();
+  const remaining = [];
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index];
+    if (value === '-C' || value === '--cwd') {
+      const next = args[++index];
+      if (!next) throw new Error(`${value} requires a directory.`);
+      cwd = path.resolve(next);
+    } else {
+      remaining.push(value);
+    }
+  }
+  return { cwd, args: remaining };
+}
+
+function takeFlags(args) {
+  const flags = new Set();
+  const values = new Map();
+  const positional = [];
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index];
+    if (!value.startsWith('-')) {
+      positional.push(value);
+      continue;
+    }
+    if (value === '-o' || value === '--output') {
+      const next = args[++index];
+      if (!next) throw new Error(`${value} requires a value.`);
+      values.set('output', next);
+      continue;
+    }
+    flags.add(value.replace(/^-+/u, ''));
+  }
+  return { flags, values, positional };
+}
+
+function has(flags, ...names) {
+  return names.some((name) => flags.has(name));
+}
+
+async function packageIdentity(cwd, config) {
+  const file = path.resolve(cwd, config.npm?.directory ?? '.', 'package.json');
+  const manifest = JSON.parse(await fs.readFile(file, 'utf8'));
+  if (!manifest.name || !manifest.version) throw new Error(`Missing name or version in ${file}`);
+  return manifest;
+}
+
+export async function runCli(argv) {
+  const parsed = parse(argv);
+  const [command, ...tail] = parsed.args;
+  if (!command || command === '--help' || command === '-h' || command === 'help') {
+    console.log(HELP);
+    return;
+  }
+  if (command === '--version' || command === '-V') {
+    console.log(VERSION);
+    return;
+  }
+
+  const { flags, values, positional } = takeFlags(tail);
+  const cwd = parsed.cwd;
+
+  switch (command) {
+    case 'init': {
+      const file = await writeDefaultConfig(cwd, { force: has(flags, 'force') });
+      heading('Initialized');
+      line('ok', `Created ${path.relative(cwd, file)}`);
+      break;
+    }
+    case 'scan': {
+      const entries = await scanProject(cwd);
+      if (has(flags, 'json')) {
+        console.log(JSON.stringify(entries.map(({ absolute, ...entry }) => entry), null, 2));
+        break;
+      }
+      heading('Project scan');
+      if (!entries.length) line('warn', 'No supported version files found.');
+      else printTable([['TYPE', 'VERSION', 'PATH'], ...entries.map((entry) => [entry.type, entry.version, entry.path])]);
+      break;
+    }
+    case 'check': {
+      const result = await runChecks(cwd, { skipCommands: has(flags, 'skip-commands') });
+      if (has(flags, 'json')) {
+        console.log(JSON.stringify(result, null, 2));
+        break;
+      }
+      heading('Release checks');
+      line(result.consistency.ok ? 'ok' : 'error', result.consistency.message);
+      line(result.git.ok ? 'ok' : 'warn', result.git.message);
+      for (const check of result.commands) line(check.ok ? 'ok' : 'error', `${check.command}${check.output ? ` — ${check.output.split('\n').at(-1)}` : ''}`);
+      if (!result.ok) process.exitCode = 1;
+      break;
+    }
+    case 'version': {
+      const version = positional[0];
+      if (!version) throw new Error('version requires <version>.');
+      const write = has(flags, 'write');
+      const changes = await updateProjectVersion(cwd, assertSemver(version), { write });
+      heading(write ? 'Version updated' : 'Version preview');
+      if (!changes.length) line('ok', `All detected files already use ${version}.`);
+      else {
+        printTable([['FROM', 'TO', 'PATH'], ...changes.map((item) => [item.from, item.to, item.path])]);
+        if (!write) line('info', 'Run again with --write to apply these changes.');
+      }
+      break;
+    }
+    case 'changelog': {
+      const version = positional[0];
+      if (!version) throw new Error('changelog requires <version>.');
+      const config = await loadConfig(cwd);
+      const file = await writeChangelog(cwd, assertSemver(version), config);
+      heading('Changelog');
+      line('ok', `Updated ${path.relative(cwd, file)}`);
+      break;
+    }
+    case 'checksum': {
+      const config = await loadConfig(cwd);
+      const target = path.resolve(cwd, positional[0] ?? config.checksumDirectory);
+      const result = await generateChecksums(target, values.get('output') ?? 'SHA256SUMS.txt');
+      heading('Checksums');
+      line('ok', `Hashed ${result.count} files into ${path.relative(cwd, result.outputPath)}`);
+      break;
+    }
+    case 'publish': {
+      const version = positional[0];
+      if (!version) throw new Error('publish requires <version>.');
+      const npmTarget = has(flags, 'npm');
+      const githubTarget = has(flags, 'github');
+      const dryRun = has(flags, 'dry-run');
+      const yes = has(flags, 'yes', 'y');
+      assertSemver(version);
+      if (!npmTarget && !githubTarget) throw new Error('Select at least one target: --npm or --github.');
+      if (!dryRun && !yes) throw new Error('Publishing is irreversible. Add --yes after reviewing a --dry-run.');
+      const config = await loadConfig(cwd);
+      const checks = await runChecks(cwd);
+      if (!checks.ok) throw new Error('Release checks failed. Resolve them before publishing.');
+      const identity = await packageIdentity(cwd, config);
+      if (identity.version !== version) throw new Error(`package.json is ${identity.version}, not ${version}.`);
+      heading(dryRun ? 'Publish dry run' : 'Publishing');
+      if (npmTarget) {
+        await publishNpm(cwd, config, { dryRun });
+        line('ok', `${dryRun ? 'Validated' : 'Published'} npm target ${identity.name}@${version}`);
+      }
+      if (githubTarget) {
+        const result = await publishGitHub(cwd, version, config, { dryRun });
+        line('ok', result.stdout);
+      }
+      break;
+    }
+    case 'verify': {
+      const version = positional[0];
+      if (!version) throw new Error('verify requires <version>.');
+      const config = await loadConfig(cwd);
+      const identity = await packageIdentity(cwd, config);
+      const explicit = has(flags, 'npm', 'github');
+      const npmTarget = explicit ? has(flags, 'npm') : true;
+      const githubTarget = explicit ? has(flags, 'github') : true;
+      heading('Publication verification');
+      let ok = true;
+      if (npmTarget) {
+        const result = await verifyNpm(cwd, identity.name, version);
+        line(result.ok ? 'ok' : 'error', `npm ${identity.name}@${version}`);
+        ok &&= result.ok;
+      }
+      if (githubTarget) {
+        const result = await verifyGitHub(cwd, version, config);
+        line(result.ok ? 'ok' : 'error', `GitHub ${config.tagPrefix ?? 'v'}${version}`);
+        ok &&= result.ok;
+      }
+      if (!ok) process.exitCode = 1;
+      break;
+    }
+    default:
+      throw new Error(`Unknown command: ${command}. Run shipforge --help.`);
+  }
+}

--- a/shipforge/src/config.js
+++ b/shipforge/src/config.js
@@ -1,0 +1,54 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+export const CONFIG_NAME = 'shipforge.config.json';
+
+export const defaultConfig = {
+  schemaVersion: 1,
+  tagPrefix: 'v',
+  changelog: 'CHANGELOG.md',
+  checksumDirectory: 'dist',
+  releaseAssets: ['dist'],
+  checks: ['npm test'],
+  npm: {
+    enabled: true,
+    directory: '.',
+    tag: 'latest'
+  },
+  github: {
+    enabled: true,
+    repository: null,
+    draft: false,
+    prerelease: false
+  }
+};
+
+export async function loadConfig(cwd) {
+  const file = path.join(cwd, CONFIG_NAME);
+  try {
+    const parsed = JSON.parse(await fs.readFile(file, 'utf8'));
+    return {
+      ...defaultConfig,
+      ...parsed,
+      npm: { ...defaultConfig.npm, ...(parsed.npm ?? {}) },
+      github: { ...defaultConfig.github, ...(parsed.github ?? {}) }
+    };
+  } catch (error) {
+    if (error?.code === 'ENOENT') return structuredClone(defaultConfig);
+    throw new Error(`Cannot read ${CONFIG_NAME}: ${error.message}`);
+  }
+}
+
+export async function writeDefaultConfig(cwd, { force = false } = {}) {
+  const file = path.join(cwd, CONFIG_NAME);
+  if (!force) {
+    try {
+      await fs.access(file);
+      throw new Error(`${CONFIG_NAME} already exists. Use --force to replace it.`);
+    } catch (error) {
+      if (error?.code !== 'ENOENT') throw error;
+    }
+  }
+  await fs.writeFile(file, `${JSON.stringify(defaultConfig, null, 2)}\n`, 'utf8');
+  return file;
+}

--- a/shipforge/src/fs-utils.js
+++ b/shipforge/src/fs-utils.js
@@ -1,0 +1,33 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const SKIP = new Set(['.git', 'node_modules', '.next', '.cache', 'coverage', 'vendor']);
+
+export async function walk(root, options = {}) {
+  const maxDepth = options.maxDepth ?? 6;
+  const results = [];
+
+  async function visit(directory, depth) {
+    if (depth > maxDepth) return;
+    const entries = await fs.readdir(directory, { withFileTypes: true });
+    for (const entry of entries) {
+      if (SKIP.has(entry.name)) continue;
+      const absolute = path.join(directory, entry.name);
+      if (entry.isDirectory()) await visit(absolute, depth + 1);
+      else if (entry.isFile()) results.push(absolute);
+    }
+  }
+
+  await visit(root, 0);
+  return results;
+}
+
+export function relative(cwd, file) {
+  return path.relative(cwd, file).split(path.sep).join('/');
+}
+
+export async function atomicWrite(file, content) {
+  const temporary = `${file}.shipforge-tmp-${process.pid}`;
+  await fs.writeFile(temporary, content, 'utf8');
+  await fs.rename(temporary, file);
+}

--- a/shipforge/src/index.js
+++ b/shipforge/src/index.js
@@ -1,0 +1,4 @@
+export { scanProject } from './scanner.js';
+export { updateProjectVersion } from './versioning.js';
+export { runChecks } from './checks.js';
+export { generateChecksums } from './checksums.js';

--- a/shipforge/src/process.js
+++ b/shipforge/src/process.js
@@ -1,0 +1,29 @@
+import { spawn } from 'node:child_process';
+
+export function run(command, args = [], options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env ?? process.env,
+      shell: false,
+      stdio: options.capture ? ['ignore', 'pipe', 'pipe'] : 'inherit',
+      windowsHide: true,
+    });
+
+    let stdout = '';
+    let stderr = '';
+    if (options.capture) {
+      child.stdout.setEncoding('utf8');
+      child.stderr.setEncoding('utf8');
+      child.stdout.on('data', (chunk) => { stdout += chunk; });
+      child.stderr.on('data', (chunk) => { stderr += chunk; });
+    }
+
+    child.on('error', reject);
+    child.on('close', (code, signal) => {
+      const result = { code: code ?? 1, signal, stdout: stdout.trim(), stderr: stderr.trim() };
+      if (code === 0 || options.allowFailure) resolve(result);
+      else reject(new Error(`${command} exited with code ${code}${stderr ? `: ${stderr.trim()}` : ''}`));
+    });
+  });
+}

--- a/shipforge/src/publish.js
+++ b/shipforge/src/publish.js
@@ -1,0 +1,63 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { run } from './process.js';
+
+async function collectAssets(cwd, paths) {
+  const assets = [];
+  for (const item of paths ?? []) {
+    const absolute = path.resolve(cwd, item);
+    try {
+      const stat = await fs.stat(absolute);
+      if (stat.isFile()) assets.push(absolute);
+      else if (stat.isDirectory()) {
+        const entries = await fs.readdir(absolute, { withFileTypes: true });
+        for (const entry of entries) if (entry.isFile()) assets.push(path.join(absolute, entry.name));
+      }
+    } catch (error) {
+      if (error?.code !== 'ENOENT') throw error;
+    }
+  }
+  return assets.sort();
+}
+
+export async function publishNpm(cwd, config, options = {}) {
+  const npmDirectory = path.resolve(cwd, config.npm?.directory ?? '.');
+  const args = ['publish', '--access', 'public', '--tag', config.npm?.tag ?? 'latest', '--provenance'];
+  if (options.dryRun) args.push('--dry-run');
+  return run('npm', args, { cwd: npmDirectory });
+}
+
+export async function publishGitHub(cwd, version, config, options = {}) {
+  const tag = `${config.tagPrefix ?? 'v'}${version}`;
+  const repositoryArgs = config.github?.repository ? ['--repo', config.github.repository] : [];
+  const existing = await run('gh', ['release', 'view', tag, ...repositoryArgs], { cwd, capture: true, allowFailure: true });
+  const assets = await collectAssets(cwd, config.releaseAssets);
+  const createOptions = [...repositoryArgs, '--title', `Release ${tag}`, '--generate-notes'];
+  const editOptions = [...repositoryArgs, '--title', `Release ${tag}`];
+  if (config.github?.draft) { createOptions.push('--draft'); editOptions.push('--draft'); }
+  if (config.github?.prerelease) { createOptions.push('--prerelease'); editOptions.push('--prerelease'); }
+
+  if (options.dryRun) {
+    return { code: 0, stdout: `Would ${existing.code === 0 ? 'update' : 'create'} ${tag} with ${assets.length} assets.`, stderr: '' };
+  }
+  if (existing.code === 0) {
+    await run('gh', ['release', 'edit', tag, ...editOptions], { cwd });
+    if (assets.length) await run('gh', ['release', 'upload', tag, ...assets, '--clobber', ...repositoryArgs], { cwd });
+  } else {
+    await run('gh', ['release', 'create', tag, ...assets, ...createOptions], { cwd });
+  }
+  return { code: 0, stdout: `Published GitHub Release ${tag}.`, stderr: '' };
+}
+
+export async function verifyNpm(cwd, packageName, version) {
+  const result = await run('npm', ['view', `${packageName}@${version}`, 'version', '--json'], { cwd, capture: true, allowFailure: true });
+  return { ok: result.code === 0 && result.stdout.replace(/["\s]/gu, '') === version, output: result.stdout || result.stderr };
+}
+
+export async function verifyGitHub(cwd, version, config) {
+  const tag = `${config.tagPrefix ?? 'v'}${version}`;
+  const args = ['release', 'view', tag, '--json', 'tagName,isDraft,isPrerelease,url'];
+  if (config.github?.repository) args.push('--repo', config.github.repository);
+  const result = await run('gh', args, { cwd, capture: true, allowFailure: true });
+  return { ok: result.code === 0, output: result.stdout || result.stderr };
+}

--- a/shipforge/src/scanner.js
+++ b/shipforge/src/scanner.js
@@ -1,0 +1,76 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { walk, relative } from './fs-utils.js';
+
+const detectors = [
+  {
+    type: 'npm',
+    names: new Set(['package.json']),
+    detect(content) {
+      try {
+        const parsed = JSON.parse(content);
+        return typeof parsed.version === 'string' ? parsed.version : null;
+      } catch { return null; }
+    }
+  },
+  {
+    type: 'npm-lock',
+    names: new Set(['package-lock.json', 'npm-shrinkwrap.json']),
+    detect(content) {
+      try {
+        const parsed = JSON.parse(content);
+        return typeof parsed.version === 'string' ? parsed.version : parsed.packages?.['']?.version ?? null;
+      } catch { return null; }
+    }
+  },
+  {
+    type: 'cargo',
+    names: new Set(['Cargo.toml']),
+    detect(content) {
+      return /^version\s*=\s*["']([^"']+)["']/mu.exec(content)?.[1] ?? null;
+    }
+  },
+  {
+    type: 'python',
+    names: new Set(['pyproject.toml']),
+    detect(content) {
+      return /^version\s*=\s*["']([^"']+)["']/mu.exec(content)?.[1] ?? null;
+    }
+  },
+  {
+    type: 'android-gradle',
+    names: new Set(['build.gradle', 'build.gradle.kts']),
+    detect(content) {
+      return /versionName\s*(?:=\s*)?["']([^"']+)["']/u.exec(content)?.[1] ?? null;
+    }
+  },
+  {
+    type: 'snap',
+    names: new Set(['snapcraft.yaml', 'snapcraft.yml']),
+    detect(content) {
+      return /^version:\s*["']?([^\s"']+)["']?/mu.exec(content)?.[1] ?? null;
+    }
+  },
+  {
+    type: 'alpine',
+    names: new Set(['APKBUILD']),
+    detect(content) {
+      return /^pkgver=([^\s#]+)/mu.exec(content)?.[1] ?? null;
+    }
+  }
+];
+
+export async function scanProject(cwd) {
+  const files = await walk(cwd);
+  const found = [];
+  for (const file of files) {
+    const name = path.basename(file);
+    for (const detector of detectors) {
+      if (!detector.names.has(name)) continue;
+      const content = await fs.readFile(file, 'utf8');
+      const version = detector.detect(content);
+      if (version) found.push({ type: detector.type, path: relative(cwd, file), absolute: file, version });
+    }
+  }
+  return found.sort((a, b) => a.path.localeCompare(b.path));
+}

--- a/shipforge/src/semver.js
+++ b/shipforge/src/semver.js
@@ -1,0 +1,19 @@
+const SEMVER = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z.-]+))?(?:\+([0-9A-Za-z.-]+))?$/u;
+
+export function assertSemver(value) {
+  if (!SEMVER.test(value)) {
+    throw new Error(`Invalid semantic version: ${value}`);
+  }
+  return value;
+}
+
+export function androidVersionCode(version) {
+  const match = SEMVER.exec(assertSemver(version));
+  const major = Number(match[1]);
+  const minor = Number(match[2]);
+  const patch = Number(match[3]);
+  if (major > 99 || minor > 99 || patch > 99) {
+    throw new Error('Android automatic versionCode supports components from 0 to 99.');
+  }
+  return major * 10000 + minor * 100 + patch;
+}

--- a/shipforge/src/ui.js
+++ b/shipforge/src/ui.js
@@ -1,0 +1,27 @@
+const symbols = {
+  ok: '✓',
+  info: '•',
+  warn: '!',
+  error: '×',
+};
+
+export function heading(text) {
+  console.log(`\nShipForge · ${text}`);
+}
+
+export function line(kind, text) {
+  console.log(`${symbols[kind] ?? symbols.info} ${text}`);
+}
+
+export function printTable(rows) {
+  if (!rows.length) return;
+  const widths = [];
+  for (const row of rows) {
+    row.forEach((cell, index) => {
+      widths[index] = Math.max(widths[index] ?? 0, String(cell).length);
+    });
+  }
+  for (const row of rows) {
+    console.log(row.map((cell, index) => String(cell).padEnd(widths[index])).join('  '));
+  }
+}

--- a/shipforge/src/versioning.js
+++ b/shipforge/src/versioning.js
@@ -1,0 +1,60 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { assertSemver, androidVersionCode } from './semver.js';
+import { scanProject } from './scanner.js';
+import { atomicWrite } from './fs-utils.js';
+
+function updateJson(content, version, file) {
+  const parsed = JSON.parse(content);
+  parsed.version = version;
+  if (path.basename(file) === 'package-lock.json') {
+    if (parsed.packages?.['']) parsed.packages[''].version = version;
+  }
+  return `${JSON.stringify(parsed, null, 2)}\n`;
+}
+
+function replaceOne(content, pattern, replacement, label) {
+  if (!pattern.test(content)) throw new Error(`Cannot locate ${label}`);
+  return content.replace(pattern, replacement);
+}
+
+export async function updateVersionFile(entry, version) {
+  const content = await fs.readFile(entry.absolute, 'utf8');
+  switch (entry.type) {
+    case 'npm':
+    case 'npm-lock':
+      return updateJson(content, version, entry.absolute);
+    case 'cargo':
+    case 'python':
+      return replaceOne(content, /^version\s*=\s*["'][^"']+["']/mu, `version = "${version}"`, 'version field');
+    case 'android-gradle': {
+      const kotlinStyle = entry.absolute.endsWith('.kts') || /versionName\s*=\s*["']/u.test(content);
+      const versionName = kotlinStyle ? `versionName = "${version}"` : `versionName "${version}"`;
+      const versionCode = kotlinStyle ? `versionCode = ${androidVersionCode(version)}` : `versionCode ${androidVersionCode(version)}`;
+      let next = replaceOne(content, /versionName\s*(?:=\s*)?["'][^"']+["']/u, versionName, 'Android versionName');
+      if (/versionCode\s*(?:=\s*)?\d+/u.test(next)) {
+        next = next.replace(/versionCode\s*(?:=\s*)?\d+/u, versionCode);
+      }
+      return next;
+    }
+    case 'snap':
+      return replaceOne(content, /^version:\s*.*$/mu, `version: '${version}'`, 'Snap version');
+    case 'alpine':
+      return replaceOne(content, /^pkgver=.*$/mu, `pkgver=${version}`, 'Alpine pkgver');
+    default:
+      throw new Error(`Unsupported version file type: ${entry.type}`);
+  }
+}
+
+export async function updateProjectVersion(cwd, version, options = {}) {
+  assertSemver(version);
+  const entries = await scanProject(cwd);
+  const changed = [];
+  for (const entry of entries) {
+    if (entry.version === version) continue;
+    const next = await updateVersionFile(entry, version);
+    changed.push({ ...entry, from: entry.version, to: version });
+    if (options.write) await atomicWrite(entry.absolute, next);
+  }
+  return changed;
+}

--- a/shipforge/test/android-kts.test.js
+++ b/shipforge/test/android-kts.test.js
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { scanProject } from '../src/scanner.js';
+import { updateProjectVersion } from '../src/versioning.js';
+
+test('preserves Kotlin Gradle assignment syntax', async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'shipforge-kts-'));
+  await fs.writeFile(path.join(root, 'build.gradle.kts'), 'versionCode = 10000\nversionName = "1.0.0"\n');
+  assert.equal((await scanProject(root))[0].version, '1.0.0');
+  await updateProjectVersion(root, '1.6.7', { write: true });
+  const content = await fs.readFile(path.join(root, 'build.gradle.kts'), 'utf8');
+  assert.match(content, /versionName = "1\.6\.7"/u);
+  assert.match(content, /versionCode = 10607/u);
+});

--- a/shipforge/test/checksums.test.js
+++ b/shipforge/test/checksums.test.js
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { generateChecksums } from '../src/checksums.js';
+
+test('creates stable SHA-256 manifest', async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'shipforge-assets-'));
+  await fs.writeFile(path.join(root, 'a.txt'), 'alpha');
+  await fs.writeFile(path.join(root, 'b.txt'), 'beta');
+  const result = await generateChecksums(root);
+  assert.equal(result.count, 2);
+  const manifest = await fs.readFile(result.outputPath, 'utf8');
+  assert.match(manifest, /a\.txt/u);
+  assert.match(manifest, /b\.txt/u);
+});

--- a/shipforge/test/scanner.test.js
+++ b/shipforge/test/scanner.test.js
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { scanProject } from '../src/scanner.js';
+import { updateProjectVersion } from '../src/versioning.js';
+
+test('scans and synchronizes npm, Android, Snap, and Alpine versions', async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'shipforge-'));
+  await fs.mkdir(path.join(root, 'android'), { recursive: true });
+  await fs.writeFile(path.join(root, 'package.json'), '{"name":"demo","version":"1.0.0"}\n');
+  await fs.writeFile(path.join(root, 'package-lock.json'), '{"name":"demo","version":"1.0.0","lockfileVersion":3,"packages":{"":{"name":"demo","version":"1.0.0"}}}\n');
+  await fs.writeFile(path.join(root, 'android', 'build.gradle'), 'versionCode 10000\nversionName "1.0.0"\n');
+  await fs.writeFile(path.join(root, 'snapcraft.yaml'), 'name: demo\nversion: 1.0.0\n');
+  await fs.writeFile(path.join(root, 'APKBUILD'), 'pkgname=demo\npkgver=1.0.0\n');
+
+  assert.equal((await scanProject(root)).length, 5);
+  const preview = await updateProjectVersion(root, '1.6.7');
+  assert.equal(preview.length, 5);
+  assert.match(await fs.readFile(path.join(root, 'package.json'), 'utf8'), /1\.0\.0/u);
+
+  await updateProjectVersion(root, '1.6.7', { write: true });
+  const versions = [...new Set((await scanProject(root)).map((entry) => entry.version))];
+  assert.deepEqual(versions, ['1.6.7']);
+  assert.match(await fs.readFile(path.join(root, 'android', 'build.gradle'), 'utf8'), /versionCode 10607/u);
+});

--- a/shipforge/test/semver.test.js
+++ b/shipforge/test/semver.test.js
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { assertSemver, androidVersionCode } from '../src/semver.js';
+
+test('validates semantic versions', () => {
+  assert.equal(assertSemver('1.2.3'), '1.2.3');
+  assert.throws(() => assertSemver('1.2'), /Invalid semantic version/u);
+});
+
+test('derives deterministic Android versionCode', () => {
+  assert.equal(androidVersionCode('1.6.7'), 10607);
+  assert.equal(androidVersionCode('12.34.56'), 123456);
+});


### PR DESCRIPTION
## What changed

- adds a new zero-runtime-dependency release automation CLI under `shipforge/`
- detects and synchronizes versions across npm manifests/lockfiles, Cargo, PyPI, Android Gradle/Groovy/Kotlin, Snap, and Alpine APKBUILD
- provides safe preview-first version updates with explicit `--write`
- validates version consistency, Git cleanliness, and configured project checks
- generates changelog entries and SHA-256 manifests
- supports explicit npm publishing with provenance and GitHub Release creation through `gh`
- blocks irreversible publication unless the user selects a target and passes `--yes`
- adds npm/GitHub publication verification
- adds standalone CI/release templates and an active monorepo CI workflow

## Security and safety

- zero runtime dependencies
- child processes use argument arrays with `shell: false`
- no token storage
- dry-run support for publication
- publication requires explicit `--npm` and/or `--github` targets
- version mutation is preview-only unless `--write` is supplied

## Validation completed

### Local

- syntax validation passed
- 5 Node.js unit tests passed
- npm package dry-run passed
- full integration simulation passed for init, scan, preview, version write, Android versionCode, npm lockfile synchronization, checksum verification, Git clean check, and configured npm tests

### GitHub Actions

Workflow run `30996310811` passed all six jobs:

- Node.js 22 on Ubuntu, Windows, and macOS
- Node.js 24 on Ubuntu, Windows, and macOS
- `npm ci --ignore-scripts`
- syntax validation
- unit tests
- `npm pack --dry-run`

## Package

- name: `shipforge-cli`
- version: `0.1.0`
- Node.js: `>=22.14.0`
- license: MIT

The package is not yet published to npm and no GitHub Release has been created for ShipForge.