### PR TITLE
Superseded: publish ShipForge CLI 0.1.0 from monorepo

### DIFF
--- a/.github/release-markers/shipforge-0.1.0-pr/trigger
+++ b/.github/release-markers/shipforge-0.1.0-pr/trigger
@@ -1,0 +1,4 @@
+ShipForge 0.1.0 npm publication and verification gate
+source=addbe0be4cc6fc90c54f396f3ad3aeadb176f7ef
+package=shipforge-cli
+version=0.1.0

--- a/.github/release-markers/shipforge-0.1.0-pr/trigger
+++ b/.github/release-markers/shipforge-0.1.0-pr/trigger
@@ -2,3 +2,4 @@ ShipForge 0.1.0 npm publication and verification gate
 source=addbe0be4cc6fc90c54f396f3ad3aeadb176f7ef
 package=shipforge-cli
 version=0.1.0
+retry=2026-08-05T18:33:00+07:00


### PR DESCRIPTION
Closed because ShipForge is being separated from the YTConv monorepo.

The standalone repository-ready source is staged on branch `standalone/shipforge-cli` at commit `57fc3165c625cfacbf07b08a0b38f69153dacc8f`.

Publication must happen only from the future `andhikamarcella/shipforge-cli` repository after its `npm` environment receives an authorized `NPM_TOKEN`. The standalone workflow is manual and verifies npm `latest` plus the registry tarball SHA-256 before creating a GitHub Release.