### PR TITLE
Closed: completed YTConv 1.7.0 iSH synchronization

### DIFF
--- a/.github/release-markers/sync-ytconv-1.7.0-ish
+++ b/.github/release-markers/sync-ytconv-1.7.0-ish
@@ -1,0 +1,1 @@
+Synchronize the native iSH core identity and SHA-256 manifest for YTConv 1.7.0.


### PR DESCRIPTION
Closed without merge. The one-time controller successfully updated the native iSH core from the stale 1.6.6 identity to 1.7.0, replaced the raw release URL with the canonical `andhikamarcella/YTConv` 1.7.0 branch, regenerated both SHA-256 entries, and passed ResourceWarning-strict iSH tests. Resulting release commit: `360a4355c2c1204c2b8cd382f7cf118c6bb20d18`.